### PR TITLE
Single Quote

### DIFF
--- a/Dark.json
+++ b/Dark.json
@@ -56637,7 +56637,7 @@
       "rarity": "R",
       "set": "Virtual Set 13",
       "front": {
-        "title": "I’ve Been Searching For You For Some Time",
+        "title": "I've Been Searching For You For Some Time",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/starwars/Virtual13-Dark/large/ivebeensearchingforyouforsometime.gif?raw=true",
         "type": "Interrupt",
         "subType": "Used or Lost",
@@ -56673,7 +56673,7 @@
       "rarity": "U2",
       "set": "Virtual Set 13",
       "front": {
-        "title": "•Dathomir: Maul’s Chambers",
+        "title": "•Dathomir: Maul's Chambers",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/starwars/Virtual13-Dark/large/dathomirmaulschambers.gif?raw=true",
         "type": "Location",
         "subType": "Site",
@@ -56745,7 +56745,7 @@
       "rarity": "U2",
       "set": "Virtual Set 13",
       "front": {
-        "title": "•First Light: Dryden’s Study",
+        "title": "•First Light: Dryden's Study",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/starwars/Virtual13-Dark/large/firstlightdrydensstudy.gif?raw=true",
         "type": "Location",
         "subType": "Site",

--- a/Light.json
+++ b/Light.json
@@ -58289,7 +58289,7 @@
       "rarity": "C",
       "set": "Virtual Set 13",
       "front": {
-        "title": "•Qi’ra",
+        "title": "•Qi'ra",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/starwars/Virtual13-Light/large/qira.gif?raw=true",
         "type": "Character",
         "subType": "Alien",
@@ -58607,7 +58607,7 @@
       "rarity": "C",
       "set": "Virtual Set 13",
       "front": {
-        "title": "•He’s The Best Smuggler Around",
+        "title": "•He's The Best Smuggler Around",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/starwars/Virtual13-Light/large/hesthebestsmuggleraround.gif?raw=true",
         "type": "Interrupt",
         "subType": "Used or Lost",
@@ -58676,7 +58676,7 @@
       "rarity": "R",
       "set": "Virtual Set 13",
       "front": {
-        "title": "•I’ve Got A Really Good Feeling About This",
+        "title": "•I've Got A Really Good Feeling About This",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/starwars/Virtual13-Light/large/ivegotareallygoodfeelingaboutthis.gif?raw=true",
         "type": "Interrupt",
         "subType": "Used",
@@ -58796,7 +58796,7 @@
       "rarity": "U",
       "set": "Virtual Set 13",
       "front": {
-        "title": "Leia’s Resistance Transport",
+        "title": "Leia's Resistance Transport",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/starwars/Virtual13-Light/large/leiasresistancetransport.gif?raw=true",
         "type": "Starship",
         "subType": "Capital: Resistance Transport",


### PR DESCRIPTION
Replaced fancy quote mark with single tick mark.

These characters don't work well in Holotable and aren't consistent with other cards that have an apostrophe.  (e.g. Han's Dice)