### PR TITLE
Added Maintenance icon.

### DIFF
--- a/Dark.json
+++ b/Dark.json
@@ -5865,6 +5865,7 @@
         "deploy": 5,
         "forfeit": 5,
         "icons": [
+          "Maintenance",
           "Pilot x2",
           "Scomp Link"
         ],
@@ -6796,6 +6797,7 @@
         "deploy": 5,
         "forfeit": 6,
         "icons": [
+          "Maintenance",
           "Pilot",
           "Warrior"
         ],
@@ -46027,6 +46029,7 @@
         "deploy": 6,
         "forfeit": 4,
         "icons": [
+          "Maintenance",
           "Warrior"
         ],
         "characteristics": [
@@ -49605,6 +49608,7 @@
         "deploy": 7,
         "forfeit": 5,
         "icons": [
+          "Maintenance",
           "Warrior"
         ],
         "characteristics": [

--- a/Light.json
+++ b/Light.json
@@ -8550,6 +8550,7 @@
         "deploy": 6,
         "forfeit": 6,
         "icons": [
+          "Maintenance",
           "Pilot",
           "Warrior"
         ],
@@ -21111,8 +21112,9 @@
         "deploy": 6,
         "forfeit": 8,
         "icons": [
-          "Pilot x2",
+          "Maintenance",
           "Nav Computer",
+          "Pilot x2",
           "Scomp Link"
         ],
         "characteristics": [
@@ -27681,6 +27683,7 @@
         "deploy": 5,
         "forfeit": 7,
         "icons": [
+          "Maintenance",
           "Pilot",
           "Warrior"
         ],


### PR DESCRIPTION
I want to be able to use this icon when cross-referencing with: https://raw.githubusercontent.com/PlayersCommittee/gemp-swccg-public/master/gemp-swccg-server/src/main/resources/swccgFormats.json.  This way I can determine which cards are banned in formats where MAINTENANCE is included in the bannedIcons list.