### PR TITLE
Added Defensive Shield icon.

### DIFF
--- a/Dark.json
+++ b/Dark.json
@@ -911,6 +911,9 @@
         "uniqueness": "*",
         "destiny": 0,
         "gametext": "Plays on table. Cancels Don't Underestimate Our Chances. When opponent plays an Interrupt and has 3 smugglers on table, if that Interrupt is placed in Lost Pile, place it out of play. Ketwol may exchange a docking bay only once per game.",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "Imperial officers aboard the Death Star considered the Rebellion a minor threat."
       },
       "cancels": [
@@ -929,6 +932,7 @@
         "type": "Defensive Shield",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Grabber",
           "Reflections III"
         ],
@@ -949,6 +953,7 @@
         "uniqueness": "*",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Grabber",
           "Reflections III"
         ],
@@ -1094,7 +1099,8 @@
         "type": "Defensive Shield",
         "destiny": 0,
         "icons": [
-          "Cloud City"
+          "Cloud City",
+          "Defensive Shield"
         ],
         "gametext": "Plays on table.  Substituted battle destinies do not count against battle destiny limits.  If all your battle destinies were canceled (and not redrawn) use 1 for your total battle destiny instead.  Once per game, may play a Defensive Shield from under your Starting Effect.",
         "lore": "Careless abuse of the Force by a young Jedi trainee can have dire consequences. When hanging from the weather vane of Cloud City, Luke's balance was his only hope."
@@ -1807,6 +1813,7 @@
         "type": "Defensive Shield",
         "destiny": 5,
         "icons": [
+          "Defensive Shield",
           "Episode I",
           "Theed Palace"
         ],
@@ -2228,6 +2235,7 @@
         "uniqueness": "*",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Grabber",
           "Episode I"
         ],
@@ -4518,6 +4526,9 @@
         "uniqueness": "*",
         "destiny": 0,
         "gametext": "Plays on table. Unless Battle Plan on table, for either player to initiate a Force drain, that player must first use 3 Force unless that player occupies a battleground site and a battleground system.",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "Administration of the Imperial installation on Endor includes coordination of troops on the ground and tight security provided by the Empire's space fleet."
       },
       "counterpart": "Battle Plan - Defensive Shield",
@@ -10349,6 +10360,9 @@
         "uniqueness": "*",
         "destiny": 0,
         "gametext": "Plays on table. While you occupy a battleground and opponent occupies less than two battlegrounds, cancel: Asteroid Sanctuary, opponent's Force drains at non-battleground locations, and opponent's Force retrieval.",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "'Chewie! Come here!'"
       },
       "cancels": [
@@ -12633,6 +12647,9 @@
         "uniqueness": "*",
         "destiny": 0,
         "gametext": "Plays on table. S-foils and Maneuvering Flaps are suspended where you have either a weapon present or a starship (or vehicle) with maneuver > 3 present.",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "Scout walker pilots are trained to set up a deadly heavy fire zone. This tactic can be disrupted by enemy weapons fire."
       },
       "legacy": false
@@ -14833,6 +14850,9 @@
         "type": "Defensive Shield",
         "destiny": 0,
         "gametext": "Plays on table. Colo Claw Fish is canceled. Opponent must first use X Force to deploy a non-unique card (except a Jawa) to a location, where X = the number of copies of that card at that location.",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "Death Star troopers on sentry duty observe and direct incoming starships and monitor other critical sites. They perform sensor scans for life forms and weapons."
       },
       "legacy": true
@@ -14849,6 +14869,9 @@
         "uniqueness": "*",
         "destiny": 0,
         "gametext": "Plays on table. Colo Claw Fish is canceled. Opponent must first use X Force to deploy a non-unique card (except a Jawa) to a location, where X = the number of copies of that card at that location.",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "Death Star troopers on sentry duty observe and direct incoming starships and monitor other critical sites. They perform sensor scans for life forms and weapons."
       },
       "counterpart": "Yavin Sentry (V)",
@@ -16713,6 +16736,7 @@
         "uniqueness": "*",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Grabber"
         ],
         "gametext": "Plays on table. If opponent just retrieved Force using an Interrupt or Utinni Effect, you may place that card here. Opponent's Force retrieval is reduced by X, where X = number of cards here.",
@@ -16731,6 +16755,7 @@
         "type": "Defensive Shield",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Reflections III",
           "Grabber"
         ],
@@ -16750,6 +16775,7 @@
         "type": "Defensive Shield",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Reflections III",
           "Grabber"
         ],
@@ -20097,6 +20123,7 @@
         "uniqueness": "*",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Episode I"
         ],
         "gametext": "Plays on table. Cancels Order To Engage and Scramble. Once per game you may take any Immediate Effect into hand from Reserve Deck; reshuffle. While opponent occupies no battleground systems, Staging Areas is suspended.",
@@ -20192,6 +20219,7 @@
         "type": "Defensive Shield",
         "destiny": 4,
         "icons": [
+          "Defensive Shield",
           "Episode I"
         ],
         "gametext": "Plays on table. Cancels Order To Engage and Scramble. Once per game, may take an Immediate Effect in to hand from Reserve Deck; reshuffle. While opponent occupies no battleground systems, Staging Areas is suspended. 'Missing' on Lost In The Wilderness is treated as 'landspeed = 0 for remainder of turn.'",
@@ -20210,6 +20238,7 @@
         "type": "Defensive Shield",
         "destiny": 4,
         "icons": [
+          "Defensive Shield",
           "Episode I"
         ],
         "gametext": "Plays on table. Ice Storm, Lost In The Wilderness, Order To Engage, Sandwhirl, and Scramble are canceled. Once per game, may /\\ an Immediate Effect. Unless opponent occupies a battleground system, Staging Areas is suspended.",
@@ -20228,6 +20257,7 @@
         "type": "Defensive Shield",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Episode I"
         ],
         "gametext": "Plays on table. Ice Storm, Lost In The Wilderness, Order To Engage, Sandwhirl, and Scramble are canceled. Once per game, may /\\ an Immediate Effect. Unless opponent occupies a battleground system, Staging Areas is suspended.",
@@ -20247,6 +20277,7 @@
         "uniqueness": "*",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Episode I"
         ],
         "gametext": "Plays on table. Cancels Order To Engage and Scramble. Once per game, may take an Immediate Effect into hand from Reserve Deck; reshuffle. While opponent occupies no battleground systems, Staging Areas is suspended. 'Missing' on Lost In The Wilderness is treated as 'landspeed = 0 for remainder of turn.'",
@@ -20640,6 +20671,7 @@
         "type": "Defensive Shield",
         "destiny": 3,
         "icons": [
+          "Defensive Shield",
           "Special Edition"
         ],
         "gametext": "Plays on table. If opponent moves from a location you occupy during your turn, they lose 2 Force. At end of opponent's turn, if you control two battlegrounds (a site and system) and opponent deployed a card with ability and did not initiate a battle, you may retrieve 1 Force.",
@@ -24827,6 +24859,9 @@
         "type": "Defensive Shield",
         "destiny": 5,
         "gametext": "Plays on table. Unless Deep Hatred on table, opponent may use only one combat card per turn. While opponent has two Jedi on Naboo, you lose no more than 2 Force to Force drains at opponent's Naboo sites. We'll Handle This may target only droids and spies.",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "Darth Vader ruthlessly used the Force to strike down enemies and soldiers who displeased him. He could choke victims from afar without touching them."
       },
       "legacy": true
@@ -24841,7 +24876,10 @@
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/starwars/ResetDS-Dark/large/ifindyourlackoffaithdisturbing.gif?raw=true",
         "type": "Defensive Shield",
         "destiny": 5,
-        "gametext": "Plays on table. Goo Nee Tay is canceled. Unless Deep Hatred on table, opponent may use only one combat card per turn. We'll Handle This may target only Undercover spies and 5D6-RA-7."
+        "gametext": "Plays on table. Goo Nee Tay is canceled. Unless Deep Hatred on table, opponent may use only one combat card per turn. We'll Handle This may target only Undercover spies and 5D6-RA-7.",
+        "icons": [
+          "Defensive Shield"
+        ]
       },
       "counterpart": "Affect Mind (V) - Defensive Shield",
       "cancels": [
@@ -26314,6 +26352,7 @@
         "type": "Defensive Shield",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Reflections III"
         ],
         "gametext": "Play on table. I'd Just As Soon Kiss A Wookiee may not be played. For opponent to deploy a card with ability for free, they must first use X Force, where X = 1/2 that card's printed deploy cost (round up). For opponent to deploy a card with ability for 0 Force, they must first use 1 Force.",
@@ -26332,6 +26371,7 @@
         "type": "Defensive Shield",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Reflections III"
         ],
         "gametext": "Plays on table. For opponent to deploy a character, starship, or vehicle for free (except by that card's own game text), opponent must first use 2 Force."
@@ -31162,6 +31202,9 @@
         "uniqueness": "*",
         "destiny": 0,
         "gametext": "Plays on table. While you occupy a Subjugated planet location, operatives are forfeit = 0, operatives do not add to Force drains, and your Force drains may not be reduced. (Subjugated planet is defined on the Objective card Local Uprising.)",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "'I will deal with them myself.'"
       },
       "counterpart": "Let's Keep A Little Optimism Here - Defensive Shield",
@@ -31178,6 +31221,7 @@
         "type": "Defensive Shield",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Reflections III"
         ],
         "gametext": "Plays on table. At opponent's Dantooine and Subjugated Planet sites, your Imperials are deploy -2 and your Force drains may not be modified or canceled by opponent. Your game text at opponent's <>Swamp and <>Jungle is canceled. Your characters present at opponent's <>Forest are immune to attrition.",
@@ -31196,6 +31240,7 @@
         "type": "Defensive Shield",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Reflections III"
         ],
         "gametext": "Plays on table. At opponent's Dantooine and Subjugated Planet sites, your Imperials are deploy -2 and your Force drains may not be modified or canceled by opponent. Your game text at opponent's <>Swamp and <>Jungle is canceled. Your characters present at opponent's <>Forest are immune to attrition.",
@@ -36314,6 +36359,9 @@
         "uniqueness": "*",
         "destiny": 0,
         "gametext": "Plays on table. At opponent's <> site where opponent's creature present, you may deploy without presence or Force icons, and your Force generation there is +1.",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "Jabba's influence is not easily ignored. Neither are his voracious and vile appetites. Even Jedi soon learn this lesson."
       },
       "legacy": false
@@ -36329,6 +36377,7 @@
         "type": "Defensive Shield",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Reflections III"
         ],
         "gametext": "Plays on table. While you occupy a Subjugated Planet location, operatives are forfeit = 0, operatives do not add to Force drains, and your Force drains may not be reduced. Nudjs do not cancel Force icons.",
@@ -36347,6 +36396,7 @@
         "type": "Defensive Shield",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Reflections III"
         ],
         "gametext": "Plays on table. While you occupy a Subjugated Planet location, operatives are forfeit = 0, operatives do not add to Force drains, and your Force drains may not be reduced. Nudjs do not cancel Force icons.",
@@ -37567,6 +37617,9 @@
         "uniqueness": "*",
         "destiny": 0,
         "gametext": "Plays on table. Your Immediate Effects may play for free. Whenever opponent cancels your card with Sense or Alter, place that canceled card in Used Pile.",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "The Imperial fleet keeps a tight grip on the systems under its control. Abuses and excesses by local citizens are not tolerated."
       },
       "counterpart": "Wise Advice - Defensive Shield",
@@ -40358,6 +40411,9 @@
         "type": "Defensive Shield",
         "destiny": 3,
         "gametext": "Plays on table. 'Three' on Fear Is My Ally is treated as 'Four'. You lose no Force to Boonta Eve Podrace. Opponent's retrieval from Boonta Eve Podrace may not be canceled. While you occupy more battlegrounds than opponent, I Did It! is suspended.",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "The Death Star has many terminals coupled to the main reactor for power distribution throughout the immense space station."
       },
       "legacy": true
@@ -40755,6 +40811,9 @@
         "uniqueness": "*",
         "destiny": 0,
         "gametext": "Plays on table. While you occupy at least 3 battlegrounds or opponent occupies no battlegrounds, you lose no more than 2 Force from each Force drain or 'insert' card.",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "Oola had to choose between giving in to Jabba's constant advances or resisting him and inciting his wrath."
       },
       "counterpart": "Ultimatum - Defensive Shield",
@@ -42580,6 +42639,9 @@
         "uniqueness": "*",
         "destiny": 0,
         "gametext": "Plays on table. If opponent is about to retrieve X Force, opponent must first use X Force or that retrieval is canceled. (X is equal to the full amount of Force allowed to be retrieved, regardless of the number of cards in opponent's Lost Pile.)",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "Imperial computer systems are equipped with complex algorithms designed to prevent access by unauthorized users."
       },
       "counterpart": "Aim High - Defensive Shield",
@@ -49194,6 +49256,9 @@
         "uniqueness": "*",
         "destiny": 0,
         "gametext": "Plays on table. Sense and Alter are now Lost Interrupts. When any player makes a destiny draw for Sense or Alter, and that destiny draw is successful, that player loses 2 Force.",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "'Always with you what cannot be done.'"
       },
       "counterpart": "Do, Or Do Not - Defensive Shield",
@@ -53015,7 +53080,10 @@
         "type": "Defensive Shield",
         "uniqueness": "*",
         "destiny": 0,
-        "gametext": "Plays on table. While you have 12 or fewer cards in hand, opponent may not remove cards from your hand (except with Grimtaash). Once per turn (even at start of turn), may target a [Coruscant] Political Effect; it is suspended for the remainder of the turn."
+        "gametext": "Plays on table. While you have 12 or fewer cards in hand, opponent may not remove cards from your hand (except with Grimtaash). Once per turn (even at start of turn), may target a [Coruscant] Political Effect; it is suspended for the remainder of the turn.",
+        "icons": [
+          "Defensive Shield"
+        ]
       },
       "counterpart": "The Republic No Longer Functions",
       "legacy": false
@@ -53647,6 +53715,7 @@
         "uniqueness": "*",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Episode I"
         ],
         "gametext": "Plays on table. For opponent to steal a weapon from target character using a non-[Episode I] card, must first draw destiny. If destiny +1 > target's ability, weapon is stolen. Otherwise, attempt fails and stealing card is placed out of play.",
@@ -53915,6 +53984,7 @@
         "uniqueness": "*",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Episode I"
         ],
         "gametext": "Plays on table. Cancels Frozen Assets and Beggar. Each player may play only one card with 'sabacc' in title each turn. You may cancel an opponent's card with 'sabacc' in title by losing 1 Force from hand.",
@@ -53937,6 +54007,7 @@
         "type": "Defensive Shield",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Episode I",
           "Reflections III"
         ],
@@ -54305,6 +54376,7 @@
         "uniqueness": "*",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Episode I"
         ],
         "gametext": "Plays on table. While opponent has a non-unique alien or non-unique starfighter in battle, opponent may not draw more than two battle destiny.",
@@ -55025,6 +55097,9 @@
         "uniqueness": "*",
         "destiny": 0,
         "gametext": "Plays on table. If an 'insert' card was just inserted or revealed, it is canceled.",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "'Give yourself to the dark side. It is the only way you can save your friends.'"
       },
       "counterpart": "Your Insight Serves You Well - Defensive Shield",
@@ -55108,6 +55183,7 @@
         "type": "Defensive Shield",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Reflections III"
         ],
         "gametext": "Plays on table. If an 'insert' card was just inserted or revealed, it is canceled. You lose no Force to Boonta Eve Podrace, and opponent's retrieval from Boonta Eve Podrace may not be canceled. While you occupy more battlegrounds than opponent, I Did It! is suspended.",
@@ -55126,6 +55202,7 @@
         "type": "Defensive Shield",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Reflections III"
         ],
         "gametext": "Plays on table. If an 'insert' card was just inserted or revealed, it is canceled. You lose no Force to Boonta Eve Podrace. While you occupy more battlegrounds than opponent, I Did It! is suspended.",
@@ -55144,6 +55221,7 @@
         "type": "Defensive Shield",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Reflections III"
         ],
         "gametext": "Plays on table. If an 'insert' card was just inserted or revealed, it is canceled. You lose no Force to Boonta Eve Podrace, and opponent's retrieval from Boonta Eve Podrace may not be canceled. While you occupy more battlegrounds than opponent, I Did It! is suspended.",
@@ -55163,6 +55241,7 @@
         "uniqueness": "*",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Reflections III"
         ],
         "gametext": "Plays on table. If an 'insert' card was just inserted or revealed, it is canceled. You lose no Force to Boonta Eve Podrace. While you occupy more battlegrounds than opponent, I Did It! is suspended.",
@@ -55557,6 +55636,7 @@
         "uniqueness": "*",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Episode I"
         ],
         "gametext": "Plays on table. Unless opponent occupies three battlegrounds, I Did It! is suspended. If Sebulba's Podracer on table, your Force loss from Boonta Eve Podrace is reduced by X, where X = number of battlegrounds you occupy.",
@@ -56398,6 +56478,9 @@
         "uniqueness": "*",
         "destiny": 0,
         "gametext": "Plays on table. Opponent's Undercover spies are immune to Double Agent. While a Jedi Test on table, Projection Of A Skywalker is canceled. If Grimtaash just revealed your hand, you may place up to two cards from hand in your Used Pile.",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "'That place is strong with the dark side of the Force. A domain of evil it is. In you must go.'"
       },
       "legacy": false

--- a/Light.json
+++ b/Light.json
@@ -138,6 +138,7 @@
         "uniqueness": "*",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Episode I"
         ],
         "gametext": "Plays on table. If you just lost a Podrace, your Force loss is limited to half the difference between the winning race total and your highest race total (round up). While you occupy three battlegrounds, Watto's Box is suspended.",
@@ -624,6 +625,7 @@
         "uniqueness": "*",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Grabber",
           "Episode I"
         ],
@@ -1309,6 +1311,9 @@
         "type": "Defensive Shield",
         "destiny": 5,
         "gametext": "Plays on table. Unless Inner Strength on table, opponent may use only one combat card per turn. While opponent has 2 Dark Jedi on Naboo, you lose no more than 2 Force to Force drains at opponent's Naboo sites. Let Them Make The First Move may target only droids and spies.",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "'What was that?' The Jedi power known as 'affect mind' is often used to create minor distractions, allowing Jedi to elude enemies rather than engage them in battle."
       },
       "legacy": true
@@ -1324,7 +1329,10 @@
         "type": "Defensive Shield",
         "uniqueness": "*",
         "destiny": 5,
-        "gametext": "Plays on table. Bad Feeling Have I is canceled. Unless Inner Strength on table, opponent may use only one combat card per turn. Let Them Make The First Move may target only Undercover spies and R2-D2."
+        "gametext": "Plays on table. Bad Feeling Have I is canceled. Unless Inner Strength on table, opponent may use only one combat card per turn. Let Them Make The First Move may target only Undercover spies and R2-D2.",
+        "icons": [
+          "Defensive Shield"
+        ]
       },
       "counterpart": "I Find Your Lack Of Faith Disturbing (V) - Defensive Shield",
       "legacy": false
@@ -1577,6 +1585,9 @@
         "uniqueness": "*",
         "destiny": 0,
         "gametext": "Plays on table. Whenever opponent retrieves X cards, opponent must first use X Force or that retrieval is canceled. (X is equal to the full amount of Force allowed to be retrieved, regardless of the number of cards in opponent's Lost Pile.)",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "The destruction of a command vehicle negatively impacts Imperial battle efficiency."
       },
       "counterpart": "Secret Plans - Defensive Shield",
@@ -2702,6 +2713,7 @@
         "uniqueness": "*",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Episode I"
         ],
         "gametext": "Plays on table. While opponent has a non-unique alien or non-unique starfighter in battle, opponent may not draw more than two battle destiny.",
@@ -4614,6 +4626,9 @@
         "uniqueness": "*",
         "destiny": 0,
         "gametext": "Plays on table. For either player to initiate a Force drain, that player must first use 3 Force unless that player occupies a battleground site and a battleground system.",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "Even though the landing of the stolen shuttle was successful, the Rebel strike team on Endor was forced to rethink their plans when Leia disappeared."
       },
       "counterpart": "Battle Order - Defensive Shield",
@@ -8068,6 +8083,9 @@
           "Cloud City"
         ],
         "gametext": "Plays on table.  Substituted battle destinies do not count against battle destiny limits.  If all your battle destinies were canceled (and not redrawn) use 1 for your total battle destiny instead.  Once per game, may play a Defensive Shield from under your Starting Effect.",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "At Cloud City, Luke came face to face with his own destiny. Looking into the abyss, he made his decision."
       },
       "legacy": true
@@ -14282,6 +14300,9 @@
         "uniqueness": "*",
         "destiny": 0,
         "gametext": "Plays on table. Sense and Alter are now Lost Interrupts. When any player makes a destiny draw for Sense or Alter, and that destiny draw is successful, that player loses 2 Force.",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "A Jedi may choose to intervene in the natural course of events, but must accept responsibility for the consequences."
       },
       "counterpart": "There Is No Try - Defensive Shield",
@@ -14403,6 +14424,7 @@
         "uniqueness": "*",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Episode I"
         ],
         "gametext": "Plays on table. Once per game may take any Immediate Effect into hand from Reserve Deck; reshuffle. While opponent occupies no battleground systems, Mobilization Points is suspended.",
@@ -14483,6 +14505,7 @@
         "type": "Defensive Shield",
         "destiny": 4,
         "icons": [
+          "Defensive Shield",
           "Episode I"
         ],
         "gametext": "Plays on table. Always Thinking With Your Stomach, Ice Storm, and Sandwhirl are canceled. Once per game, may /\\ an Immediate Effect. Unless opponent occupies a battleground system, Mobilization Points is suspended.",
@@ -14501,6 +14524,7 @@
         "type": "Defensive Shield",
         "destiny": 4,
         "icons": [
+          "Defensive Shield",
           "Episode I"
         ],
         "gametext": "Plays on table. Once per game, may take an Immediate Effect into hand from Reserve Deck; reshuffle. While opponent occupies no battleground systems, Mobilization Points is suspended. 'Missing' on Always Thinking With Your Stomach is treated as 'landspeed = 0 for remainder of turn.'",
@@ -14519,6 +14543,7 @@
         "type": "Defensive Shield",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Episode I"
         ],
         "gametext": "Plays on table. Always Thinking With Your Stomach, Ice Storm, and Sandwhirl are canceled. Once per game, may /\\ an Immediate Effect. Unless opponent occupies a battleground system, Mobilization Points is suspended.",
@@ -14538,6 +14563,7 @@
         "uniqueness": "*",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Episode I"
         ],
         "gametext": "Plays on table. Once per game, may take an Immediate Effect into hand from Reserve Deck; reshuffle. While opponent occupies no battleground systems, Mobilization Points is suspended. 'Missing' on Always Thinking With Your Stomach is treated as 'landspeed = 0 for remainder of turn.'",
@@ -19931,7 +19957,10 @@
         "type": "Defensive Shield",
         "uniqueness": "*",
         "destiny": 0,
-        "gametext": "Plays on table. For opponent to deploy a character, starship, or vehicle for free (except by that card's own game text), opponent must first use 2 Force."
+        "gametext": "Plays on table. For opponent to deploy a character, starship, or vehicle for free (except by that card's own game text), opponent must first use 2 Force.",
+        "icons": [
+          "Defensive Shield"
+        ]
       },
       "counterpart": "Imperial Detention",
       "legacy": false
@@ -21593,6 +21622,9 @@
         "uniqueness": "*",
         "destiny": 0,
         "gametext": "Plays on table. Cancels Responsibility Of Command and You Overestimate Their Chances. While Brangus Glee on table, once per turn you may search opponent's Lost Pile and place all docking bays found there out of play.",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "'You can go about your business.'"
       },
       "cancels": [
@@ -21612,6 +21644,7 @@
         "type": "Defensive Shield",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Reflections III"
         ],
         "gametext": "Plays on table. Cancels A Dangerous Time, Bad Feeling Have I, Responsibility Of Command and You Overestimate Their Chances. Unless [Virtual] Epic Duel on table, Force loss from epic duels is reduced to 0 and characters about to be placed out of play by a duel are instead lost.",
@@ -29036,6 +29069,9 @@
         "uniqueness": "*",
         "destiny": 0,
         "gametext": "Plays on table. While you occupy a Renegade planet location, operatives are forfeit = 0, operatives do not add to Force drains and your Force drains may not be reduced. (Renegade planet is defined on the Objective card Imperial Occupation.)",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "The heroes of the Rebellion know that where there is life, there is hope."
       },
       "counterpart": "Leave Them To Me - Defensive Shield",
@@ -29052,6 +29088,7 @@
         "type": "Defensive Shield",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Reflections III"
         ],
         "gametext": "Plays on table. Ounee Ta is canceled. At opponent's Ralltiir and Renegade Planet sites, your Rebels are deploy -2 and your Force drains may not be modified or canceled by opponent. Your game text at opponent's <>Swamp and <>Jungle is canceled. Your characters present at opponent's <>Forest are immune to attrition.",
@@ -29089,6 +29126,7 @@
         "type": "Defensive Shield",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Reflections III"
         ],
         "gametext": "Plays on table. Ounee Ta is canceled. At opponent's Ralltiir and Renegade Planet sites, your Rebels are deploy -2 and your Force drains may not be modified or canceled by opponent. Your game text at opponent's <>Swamp and <>Jungle is canceled. Your characters present at opponent's <>Forest are immune to attrition.",
@@ -36587,6 +36625,7 @@
         "uniqueness": "*",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Episode I"
         ],
         "gametext": "Plays on table. For opponent to steal a weapon from target character using a non-[Episode I] card, must first draw destiny. If destiny +1 > target's ability, weapon stolen. Otherwise, attempt fails and stealing card is placed out of play.",
@@ -36892,6 +36931,9 @@
         "uniqueness": "*",
         "destiny": 0,
         "gametext": "Plays on table. At each opponent's <> site, your Rebels are each deploy -2 and your Force generation is +1.",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "Jabba's decadent behavior makes him susceptible to deception. Leia and Lando exploited this weakness, posing as Jabba's kind of scum."
       },
       "canceledBy": [
@@ -36910,6 +36952,7 @@
         "type": "Defensive Shield",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Reflections III"
         ],
         "gametext": "Plays on table. While you occupy a Renegade planet location, operatives are forfeit = 0, operatives do not add to Force drains and your Force drains may not be reduced. Sleens do not cancel Force icons. Cannot be canceled.",
@@ -36928,6 +36971,7 @@
         "type": "Defensive Shield",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Reflections III"
         ],
         "gametext": "Plays on table. While you occupy a Renegade planet location, operatives are forfeit = 0, operatives do not add to Force drains and your Force drains may not be reduced. Sleens do not cancel Force icons. Cannot be canceled.",
@@ -38158,6 +38202,7 @@
         "uniqueness": "*",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Episode I"
         ],
         "gametext": "Plays on any interior site. This location may not be targeted by Proton Bombs.",
@@ -38176,6 +38221,7 @@
         "type": "Defensive Shield",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Episode I",
           "Reflections III"
         ],
@@ -38196,6 +38242,7 @@
         "uniqueness": "*",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Episode I",
           "Reflections III"
         ],
@@ -46632,6 +46679,7 @@
         "type": "Defensive Shield",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Episode I",
           "Reflections III"
         ],
@@ -46652,6 +46700,7 @@
         "uniqueness": "*",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Episode I",
           "Reflections III"
         ],
@@ -51336,7 +51385,8 @@
         "type": "Defensive Shield",
         "destiny": 0,
         "icons": [
-          "Dagobah"
+          "Dagobah",
+          "Defensive Shield"
         ],
         "gametext": "Plays on table. It Can Wait may not be played. For opponent to deploy a card with ability for free, they must first use X Force, where X = 1/2 that card's printed deploy cost (round up). For opponent to deploy a card with ability for 0 Force, they must first use 1 Force. May not be canceled.",
         "lore": "Protocol droids are programmed to interface with a variety of computer technologies. Quick and precise interpretation can dramatically increase operational efficiency."
@@ -51354,7 +51404,10 @@
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/starwars/ResetDS-Light/large/therepublicnolongerfunctions.gif?raw=true",
         "type": "Defensive Shield",
         "destiny": 0,
-        "gametext": "Plays on table. While you have 12 or fewer cards in hand, opponent may not remove cards from your hand (except with Monnok). Once per turn (even at start of turn), may target a [Coruscant] Political Effect; it is suspended for the remainder of the turn."
+        "gametext": "Plays on table. While you have 12 or fewer cards in hand, opponent may not remove cards from your hand (except with Monnok). Once per turn (even at start of turn), may target a [Coruscant] Political Effect; it is suspended for the remainder of the turn.",
+        "icons": [
+          "Defensive Shield"
+        ]
       },
       "legacy": false
     },
@@ -51587,6 +51640,7 @@
         "destiny": 0,
         "icons": [
           "Death Star II",
+          "Defensive Shield",
           "Reflections 3"
         ],
         "gametext": "Unless you have deployed a Skywalker this game, plays on Table. 'Luke' and 'Son of Vader' on opponent's (Death Star II) cards are treated as 'Leia'and 'Lady Vader,' respectively. Once during your turn, opponent may activate 1 Force.",
@@ -51605,6 +51659,7 @@
         "type": "Defensive Shield",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Reflections III"
         ],
         "gametext": "Plays on Your Destiny unless Leia or Luke has been deployed this game (even as a captive). [Death Star II] Luke and We're The Bait are lost. Opponent's Objective and [Death Star II] Effects target Leia instead of Luke. Force loss from Take Your Father's Place is -1.",
@@ -52640,6 +52695,9 @@
         "type": "Defensive Shield",
         "destiny": 3,
         "gametext": "Plays on table. 'Three' on An Unusual Amount Of Fear is treated as 'Four'. You lose no Force to Boonta Eve Podrace. Opponent's retrieval from Boonta Eve Podrace may not be canceled. While you occupy three battlegrounds, Watto's Box is suspended.",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "Expert traffic controllers coordinate launches faster than automated launch systems. Rebel bases scramble fighters quickly during Imperial attacks."
       },
       "legacy": true
@@ -53173,6 +53231,9 @@
         "uniqueness": "*",
         "destiny": 0,
         "gametext": "Plays on table. While you occupy at least 3 battlegrounds or opponent occupies no battlegrounds, you lose no more than 2 Force from each Force drain or 'insert' card.",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "'Jabba! This is your last chance. Free us or die.'"
       },
       "counterpart": "Resistance - Defensive Shield",
@@ -54253,6 +54314,7 @@
         "type": "Defensive Shield",
         "destiny": 3,
         "icons": [
+          "Defensive Shield",
           "Special Edition"
         ],
         "gametext": "Plays on table. Whenever opponent excludes any character(s) from battle, they lose 2 Force. At end of opponent's turn, if you control two battlegrounds (a site and a system) and opponent deployed a card with ability and did not inititate a battle, may retrieve 1 Force.",
@@ -55377,6 +55439,9 @@
         "uniqueness": "*",
         "destiny": 0,
         "gametext": "Plays on table. Your Immediate Effects may play for free. Whenever opponent cancels your card with Sense or Alter, place that canceled card in Used Pile.",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "The guidance of experienced Jedi allowed Luke to confront Vader."
       },
       "counterpart": "Oppressive Enforcement - Defensive Shield",
@@ -56643,6 +56708,9 @@
         "type": "Defensive Shield",
         "destiny": 0,
         "gametext": "Plays on table.  Colo Claw Fish is canceled.  Opponent must first use X Force to deploy a non-unique card (except a Jawa or Tusken Raider) to a location, where X = the number of copies of that card at that location.  [Reflections III] lightsaber weapon destiny draws cannot be increased above their printed value.",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "Rebel sentries are stationed on raised sensor platforms. On watch for Imperial scouts and other hazards, they supplement data gathered by Yavin Base's main sensors."
       },
       "legacy": true
@@ -56658,7 +56726,10 @@
         "type": "Defensive Shield",
         "uniqueness": "*",
         "destiny": 0,
-        "gametext": "Plays on table. Colo Claw Fish is canceled. Opponent must first use X Force to deploy a non-unique card (except a Jawa or Tusken Raider) to a location, where X = the number of copies of that card at that location."
+        "gametext": "Plays on table. Colo Claw Fish is canceled. Opponent must first use X Force to deploy a non-unique card (except a Jawa or Tusken Raider) to a location, where X = the number of copies of that card at that location.",
+        "icons": [
+          "Defensive Shield"
+        ]
       },
       "cancels": [
         "Colo Claw Fish"
@@ -57432,6 +57503,9 @@
         "uniqueness": "*",
         "destiny": 0,
         "gametext": "Plays on table. Cancels Scanning Crew. If an 'insert' card was just inserted or revealed, it is canceled.",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "Luke knew that while the dark side was quicker and more seductive, eventually evil would turn on itself."
       },
       "counterpart": "You Cannot Hide Forever - Defensive Shield",
@@ -57518,6 +57592,9 @@
           "Death Star II"
         ],
         "gametext": "Plays on table. Scanning Crew is canceled. If an 'insert' card was just inserted or revealed, it is canceled. You lose no Force to Boonta Eve Podrace, and opponent's retrieval from Boonta Eve Podrace may not be canceled. While you occupy three battlegrounds, Watto's Box is suspended.",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "Luke knew that while the dark side was quicker and more seductive, eventually evil would turn on itself."
       },
       "legacy": true
@@ -57533,7 +57610,8 @@
         "type": "Defensive Shield",
         "destiny": 5,
         "icons": [
-          "Death Star II"
+          "Death Star II",
+          "Defensive Shield"
         ],
         "gametext": "Plays on table. Scanning Crew is canceled. If an 'insert' card was just inserted or revealed, it is canceled. You lose no Force to Boonta Eve Podrace. While you occupy three battlegrounds, Watto's Box is suspended.",
         "lore": "Luke knew that while the dark side was quicker and more seductive, eventually evil would turn on itself."
@@ -57551,6 +57629,7 @@
         "type": "Defensive Shield",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Reflections III"
         ],
         "gametext": "Plays on table. Scanning Crew is canceled. If an 'insert' card was just inserted or revealed, it is canceled. You lose no Force to Boonta Eve Podrace, and opponent's retrieval from Boonta Eve Podrace may not be canceled. While you occupy three battlegrounds, Watto's Box is suspended.",
@@ -57570,6 +57649,7 @@
         "uniqueness": "*",
         "destiny": 0,
         "icons": [
+          "Defensive Shield",
           "Reflections III"
         ],
         "gametext": "Plays on table. Scanning Crew is canceled. If an 'insert' card was just inserted or revealed, it is canceled. You lose no Force to Boonta Eve Podrace. While you occupy three battlegrounds, Watto's Box is suspended.",
@@ -57605,6 +57685,9 @@
         "uniqueness": "*",
         "destiny": 0,
         "gametext": "Plays on table. Cancels A Dangerous Time. Each player may play only one card with 'sabacc' in title each turn. You may cancel an opponent's card with 'sabacc' in title by losing 1 Force from hand.",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "Han was not sure if Lando had forgiven him for winning the Millennium Falcon. As the old gamblers' saying about sabacc goes: 'Win the game, lose a friend.'"
       },
       "cancels": [
@@ -57980,6 +58063,9 @@
         "uniqueness": "*",
         "destiny": 0,
         "gametext": "Plays on table. Cancels A Dangerous Time. Each player may play only one card with 'sabacc' in title each turn. You may cancel an opponent's card with 'sabacc' in title by losing 1 Force from hand.",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "Han was not sure if Lando had forgiven him for winning the Millennium Falcon. As the old gamblers' saying about sabacc goes: 'Win the game, lose a friend.'"
       },
       "cancels": [
@@ -58360,6 +58446,9 @@
         "uniqueness": "*",
         "destiny": 0,
         "gametext": "Plays on table. Opponent's Undercover spies are immune to Nevar Yalnal. Field Promotion is canceled if on Ozzel or opponent's [Maintenance] card. If Monnok just revealed your hand, you may place up to two cards from hand in your Used Pile.",
+        "icons": [
+          "Defensive Shield"
+        ],
         "lore": "'Lord Vader, the fleet has moved out of lightspeed and we're preparing to aah . . . ukh . . . uh . . . uuuuukkk!'"
       },
       "legacy": false


### PR DESCRIPTION
I want to be able to use this icon when cross-referencing with: https://raw.githubusercontent.com/PlayersCommittee/gemp-swccg-public/master/gemp-swccg-server/src/main/resources/swccgFormats.json. This way I can determine which cards are banned in formats where DEFENSIVE_SHIELD is included in the bannedIcons list.