### PR TITLE
great-pit-of-carkoon

### DIFF
--- a/Dark.json
+++ b/Dark.json
@@ -47411,7 +47411,7 @@
         ],
         "lightSideIcons": 1,
         "darkSideIcons": 1,
-        "gametext": "Dark: During your control phase, may cause Sarlacc to immediately attack one captive present.  Light:"
+        "gametext": "Dark:  During your control phase, may cause Sarlacc to immediately attack one captive present.  Light:"
       },
       "pulledBy": [
         "Imperial Entanglements",


### PR DESCRIPTION
Added single space after Dark: (bringing it to two spaces) to be consistent with other sites that have 2 spaces after Dark:.