### PR TITLE
Sets2

### DIFF
--- a/Dark.json
+++ b/Dark.json
@@ -5,7 +5,12 @@
       "gempId": "7_163",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "2X-7KPR (Tooex)",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/2x7kprtooex.gif",
@@ -29,7 +34,12 @@
       "gempId": "4_114",
       "side": "Dark",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•3,720 To 1",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/3720to1.gif",
@@ -57,7 +67,12 @@
       "id": 6053,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•3,720 To 1 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/3720to1.gif",
@@ -76,7 +91,12 @@
       "gempId": "14_69",
       "side": "Dark",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•3B3-10",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/3b310.gif",
@@ -117,7 +137,12 @@
       "id": 6054,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•3B3-10 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/3b310.gif",
@@ -146,7 +171,12 @@
       "gempId": "14_70",
       "side": "Dark",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•3B3-1204",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/3b31204.gif",
@@ -187,7 +217,12 @@
       "gempId": "14_71",
       "side": "Dark",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•3B3-21",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/3b321.gif",
@@ -225,7 +260,12 @@
       "gempId": "14_72",
       "side": "Dark",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•3B3-888",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/3b3888.gif",
@@ -263,7 +303,12 @@
       "gempId": "4_91",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•4-LOM",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/4lom.gif",
@@ -304,7 +349,12 @@
       "gempId": "109_6",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Enhanced Cloud City",
+      "set": "109",
+      "printings": [
+        {
+          "set": "109"
+        }
+      ],
       "front": {
         "title": "•4-LOM With Concussion Rifle",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedCloudCity-Dark/large/4lomwithconcussionrifle.gif",
@@ -347,7 +397,12 @@
       "id": 6055,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•4-LOM With Concussion Rifle (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/4lomwithconcussionrifle.gif",
@@ -376,7 +431,12 @@
       "gempId": "200_71",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•4-LOM With Concussion Rifle (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/4lomwithconcussionrifle.gif",
@@ -419,7 +479,12 @@
       "gempId": "4_174",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•4-LOM's Concussion Rifle",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/4lomsconcussionrifle.gif",
@@ -447,7 +512,12 @@
       "gempId": "1_163",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•5D6-RA-7 (Fivedesix)",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/5d6ra7.gif",
@@ -477,7 +547,12 @@
       "id": 6056,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•5D6-RA-7 (Fivedesix) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/5d6ra7.gif",
@@ -503,7 +578,12 @@
       "gempId": "200_72",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•5D6-RA-7 (Fivedesix) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/5d6ra7.gif",
@@ -534,7 +614,12 @@
       "gempId": "7_218",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•A Bright Center To The Universe",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/abrightcentertotheuniverse.gif",
@@ -554,7 +639,12 @@
       "id": 6057,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•A Bright Center To The Universe (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/abrightcentertotheuniverse.gif",
@@ -573,7 +663,12 @@
       "gempId": "4_136",
       "side": "Dark",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•A Dangerous Time",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/adangeroustime.gif",
@@ -597,7 +692,12 @@
       "gempId": "3_116",
       "side": "Dark",
       "rarity": "C1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•A Dark Time For The Rebellion",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/adarktimefortherebellion.gif",
@@ -617,7 +717,12 @@
       "id": 6058,
       "side": "Dark",
       "rarity": "C1",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•A Dark Time For The Rebellion (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/adarktimefortherebellion.gif",
@@ -634,7 +739,12 @@
       "gempId": "201_33",
       "side": "Dark",
       "rarity": "C1",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•A Dark Time For The Rebellion (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Dark/large/adarktimefortherebellion.gif",
@@ -653,7 +763,12 @@
       "gempId": "7_219",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•A Day Long Remembered",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/adaylongremembered.gif",
@@ -674,7 +789,12 @@
       "id": 6059,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•A Day Long Remembered (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/adaylongremembered.gif",
@@ -693,7 +813,12 @@
       "gempId": "200_101",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•A Day Long Remembered (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/adaylongremembered.gif",
@@ -714,7 +839,12 @@
       "gempId": "1_208",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•A Disturbance In The Force",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/adisturbanceintheforce.gif",
@@ -741,7 +871,12 @@
       "id": 6060,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•A Disturbance In The Force (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/adisturbanceintheforce.gif",
@@ -757,7 +892,12 @@
       "gempId": "11_68",
       "side": "Dark",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•A Million Voices Crying Out",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/amillionvoicescryingout.gif",
@@ -784,7 +924,12 @@
       "gempId": "7_245",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•A Real Hero",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/arealhero.gif",
@@ -810,7 +955,12 @@
       "id": 6061,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•A Sith's Plans",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/asithsplans.gif",
@@ -828,7 +978,12 @@
       "id": 6062,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•A Sith's Weapon",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/asithsweapon.gif",
@@ -848,7 +1003,12 @@
       "id": 6063,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "A Stunning Move / A Valuable Hostage",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/astunningmove.gif",
@@ -876,7 +1036,12 @@
       "gempId": "211_26",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "A Stunning Move / A Valuable Hostage",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Dark/large/astunningmove.gif",
@@ -906,7 +1071,12 @@
       "gempId": "205_19",
       "side": "Dark",
       "rarity": "F",
-      "set": "Virtual Set 5",
+      "set": "205",
+      "printings": [
+        {
+          "set": "205"
+        }
+      ],
       "front": {
         "title": "•A Trophy Sacrificed",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual5-Dark/large/atrophysacrificed.gif",
@@ -927,7 +1097,12 @@
       "gempId": "13_51",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•A Useless Gesture",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/auselessgesture.gif",
@@ -949,7 +1124,12 @@
       "id": 6065,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•A Useless Gesture (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Dark/large/auselessgesture.gif",
@@ -970,7 +1150,12 @@
       "gempId": "200_93",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 0",
+      "set": "200d",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•A Useless Gesture (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/ResetDS-Dark/large/auselessgesture.gif",
@@ -992,7 +1177,12 @@
       "gempId": "14_120",
       "side": "Dark",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•AAT Assault Leader",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/aatassaultleader.gif",
@@ -1027,7 +1217,12 @@
       "gempId": "14_126",
       "side": "Dark",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "AAT Laser Cannon",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/aatlasercannon.gif",
@@ -1054,7 +1249,12 @@
       "gempId": "5_110",
       "side": "Dark",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Ability, Ability, Ability",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/abilityabilityability.gif",
@@ -1079,7 +1279,12 @@
       "id": 6066,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Ability, Ability, Ability (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/abilityabilityability.gif",
@@ -1098,7 +1303,12 @@
       "gempId": "5_111",
       "side": "Dark",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Abyss",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/abyss.gif",
@@ -1121,7 +1331,12 @@
       "id": 6067,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "Abyss (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Dark/large/abyss.gif",
@@ -1141,7 +1356,12 @@
       "gempId": "6_91",
       "side": "Dark",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Abyssin",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/abyssin.gif",
@@ -1165,7 +1385,12 @@
       "gempId": "6_151",
       "side": "Dark",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Abyssin Ornament",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/abyssinornament.gif",
@@ -1187,7 +1412,12 @@
       "gempId": "10_28",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Abyssin Ornament & •Wounded Wookiee",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Dark/large/abyssinornament&woundedwookiee.gif",
@@ -1206,7 +1436,12 @@
       "id": 6068,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Abyssin Ornament & •Wounded Wookiee (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/abyssinornament&woundedwookiee.gif",
@@ -1225,7 +1460,12 @@
       "id": 6069,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Abyssin Ornament (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/abyssinornament.gif",
@@ -1242,7 +1482,12 @@
       "gempId": "8_134",
       "side": "Dark",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "Accelerate",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/accelerate.gif",
@@ -1259,7 +1504,12 @@
       "gempId": "12_127",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Accepting Trade Federation Control",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/acceptingtradefederationcontrol.gif",
@@ -1286,7 +1536,12 @@
       "id": 6070,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•According To My Design",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/accordingtomydesign.gif",
@@ -1306,7 +1561,12 @@
       "gempId": "201_34",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•According To My Design",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Dark/large/accordingtomydesign.gif",
@@ -1331,7 +1591,12 @@
       "gempId": "9_152",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Accuser",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/accuser.gif",
@@ -1369,7 +1634,12 @@
       "id": 6071,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Accuser (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/accuser.gif",
@@ -1397,7 +1667,12 @@
       "gempId": "14_93",
       "side": "Dark",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Activate The Droids",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/activatethedroids.gif",
@@ -1422,7 +1697,12 @@
       "gempId": "9_97",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Admiral Chiraneau",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/admiralchiraneau.gif",
@@ -1456,7 +1736,12 @@
       "gempId": "1_164",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Admiral Motti",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/admiralmotti.gif",
@@ -1500,7 +1785,12 @@
       "id": 6072,
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Admiral Motti (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/admiralmotti.gif",
@@ -1528,7 +1818,12 @@
       "gempId": "200_73",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Admiral Motti (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/admiralmotti.gif",
@@ -1575,7 +1870,12 @@
       "id": 6073,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Admiral Motti, Battlestation Coordinator (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/admiralmottibattlestationcoordinator.gif",
@@ -1604,7 +1904,12 @@
       "gempId": "3_82",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Admiral Ozzel",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/admiralozzel.gif",
@@ -1640,7 +1945,12 @@
       "id": 6074,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Admiral Ozzel (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/admiralozzel.gif",
@@ -1664,7 +1974,12 @@
       "id": 6075,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Admiral Pellaeon",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/admiralpellaeon.gif",
@@ -1691,7 +2006,12 @@
       "gempId": "9_98",
       "side": "Dark",
       "rarity": "XR",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Admiral Piett",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/admiralpiett.gif",
@@ -1761,7 +2081,12 @@
       "id": 6076,
       "side": "Dark",
       "rarity": "XR",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Admiral Piett (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/admiralpiett.gif",
@@ -1790,7 +2115,12 @@
       "gempId": "2_82",
       "side": "Dark",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•••Advosze",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/advosze.gif",
@@ -1822,7 +2152,12 @@
       "gempId": "14_94",
       "side": "Dark",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•After Her!",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/afterher.gif",
@@ -1850,7 +2185,12 @@
       "id": 6077,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•After Her! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Dark/large/afterher.gif",
@@ -1871,7 +2211,12 @@
       "gempId": "203_22",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•Agent Kallus",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Dark/large/agentkallus.gif",
@@ -1904,7 +2249,12 @@
       "gempId": "203_22",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•Agent Kallus (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/OfficialAI-Dark/large/agentkallus.gif",
@@ -1932,7 +2282,12 @@
       "gempId": "10_29",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "Agents of Black Sun / Vengeance of the Dark Prince",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Dark/large/agentsofblacksun.gif",
@@ -1954,7 +2309,12 @@
       "gempId": "5_130",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Aiiii! Aaa! Agggggggggg!",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/aiiiiaaaagggggggggg.gif",
@@ -1979,7 +2339,12 @@
       "gempId": "7_164",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Ak-rev",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/akrev.gif",
@@ -2028,7 +2393,12 @@
       "gempId": "12_97",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Aks Moe",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/aksmoe.gif",
@@ -2060,7 +2430,12 @@
       "gempId": "1_281",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Alderaan",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/alderaan.gif",
@@ -2084,7 +2459,12 @@
       "gempId": "7_220",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Alert My Star Destroyer!",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/alertmystardestroyer.gif",
@@ -2112,7 +2492,12 @@
       "id": 6080,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Alert My Star Destroyer! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/alertmystardestroyer.gif",
@@ -2131,7 +2516,12 @@
       "gempId": "208_38",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "Alert My Star Destroyer! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/alertmystardestroyer.gif",
@@ -2154,7 +2544,12 @@
       "gempId": "7_246",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "All Power To Weapons",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/allpowertoweapons.gif",
@@ -2186,7 +2581,12 @@
       "gempId": "5_112",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•All Too Easy",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/alltooeasy.gif",
@@ -2221,7 +2621,12 @@
       "gempId": "6_141",
       "side": "Dark",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•All Wrapped Up",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/allwrappedup.gif",
@@ -2241,7 +2646,12 @@
       "id": 6081,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•All Wrapped Up (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/allwrappedup.gif",
@@ -2260,7 +2670,12 @@
       "gempId": "12_128",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Allegations Of Corruption",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/allegationsofcorruption.gif",
@@ -2285,7 +2700,12 @@
       "gempId": "13_52",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Allegations Of Corruption",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/allegationsofcorruption.gif",
@@ -2311,7 +2731,12 @@
       "gempId": "12_145",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Alter",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/alter.gif",
@@ -2353,7 +2778,12 @@
       "gempId": "1_234",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Alter",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/alter.gif",
@@ -2388,7 +2818,12 @@
       "gempId": "10_30",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "Alter & Collateral Damage",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Dark/large/alter&collateraldamage.gif",
@@ -2417,7 +2852,12 @@
       "id": 6082,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "Alter (Coruscant) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/altercoruscant.gif",
@@ -2438,7 +2878,12 @@
       "gempId": "200_144",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "Alter (Coruscant) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/altercoruscant.gif",
@@ -2458,7 +2903,12 @@
       "id": 6084,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "Alter (Premiere) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/alterpremiere.gif",
@@ -2475,7 +2925,12 @@
       "gempId": "200_115",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "Alter (Premiere) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/alterpremiere.gif",
@@ -2491,7 +2946,12 @@
       "id": 6086,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Altering The Deal",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/alteringthedeal.gif",
@@ -2510,7 +2970,12 @@
       "gempId": "8_135",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Always Thinking With Your Stomach",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/alwaysthinkingwithyourstomach.gif",
@@ -2532,7 +2997,12 @@
       "gempId": "211_12",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "••Always Two There Are",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Dark/large/alwaystwothereare.gif",
@@ -2552,7 +3022,12 @@
       "gempId": "6_92",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Amanaman",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/amanaman.gif",
@@ -2577,7 +3052,12 @@
       "gempId": "6_93",
       "side": "Dark",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Amanin",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/amanin.gif",
@@ -2597,7 +3077,12 @@
       "id": 6088,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•An Enemy Of The Republic",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/anenemyoftherepublic.gif",
@@ -2617,7 +3102,12 @@
       "gempId": "8_116",
       "side": "Dark",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•An Entire Legion Of My Best Troops",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/anentirelegionofmybesttroops.gif",
@@ -2640,7 +3130,12 @@
       "gempId": "209_41",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "An Inkling Of Its Destructive Potential",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Dark/large/aninklingofitsdestructivepotential.gif",
@@ -2656,7 +3151,12 @@
       "gempId": "4_154",
       "side": "Dark",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Anoat",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/anoat.gif",
@@ -2684,7 +3184,12 @@
       "gempId": "7_165",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Anoat Operative",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/anoatoperative.gif",
@@ -2715,7 +3220,12 @@
       "gempId": "6_174",
       "side": "Dark",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Antipersonnel Laser Cannon",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/antipersonnellasercannon.gif",
@@ -2742,7 +3252,12 @@
       "gempId": "109_7",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Enhanced Cloud City",
+      "set": "109",
+      "printings": [
+        {
+          "set": "109"
+        }
+      ],
       "front": {
         "title": "•Any Methods Necessary",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedCloudCity-Dark/large/anymethodsnecessary.gif",
@@ -2794,7 +3309,12 @@
       "gempId": "206_13",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 6",
+      "set": "206",
+      "printings": [
+        {
+          "set": "206"
+        }
+      ],
       "front": {
         "title": "•Any Methods Necessary (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual6-Dark/large/anymethodsnecessary.gif",
@@ -2828,7 +3348,12 @@
       "gempId": "4_137",
       "side": "Dark",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Apology Accepted",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/apologyaccepted.gif",
@@ -2846,7 +3371,12 @@
       "gempId": "209_46",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Apology Accepted (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Dark/large/apologyaccepted.gif",
@@ -2866,7 +3396,12 @@
       "gempId": "6_94",
       "side": "Dark",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•••Aqualish",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/aqualish.gif",
@@ -2891,7 +3426,12 @@
       "gempId": "8_117",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Aratech Corporation",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/aratechcorporation.gif",
@@ -2916,7 +3456,12 @@
       "id": 6091,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Aratech Corporation (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/aratechcorporation.gif",
@@ -2935,7 +3480,12 @@
       "gempId": "200_103",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Aratech Corporation (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/aratechcorporation.gif",
@@ -2960,7 +3510,12 @@
       "id": 6092,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Arena Execution",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/arenaexecution.gif",
@@ -2978,7 +3533,12 @@
       "id": 6093,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Arena Pillars",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/arenapillars.gif",
@@ -2997,7 +3557,12 @@
       "gempId": "10_31",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Arica",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Dark/large/arica.gif",
@@ -3042,7 +3607,12 @@
       "id": 6094,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Arica (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/arica.gif",
@@ -3071,7 +3641,12 @@
       "gempId": "200_74",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Arica (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/arica.gif",
@@ -3114,7 +3689,12 @@
       "gempId": "14_121",
       "side": "Dark",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•••Armored Attack Tank",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/armoredattacktank.gif",
@@ -3149,7 +3729,12 @@
       "gempId": "301_3",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Premium Set",
+      "set": "301",
+      "printings": [
+        {
+          "set": "301"
+        }
+      ],
       "front": {
         "title": "•Asajj Ventress With Lightsabers",
         "imageUrl": "https://res.starwarsccg.org/cards/DemoDeck-Dark/large/asajjventresswithlightsabers.gif",
@@ -3187,7 +3772,12 @@
       "id": 6095,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Assassin's Blaster Rifle",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/assassinsblasterrifle.gif",
@@ -3203,7 +3793,12 @@
       "gempId": "1_311",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Assault Rifle",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/assaultrifle.gif",
@@ -3229,7 +3824,12 @@
       "id": 6096,
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Assault Rifle (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/assaultrifle.gif",
@@ -3246,7 +3846,12 @@
       "gempId": "4_155",
       "side": "Dark",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "<><><>Asteroid Field",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/asteroidfield.gif",
@@ -3269,7 +3874,12 @@
       "gempId": "2_116",
       "side": "Dark",
       "rarity": "U2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Astromech Shortage",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/astromechshortage.gif",
@@ -3292,7 +3902,12 @@
       "id": 6097,
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Astromech Shortage (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/astromechshortage.gif",
@@ -3311,7 +3926,12 @@
       "gempId": "14_95",
       "side": "Dark",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•At Last We Are Getting Results",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/atlastwearegettingresults.gif",
@@ -3335,7 +3955,12 @@
       "id": 6098,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•At Last We Are Getting Results (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/atlastwearegettingresults.gif",
@@ -3356,7 +3981,12 @@
       "gempId": "3_158",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "AT-AT Cannon",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/atatcannon.gif",
@@ -3379,7 +4009,12 @@
       "id": 6099,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "AT-AT Cannon (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/atatcannon.gif",
@@ -3398,7 +4033,12 @@
       "id": 6100,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•AT-AT Commander",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/atatcommander.gif",
@@ -3422,7 +4062,12 @@
       "id": 6101,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•••AT-AT Deployment Platform",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/atatdeploymentplatform.gif",
@@ -3444,7 +4089,12 @@
       "gempId": "3_83",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "AT-AT Driver",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/atatdriver.gif",
@@ -3467,7 +4117,12 @@
       "id": 6102,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "AT-AT Driver (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/atatdriver.gif",
@@ -3492,7 +4147,12 @@
       "gempId": "8_178",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "AT-ST Dual Cannon",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/atstdualcannon.gif",
@@ -3520,7 +4180,12 @@
       "id": 6103,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "AT-ST Dual Cannon (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/atstdualcannon.gif",
@@ -3540,7 +4205,12 @@
       "gempId": "8_91",
       "side": "Dark",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•••AT-ST Pilot",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/atstpilot.gif",
@@ -3565,7 +4235,12 @@
       "gempId": "5_131",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Atmospheric Assault",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/atmosphericassault.gif",
@@ -3585,7 +4260,12 @@
       "id": 6104,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Atmospheric Assault (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/atmosphericassault.gif",
@@ -3605,7 +4285,12 @@
       "gempId": "11_51",
       "side": "Dark",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Aurra Sing",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/aurrasing.gif",
@@ -3650,7 +4335,12 @@
       "gempId": "11_52",
       "side": "Dark",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Aurra Sing (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/aurrasingai.gif",
@@ -3677,7 +4367,12 @@
       "id": 6106,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Aurra Sing (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/aurrasing.gif",
@@ -3706,7 +4401,12 @@
       "id": 6107,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Aurra Sing (V) (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/aurrasingai.gif",
@@ -3735,7 +4435,12 @@
       "id": 6108,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Aurra Sing, Deadly Assassin",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/aurrasingdeadlyassassin.gif",
@@ -3763,7 +4468,12 @@
       "gempId": "13_53",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Aurra Sing's Blaster Rifle",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/aurrasingsblasterrifle.gif",
@@ -3798,7 +4508,12 @@
       "gempId": "4_166",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Avenger",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/avenger.gif",
@@ -3841,7 +4556,12 @@
       "gempId": "4_115",
       "side": "Dark",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Awwww, Cannot Get Your Ship Out",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/awwwwcannotgetyourshipout.gif",
@@ -3863,7 +4583,12 @@
       "id": 6109,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Awwww, Cannot Get Your Ship Out (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/awwwwcannotgetyourshipout.gif",
@@ -3883,7 +4608,12 @@
       "gempId": "204_36",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•••B2 Battle Droid",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Dark/large/b2battledroid.gif",
@@ -3919,7 +4649,12 @@
       "id": 6110,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•••B2 Super Battle Droid",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/b2superbattledroid.gif",
@@ -3949,7 +4684,12 @@
       "gempId": "4_116",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Bad Feeling Have I",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/badfeelinghavei.gif",
@@ -3973,7 +4713,12 @@
       "id": 6111,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Baktoid Armor Workshop",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/baktoidarmorworkshop.gif",
@@ -3992,7 +4737,12 @@
       "gempId": "209_33",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Bala-Tik",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Dark/large/balatik.gif",
@@ -4023,7 +4773,12 @@
       "gempId": "6_95",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Bane Malar",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/banemalar.gif",
@@ -4057,7 +4812,12 @@
       "id": 6113,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Bane Malar (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/banemalar.gif",
@@ -4084,7 +4844,12 @@
       "id": 6114,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Bane Malar, Spice Addict",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/banemalarspiceaddict.gif",
@@ -4112,7 +4877,12 @@
       "gempId": "1_209",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Baniss Keeg",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/banisskeeg.gif",
@@ -4133,7 +4903,12 @@
       "gempId": "203_23",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•Baniss Keeg, Pilot Instructor",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Dark/large/banisskeegpilotinstructor.gif",
@@ -4177,7 +4952,12 @@
       "gempId": "1_307",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Bantha",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/bantha.gif",
@@ -4204,7 +4984,12 @@
       "id": 6115,
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Bantha (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/bantha.gif",
@@ -4226,7 +5011,12 @@
       "gempId": "6_152",
       "side": "Dark",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Bantha Fodder",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/banthafodder.gif",
@@ -4264,7 +5054,12 @@
       "gempId": "7_221",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "••Bantha Herd",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/banthaherd.gif",
@@ -4285,7 +5080,12 @@
       "id": 6116,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "••Bantha Herd (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/banthaherd.gif",
@@ -4304,7 +5104,12 @@
       "gempId": "6_96",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Barada",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/barada.gif",
@@ -4329,7 +5134,12 @@
       "gempId": "9_99",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Baron Soontir Fel",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/baronsoontirfel.gif",
@@ -4368,7 +5178,12 @@
       "gempId": "7_166",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Barquin D'an",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/barquindan.gif",
@@ -4398,7 +5213,12 @@
       "gempId": "12_98",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Baskol Yeesrim",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/baskolyeesrim.gif",
@@ -4430,7 +5250,12 @@
       "gempId": "9_92",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Battle Deployment",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/battledeployment.gif",
@@ -4480,7 +5305,12 @@
       "gempId": "12_186",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Battle Droid Blaster Rifle",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/battledroidblasterrifle.gif",
@@ -4507,7 +5337,12 @@
       "gempId": "14_73",
       "side": "Dark",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•••Battle Droid Officer",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/battledroidofficer.gif",
@@ -4547,7 +5382,12 @@
       "gempId": "14_74",
       "side": "Dark",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "Battle Droid Pilot",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/battledroidpilot.gif",
@@ -4582,7 +5422,12 @@
       "id": 6117,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Battle Droid Squad",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/battledroidsquad.gif",
@@ -4610,7 +5455,12 @@
       "gempId": "8_118",
       "side": "Dark",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Battle Order",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/battleorder.gif",
@@ -4634,7 +5484,12 @@
       "gempId": "13_54",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Battle Order",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/battleorder.gif",
@@ -4655,7 +5510,12 @@
       "gempId": "12_129",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Battle Order & •First Strike",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/battleorder&firststrike.gif",
@@ -4676,7 +5536,12 @@
       "gempId": "6_97",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Beedo",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/beedo.gif",
@@ -4710,7 +5575,12 @@
       "gempId": "12_130",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Begin Landing Your Troops",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/beginlandingyourtroops.gif",
@@ -4751,7 +5621,12 @@
       "id": 6118,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Begin Landing Your Troops & The Dark Path",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/beginlandingyourtroops&thedarkpath.gif",
@@ -4766,7 +5641,12 @@
       "gempId": "11_95",
       "side": "Dark",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Ben Quadinaros' Podracer",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/benquadinarospodracer.gif",
@@ -4786,7 +5666,12 @@
       "gempId": "2_117",
       "side": "Dark",
       "rarity": "R2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Besieged",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/besieged.gif",
@@ -4810,7 +5695,12 @@
       "id": 6119,
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Besieged (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/besieged.gif",
@@ -4829,7 +5719,12 @@
       "gempId": "5_164",
       "side": "Dark",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Bespin",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/bespin.gif",
@@ -4855,7 +5750,12 @@
       "id": 6120,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Bespin (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/bespin.gif",
@@ -4875,7 +5775,12 @@
       "gempId": "2_156",
       "side": "Dark",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Bespin Motors Void Spider THX 1138",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/bespinmotorsvoidspiderthx1138.gif",
@@ -4903,7 +5808,12 @@
       "gempId": "5_165",
       "side": "Dark",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Bespin: Cloud City",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/bespincloudcity.gif",
@@ -4929,7 +5839,12 @@
       "gempId": "6_98",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Bib Fortuna",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/bibfortuna.gif",
@@ -4958,7 +5873,12 @@
       "gempId": "13_55",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Bib Fortuna",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/bibfortuna.gif",
@@ -4986,7 +5906,12 @@
       "id": 6121,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Bib Fortuna (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/bibfortuna.gif",
@@ -5011,7 +5936,12 @@
       "gempId": "4_156",
       "side": "Dark",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "<>Big One",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/bigone.gif",
@@ -5034,7 +5964,12 @@
       "gempId": "4_157",
       "side": "Dark",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "<>Big One: Asteroid Cave Or Space Slug Belly",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/bigoneasteroidcaveorspaceslugbelly.gif",
@@ -5060,7 +5995,12 @@
       "gempId": "8_119",
       "side": "Dark",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Biker Scout Gear",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/bikerscoutgear.gif",
@@ -5086,7 +6026,12 @@
       "gempId": "8_92",
       "side": "Dark",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "Biker Scout Trooper",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/bikerscouttrooper.gif",
@@ -5123,7 +6068,12 @@
       "gempId": "202_13",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 2",
+      "set": "202",
+      "printings": [
+        {
+          "set": "202"
+        }
+      ],
       "front": {
         "title": "•Binder",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual2-Dark/large/binder.gif",
@@ -5158,7 +6108,12 @@
       "gempId": "5_106",
       "side": "Dark",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Binders",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/binders.gif",
@@ -5179,7 +6134,12 @@
       "id": 6122,
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Black 1",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/black1.gif",
@@ -5205,7 +6165,12 @@
       "gempId": "9_153",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Black 11",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/black11.gif",
@@ -5239,7 +6204,12 @@
       "gempId": "1_299",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Black 2",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/black2.gif",
@@ -5274,7 +6244,12 @@
       "id": 6123,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Black 2 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/black2.gif",
@@ -5298,7 +6273,12 @@
       "gempId": "200_127",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Black 2 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/black2.gif",
@@ -5342,7 +6322,12 @@
       "gempId": "1_300",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Black 3",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/black3.gif",
@@ -5377,7 +6362,12 @@
       "id": 6124,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Black 3 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/black3.gif",
@@ -5401,7 +6391,12 @@
       "gempId": "210_28",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•Black 3 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Dark/large/black3.gif",
@@ -5425,7 +6420,12 @@
       "gempId": "2_151",
       "side": "Dark",
       "rarity": "U2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Black 4",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/black4.gif",
@@ -5460,7 +6460,12 @@
       "id": 6126,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Black 5",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/black5.gif",
@@ -5487,7 +6492,12 @@
       "gempId": "200_128",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Black 5",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/black5.gif",
@@ -5525,7 +6535,12 @@
       "gempId": "202_14",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Set 2",
+      "set": "202",
+      "printings": [
+        {
+          "set": "202"
+        }
+      ],
       "front": {
         "title": "•Black 6",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual2-Dark/large/black6.gif",
@@ -5557,7 +6572,12 @@
       "gempId": "106_10",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Official Tournament Sealed Deck",
+      "set": "106",
+      "printings": [
+        {
+          "set": "106"
+        }
+      ],
       "front": {
         "title": "•••Black Squadron TIE",
         "imageUrl": "https://res.starwarsccg.org/cards/OfficialTournamentSealedDeck-Dark/large/blacksquadrontie.gif",
@@ -5593,7 +6613,12 @@
       "gempId": "10_32",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Black Sun Fleet",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Dark/large/blacksunfleet.gif",
@@ -5612,7 +6637,12 @@
       "gempId": "1_210",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Blast Door Controls",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/blastdoorcontrols.gif",
@@ -5642,7 +6672,12 @@
       "gempId": "7_247",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Blast Points",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/blastpoints.gif",
@@ -5663,7 +6698,12 @@
       "gempId": "5_132",
       "side": "Dark",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Blasted Droid",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/blasteddroid.gif",
@@ -5685,7 +6725,12 @@
       "gempId": "1_211",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Blaster Rack",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/blasterrack.gif",
@@ -5704,7 +6749,12 @@
       "id": 6127,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Blaster Rack (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/blasterrack.gif",
@@ -5720,7 +6770,12 @@
       "gempId": "200_104",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "Blaster Rack (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/blasterrack.gif",
@@ -5745,7 +6800,12 @@
       "gempId": "1_312",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Blaster Rifle",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/blasterrifle.gif",
@@ -5778,7 +6838,12 @@
       "id": 6128,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "Blaster Rifle (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/blasterrifle.gif",
@@ -5795,7 +6860,12 @@
       "gempId": "200_141",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "Blaster Rifle (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/blasterrifle.gif",
@@ -5824,7 +6894,12 @@
       "gempId": "1_199",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Blaster Scope",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/blasterscope.gif",
@@ -5843,7 +6918,12 @@
       "gempId": "3_154",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Blizzard 1",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/blizzard1.gif",
@@ -5883,7 +6963,12 @@
       "id": 6129,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Blizzard 1 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/blizzard1.gif",
@@ -5909,7 +6994,12 @@
       "gempId": "3_155",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Blizzard 2",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/blizzard2.gif",
@@ -5946,7 +7036,12 @@
       "id": 6130,
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Blizzard 2 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/blizzard2.gif",
@@ -5973,7 +7068,12 @@
       "gempId": "200_139",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Blizzard 2 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/blizzard2.gif",
@@ -6016,7 +7116,12 @@
       "gempId": "13_56",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Blizzard 4",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/blizzard4.gif",
@@ -6166,7 +7271,12 @@
       "id": 6131,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Blizzard 4 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/blizzard4.gif",
@@ -6193,7 +7303,12 @@
       "gempId": "3_156",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Blizzard Scout 1",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/blizzardscout1.gif",
@@ -6231,7 +7346,12 @@
       "id": 6132,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Blizzard Scout 1 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/blizzardscout1.gif",
@@ -6258,7 +7378,12 @@
       "gempId": "200_140",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Blizzard Scout 1 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/blizzardscout1.gif",
@@ -6297,7 +7422,12 @@
       "gempId": "3_157",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•••Blizzard Walker",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/blizzardwalker.gif",
@@ -6334,7 +7464,12 @@
       "gempId": "14_114",
       "side": "Dark",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Blockade Flagship",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/blockadeflagship.gif",
@@ -6379,7 +7514,12 @@
       "id": 6133,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Blockade Flagship (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/blockadeflagship.gif",
@@ -6407,7 +7547,12 @@
       "gempId": "12_164",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Blockade Flagship: Bridge",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/blockadeflagshipbridge.gif",
@@ -6438,7 +7583,12 @@
       "gempId": "14_111",
       "side": "Dark",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Blockade Flagship: Docking Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/blockadeflagshipdockingbay.gif",
@@ -6473,7 +7623,12 @@
       "gempId": "13_57",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Blockade Flagship: Hallway",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/blockadeflagshiphallway.gif",
@@ -6501,7 +7656,12 @@
       "id": 6134,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Blockade Support Ship",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/blockadesupportship.gif",
@@ -6530,7 +7690,12 @@
       "gempId": "200_129",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Blockade Support Ship",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/blockadesupportship.gif",
@@ -6564,7 +7729,12 @@
       "gempId": "13_58",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Blow Parried",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/blowparried.gif",
@@ -6593,7 +7763,12 @@
       "gempId": "7_222",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Blown Clear",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/blownclear.gif",
@@ -6613,7 +7788,12 @@
       "id": 6135,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Blown Clear (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/blownclear.gif",
@@ -6633,7 +7813,12 @@
       "gempId": "5_91",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Boba Fett",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/bobafett.gif",
@@ -6682,7 +7867,15 @@
       "gempId": "7_167",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "105"
+        },
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Boba Fett",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/bobafett.gif",
@@ -6729,7 +7922,12 @@
       "id": 6136,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Boba Fett (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/bobafett.gif",
@@ -6756,7 +7954,12 @@
       "id": 6137,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Boba Fett (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/bobafett.gif",
@@ -6783,7 +7986,12 @@
       "gempId": "206_9",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 6",
+      "set": "206",
+      "printings": [
+        {
+          "set": "206"
+        }
+      ],
       "front": {
         "title": "•Boba Fett (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual6-Dark/large/bobafett.gif",
@@ -6809,7 +8017,12 @@
       "gempId": "109_8",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Enhanced Cloud City",
+      "set": "109",
+      "printings": [
+        {
+          "set": "109"
+        }
+      ],
       "front": {
         "title": "•Boba Fett In Slave I",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedCloudCity-Dark/large/bobafettinslavei.gif",
@@ -6847,7 +8060,12 @@
       "id": 6139,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Boba Fett In Slave I (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/bobafettinslavei.gif",
@@ -6876,7 +8094,12 @@
       "gempId": "200_130",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Boba Fett In Slave I (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/bobafettinslavei.gif",
@@ -6916,7 +8139,12 @@
       "gempId": "108_5",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Enhanced Premiere",
+      "set": "108",
+      "printings": [
+        {
+          "set": "108"
+        }
+      ],
       "front": {
         "title": "•Boba Fett With Blaster Rifle",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedPremiere-Dark/large/bobafettwithblasterrifle.gif",
@@ -6965,7 +8193,12 @@
       "gempId": "13_59",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Boba Fett, Bounty Hunter",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/bobafettbountyhunter.gif",
@@ -7016,7 +8249,12 @@
       "id": 6140,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Boba Fett, Bounty Hunter (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/bobafettbountyhunter.gif",
@@ -7042,7 +8280,12 @@
       "id": 6141,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Boba Fett, Prepared Hunter",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/bobafettpreparedhunter.gif",
@@ -7070,7 +8313,12 @@
       "id": 6142,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Boba Fett, Relentless Bounty Hunter",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/bobafettrelentlessbountyhunter.gif",
@@ -7097,7 +8345,12 @@
       "gempId": "5_179",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Boba Fett's Blaster Rifle",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/bobafettsblasterrifle.gif",
@@ -7132,7 +8385,12 @@
       "id": 6143,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Boba Fett's Blaster Rifle (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/bobafettsblasterrifle.gif",
@@ -7152,7 +8410,12 @@
       "gempId": "205_22",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 5",
+      "set": "205",
+      "printings": [
+        {
+          "set": "205"
+        }
+      ],
       "front": {
         "title": "•Boba Fett's Blaster Rifle (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual5-Dark/large/bobafettsblasterrifle.gif",
@@ -7186,7 +8449,12 @@
       "gempId": "7_168",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Boelo",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/boelo.gif",
@@ -7220,7 +8488,12 @@
       "gempId": "4_108",
       "side": "Dark",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Bog-wing",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/bogwing.gif",
@@ -7251,7 +8524,12 @@
       "gempId": "14_75",
       "side": "Dark",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Bok Askol",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/bokaskol.gif",
@@ -7276,7 +8554,12 @@
       "gempId": "4_117",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "<>Bombing Run",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/bombingrun.gif",
@@ -7298,7 +8581,12 @@
       "gempId": "11_79",
       "side": "Dark",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "Boonta Eve Podrace",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/boontaevepodrace.gif",
@@ -7317,7 +8605,12 @@
       "gempId": "1_313",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Boosted TIE Cannon",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/boostedtiecannon.gif",
@@ -7340,7 +8633,12 @@
       "gempId": "1_235",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Boring Conversation Anyway",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/boringconversationanyway.gif",
@@ -7373,7 +8671,12 @@
       "gempId": "4_92",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Bossk",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/bossk.gif",
@@ -7414,7 +8717,12 @@
       "id": 6144,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Bossk (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/bossk.gif",
@@ -7440,7 +8748,12 @@
       "gempId": "200_75",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Bossk (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/bossk.gif",
@@ -7480,7 +8793,12 @@
       "gempId": "7_301",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Bossk In Hound's Tooth",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/bosskinhoundstooth.gif",
@@ -7512,7 +8830,12 @@
       "id": 6145,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Bossk In Hound's Tooth (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/bosskinhoundstooth.gif",
@@ -7541,7 +8864,12 @@
       "gempId": "200_131",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Bossk In Hound's Tooth (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/bosskinhoundstooth.gif",
@@ -7574,7 +8902,12 @@
       "gempId": "110_5",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Enhanced Jabba's Palace",
+      "set": "110",
+      "printings": [
+        {
+          "set": "110"
+        }
+      ],
       "front": {
         "title": "•Bossk With Mortar Gun",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedJabbasPalace-Dark/large/bosskwithmortargun.gif",
@@ -7610,7 +8943,12 @@
       "id": 6146,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Bossk with Mortar Gun (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/bosskwithmortargun.gif",
@@ -7636,7 +8974,12 @@
       "gempId": "4_175",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Bossk's Mortar Gun",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/bossksmortargun.gif",
@@ -7663,7 +9006,12 @@
       "gempId": "5_113",
       "side": "Dark",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Bounty",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/bounty.gif",
@@ -7688,7 +9036,12 @@
       "id": 6147,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Bounty (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/bounty.gif",
@@ -7709,7 +9062,12 @@
       "gempId": "204_47",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Bow To The First Order",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Dark/large/bowtothefirstorder.gif",
@@ -7737,7 +9095,12 @@
       "gempId": "7_169",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Brangus Glee",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/brangusglee.gif",
@@ -7768,7 +9131,12 @@
       "id": 6148,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Brangus Glee (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/brangusglee.gif",
@@ -7798,7 +9166,12 @@
       "gempId": "3_98",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Breached Defenses",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/breacheddefenses.gif",
@@ -7827,7 +9200,12 @@
       "id": 6149,
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Breached Defenses & •Molator",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/breacheddefenses&molator.gif",
@@ -7845,7 +9223,12 @@
       "gempId": "5_133",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Brief Loss Of Control",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/brieflossofcontrol.gif",
@@ -7862,7 +9245,12 @@
       "id": 6150,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Brief Loss Of Control (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/brieflossofcontrol.gif",
@@ -7882,7 +9270,12 @@
       "gempId": "9_151",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "Bring Him Before Me / Take Your Father's Place",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/bringhimbeforeme.gif",
@@ -7904,7 +9297,12 @@
       "gempId": "4_118",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Broken Concentration",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/brokenconcentration.gif",
@@ -7924,7 +9322,12 @@
       "id": 6152,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Broken Concentration (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/brokenconcentration.gif",
@@ -7943,7 +9346,12 @@
       "gempId": "6_138",
       "side": "Dark",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Bubo",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/bubo.gif",
@@ -7973,7 +9381,12 @@
       "id": 6153,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Cad Bane",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/cadbane.gif",
@@ -7999,7 +9412,12 @@
       "gempId": "203_24",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•Cad Bane",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Dark/large/cadbane.gif",
@@ -8036,7 +9454,12 @@
       "gempId": "1_200",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Caller",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/caller.gif",
@@ -8053,7 +9476,12 @@
       "gempId": "6_142",
       "side": "Dark",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Cane Adiss",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/caneadiss.gif",
@@ -8076,7 +9504,12 @@
       "id": 6154,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "<>Cane Adiss (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/caneadiss.gif",
@@ -8096,7 +9529,12 @@
       "gempId": "5_92",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Captain Bewil",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/captainbewil.gif",
@@ -8132,7 +9570,12 @@
       "id": 6155,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Captain Bewil (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/captainbewil.gif",
@@ -8157,7 +9600,12 @@
       "gempId": "204_37",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Captain Bewil (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Dark/large/captainbewil.gif",
@@ -8189,7 +9637,12 @@
       "gempId": "14_76",
       "side": "Dark",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Captain Daultay Dofine",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/captaindaultaydofine.gif",
@@ -8233,7 +9686,12 @@
       "gempId": "10_33",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Captain Gilad Pellaeon",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Dark/large/captaingileadpellaeon.gif",
@@ -8268,7 +9726,12 @@
       "gempId": "9_100",
       "side": "Dark",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Captain Godherdt",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/captaingodherdt.gif",
@@ -8300,7 +9763,12 @@
       "gempId": "9_101",
       "side": "Dark",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Captain Jonus",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/captainjonus.gif",
@@ -8331,7 +9799,12 @@
       "gempId": "205_21",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 5",
+      "set": "205",
+      "printings": [
+        {
+          "set": "205"
+        }
+      ],
       "front": {
         "title": "•Captain Jonus in Scimitar 2",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual5-Dark/large/captainjonusinscimitar2.gif",
@@ -8366,7 +9839,12 @@
       "gempId": "2_83",
       "side": "Dark",
       "rarity": "U1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Captain Khurgee",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/captainkhurgee.gif",
@@ -8399,7 +9877,12 @@
       "id": 6156,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Captain Khurgee (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/captainkhurgee.gif",
@@ -8424,7 +9907,12 @@
       "gempId": "3_84",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Captain Lennox",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/captainlennox.gif",
@@ -8461,7 +9949,12 @@
       "id": 6157,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Captain Lennox (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/captainlennox.gif",
@@ -8486,7 +9979,12 @@
       "id": 6158,
       "side": "Dark",
       "rarity": "C3",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Captain Mod Terrik",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/captainmodterrik.gif",
@@ -8512,7 +10010,12 @@
       "gempId": "4_93",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Captain Needa",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/captainneeda.gif",
@@ -8550,7 +10053,12 @@
       "gempId": "208_37",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Captain Peavey",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/captainpeavey.gif",
@@ -8585,7 +10093,12 @@
       "gempId": "204_38",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Captain Phasma",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Dark/large/captainphasma.gif",
@@ -8622,7 +10135,12 @@
       "gempId": "3_85",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Captain Piett",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/captainpiett.gif",
@@ -8659,7 +10177,12 @@
       "id": 6159,
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Captain Piett (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/captainpiett.gif",
@@ -8687,7 +10210,12 @@
       "gempId": "9_102",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Captain Sarkli",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/captainsarkli.gif",
@@ -8722,7 +10250,12 @@
       "gempId": "9_103",
       "side": "Dark",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Captain Yorr",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/captainyorr.gif",
@@ -8753,7 +10286,12 @@
       "id": 6160,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Captain Yorr (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/captainyorr.gif",
@@ -8778,7 +10316,12 @@
       "gempId": "7_296",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Carbon Chamber Testing / My Favorite Decoration",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/carbonchambertesting.gif",
@@ -8800,7 +10343,12 @@
       "gempId": "5_114",
       "side": "Dark",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Carbon-Freezing",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/carbonfreezing.gif",
@@ -8825,7 +10373,12 @@
       "gempId": "5_107",
       "side": "Dark",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Carbonite Chamber Console",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/carbonitechamberconsole.gif",
@@ -8848,7 +10401,12 @@
       "id": 6162,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Carbonite Chamber Console (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/carbonitechamberconsole.gif",
@@ -8864,7 +10422,12 @@
       "gempId": "211_8",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Carbonite Chamber Console (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Dark/large/carbonitechamberconsole.gif",
@@ -8883,7 +10446,12 @@
       "gempId": "8_156",
       "side": "Dark",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Carida",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/carida.gif",
@@ -8914,7 +10482,12 @@
       "id": 6164,
       "side": "Dark",
       "rarity": "F",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Carida: ISB Training Academy",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/caridaisbtrainingacademy.gif",
@@ -8936,7 +10509,12 @@
       "id": 6165,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Carnor Jax, Royal Guard",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/carnorjaxroyalguard.gif",
@@ -8962,7 +10540,12 @@
       "gempId": "14_101",
       "side": "Dark",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Cease Fire!",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/ceasefire.gif",
@@ -8995,7 +10578,12 @@
       "gempId": "106_11",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Official Tournament Sealed Deck",
+      "set": "106",
+      "printings": [
+        {
+          "set": "106"
+        }
+      ],
       "front": {
         "title": "•Chall Bekan",
         "imageUrl": "https://res.starwarsccg.org/cards/OfficialTournamentSealedDeck-Dark/large/challbekan.gif",
@@ -9031,7 +10619,12 @@
       "gempId": "1_236",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Charming To The Last",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/charmingtothelast.gif",
@@ -9048,7 +10641,12 @@
       "gempId": "6_99",
       "side": "Dark",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Chevin",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/chevin.gif",
@@ -9068,7 +10666,12 @@
       "id": 6166,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "Chevin (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/chevin.gif",
@@ -9092,7 +10695,12 @@
       "gempId": "1_165",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Chief Bast",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/chiefbast.gif",
@@ -9120,7 +10728,12 @@
       "gempId": "209_34",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Chief Bast (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Dark/large/chiefbast.gif",
@@ -9144,7 +10757,12 @@
       "gempId": "5_93",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Chief Retwin",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/chiefretwin.gif",
@@ -9175,7 +10793,12 @@
       "gempId": "9_154",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Chimaera",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/chimaera.gif",
@@ -9219,7 +10842,12 @@
       "gempId": "12_99",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Chokk",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/chokk.gif",
@@ -9249,7 +10877,12 @@
       "id": 6168,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Chokk (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/chokk.gif",
@@ -9277,7 +10910,12 @@
       "gempId": "7_170",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Chyler",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/chyler.gif",
@@ -9306,7 +10944,12 @@
       "gempId": "4_138",
       "side": "Dark",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Close Call",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/closecall.gif",
@@ -9333,7 +10976,12 @@
       "id": 6169,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Close Call (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/closecall.gif",
@@ -9353,7 +11001,12 @@
       "gempId": "200_116",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Close Call (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/closecall.gif",
@@ -9381,7 +11034,12 @@
       "gempId": "8_120",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Closed Door",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/closeddoor.gif",
@@ -9408,7 +11066,12 @@
       "gempId": "5_178",
       "side": "Dark",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Cloud Car",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/cloudcar.gif",
@@ -9440,7 +11103,12 @@
       "gempId": "5_180",
       "side": "Dark",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Cloud City Blaster",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/cloudcityblaster.gif",
@@ -9466,7 +11134,12 @@
       "gempId": "5_94",
       "side": "Dark",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•••Cloud City Engineer",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/cloudcityengineer.gif",
@@ -9489,7 +11162,12 @@
       "gempId": "7_223",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Cloud City Occupation",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/cloudcityoccupation.gif",
@@ -9514,7 +11192,12 @@
       "gempId": "5_134",
       "side": "Dark",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Cloud City Sabacc",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/cloudcitysabacc.gif",
@@ -9536,7 +11219,12 @@
       "gempId": "5_95",
       "side": "Dark",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Cloud City Trooper",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/cloudcitytrooper.gif",
@@ -9568,7 +11256,12 @@
       "gempId": "5_166",
       "side": "Dark",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Cloud City: Carbonite Chamber",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/cloudcitycarbonitechamber.gif",
@@ -9596,7 +11289,12 @@
       "gempId": "7_269",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Cloud City: Casino",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/cloudcitycasino.gif",
@@ -9621,7 +11319,12 @@
       "gempId": "5_167",
       "side": "Dark",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Cloud City: Chasm Walkway",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/cloudcitychasmwalkway.gif",
@@ -9649,7 +11352,12 @@
       "gempId": "5_168",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Cloud City: Dining Room",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/cloudcitydiningroom.gif",
@@ -9672,7 +11380,12 @@
       "id": 6170,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Cloud City: Dining Room (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/cloudcitydiningroom.gif",
@@ -9694,7 +11407,12 @@
       "gempId": "7_270",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Cloud City: Downtown Plaza",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/cloudcitydowntownplaza.gif",
@@ -9722,7 +11440,12 @@
       "gempId": "5_169",
       "side": "Dark",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Cloud City: East Platform (Docking Bay)",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/cloudcityeastplatformdockingbay.gif",
@@ -9754,7 +11477,12 @@
       "gempId": "5_170",
       "side": "Dark",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Cloud City: Incinerator",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/cloudcityincinerator.gif",
@@ -9782,7 +11510,12 @@
       "gempId": "7_271",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Cloud City: Interrogation Room",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/cloudcityinterrogationroom.gif",
@@ -9809,7 +11542,12 @@
       "gempId": "5_171",
       "side": "Dark",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Cloud City: Lower Corridor",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/cloudcitylowercorridor.gif",
@@ -9837,7 +11575,12 @@
       "gempId": "7_272",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Cloud City: Port Town District",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/cloudcityporttowndistrict.gif",
@@ -9861,7 +11604,12 @@
       "gempId": "5_172",
       "side": "Dark",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Cloud City: Security Tower",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/cloudcitysecuritytower.gif",
@@ -9894,7 +11642,12 @@
       "id": 6171,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Cloud City: Security Tower (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/cloudcitysecuritytower.gif",
@@ -9915,7 +11668,12 @@
       "gempId": "200_126",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Cloud City: Security Tower (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/cloudcitysecuritytower.gif",
@@ -9946,7 +11704,12 @@
       "gempId": "5_173",
       "side": "Dark",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Cloud City: Upper Plaza Corridor",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/cloudcityupperplazacorridor.gif",
@@ -9974,7 +11737,12 @@
       "gempId": "7_273",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Cloud City: Upper Walkway",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/cloudcityupperwalkway.gif",
@@ -9998,7 +11766,12 @@
       "gempId": "7_274",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Cloud City: West Gallery",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/cloudcitywestgallery.gif",
@@ -10026,7 +11799,12 @@
       "gempId": "5_174",
       "side": "Dark",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "<><><>Clouds",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/clouds.gif",
@@ -10052,7 +11830,12 @@
       "gempId": "3_117",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Cold Feet",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/coldfeet.gif",
@@ -10068,7 +11851,12 @@
       "id": 6172,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "Cold Feet (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/coldfeet.gif",
@@ -10088,7 +11876,12 @@
       "gempId": "201_35",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "Cold Feet (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Dark/large/coldfeet.gif",
@@ -10113,7 +11906,12 @@
       "gempId": "3_118",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Collapsing Corridor",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/collapsingcorridor.gif",
@@ -10131,7 +11929,12 @@
       "gempId": "1_237",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Collateral Damage",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/collateraldamage.gif",
@@ -10148,7 +11951,12 @@
       "id": 6173,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Collateral Damage (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/collateraldamage.gif",
@@ -10165,7 +11973,12 @@
       "gempId": "13_60",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Colo Claw Fish",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/coloclawfish.gif",
@@ -10198,7 +12011,12 @@
       "gempId": "9_104",
       "side": "Dark",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Colonel Davod Jon",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/coloneldavodjon.gif",
@@ -10230,7 +12048,12 @@
       "gempId": "8_93",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Colonel Dyer",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/coloneldyer.gif",
@@ -10268,7 +12091,12 @@
       "gempId": "9_105",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Colonel Jendon",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/coloneljendon.gif",
@@ -10296,7 +12124,12 @@
       "id": 6174,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Colonel Jendon in Onyx 1",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/coloneljendoninonyx1.gif",
@@ -10324,7 +12157,12 @@
       "gempId": "200_132",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Colonel Jendon in Onyx 1",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/coloneljendoninonyx1.gif",
@@ -10369,7 +12207,12 @@
       "gempId": "1_166",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Colonel Wullf Yularen",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/colonelwullfyularen.gif",
@@ -10400,7 +12243,12 @@
       "id": 6175,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Colonel Wullf Yularen (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/colonelwullfyularen.gif",
@@ -10424,7 +12272,12 @@
       "gempId": "201_22",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Colonel Wullf Yularen (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Dark/large/colonelwullfyularen.gif",
@@ -10454,7 +12307,12 @@
       "gempId": "7_311",
       "side": "Dark",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•••Combat Cloud Car",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/combatcloudcar.gif",
@@ -10486,7 +12344,12 @@
       "gempId": "8_136",
       "side": "Dark",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Combat Readiness",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/combatreadiness.gif",
@@ -10504,7 +12367,12 @@
       "id": 6176,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Combat Readiness (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/combatreadiness.gif",
@@ -10525,7 +12393,12 @@
       "gempId": "200_117",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Combat Readiness (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/combatreadiness.gif",
@@ -10548,7 +12421,12 @@
       "gempId": "9_121",
       "side": "Dark",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Combat Response",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/combatresponse.gif",
@@ -10572,7 +12450,12 @@
       "id": 6177,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Combat Response (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/combatresponse.gif",
@@ -10591,7 +12474,12 @@
       "gempId": "200_105",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Combat Response (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/combatresponse.gif",
@@ -10622,7 +12510,12 @@
       "gempId": "13_61",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Come Here You Big Coward",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/comehereyoubigcoward.gif",
@@ -10647,7 +12540,12 @@
       "gempId": "7_224",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Come Here You Big Coward",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/comehereyoubigcoward.gif",
@@ -10663,7 +12561,12 @@
       "gempId": "2_118",
       "side": "Dark",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Come With Me",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/comewithme.gif",
@@ -10683,7 +12586,12 @@
       "id": 6179,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Come With Me (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/comewithme.gif",
@@ -10702,7 +12610,12 @@
       "gempId": "1_201",
       "side": "Dark",
       "rarity": "C1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Comlink",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/comlink.gif",
@@ -10721,7 +12634,12 @@
       "id": 6180,
       "side": "Dark",
       "rarity": "C1",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "Comlink (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/comlink.gif",
@@ -10737,7 +12655,12 @@
       "gempId": "4_94",
       "side": "Dark",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•••Comm Chief",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/commchief.gif",
@@ -10762,7 +12685,12 @@
       "gempId": "4_95",
       "side": "Dark",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Commander Brandei",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/commanderbrandei.gif",
@@ -10839,7 +12767,12 @@
       "gempId": "210_30",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•Commander Brandei (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Dark/large/commanderbrandei.gif",
@@ -10865,7 +12798,12 @@
       "id": 6182,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Commander Daine Jir",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/commanderdainejir.gif",
@@ -10893,7 +12831,12 @@
       "gempId": "5_96",
       "side": "Dark",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Commander Desanne",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/commanderdesanne.gif",
@@ -10931,7 +12874,12 @@
       "gempId": "4_96",
       "side": "Dark",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Commander Gherant",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/commandergherant.gif",
@@ -10971,7 +12919,12 @@
       "gempId": "8_94",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Commander Igar",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/commanderigar.gif",
@@ -11016,7 +12969,12 @@
       "id": 6183,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Commander Igar (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/commanderigar.gif",
@@ -11045,7 +13003,12 @@
       "gempId": "9_106",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Commander Merrejk",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/commandermerrejk.gif",
@@ -11110,7 +13073,12 @@
       "gempId": "4_97",
       "side": "Dark",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Commander Nemet",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/commandernemet.gif",
@@ -11140,7 +13108,12 @@
       "id": 6184,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Commander Nemet (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/commandernemet.gif",
@@ -11168,7 +13141,12 @@
       "gempId": "203_25",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•Commander Nemet (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Dark/large/commandernemet.gif",
@@ -11221,7 +13199,12 @@
       "gempId": "1_167",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Commander Praji",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/commanderpraji.gif",
@@ -11259,7 +13242,12 @@
       "id": 6185,
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Commander Praji (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/commanderpraji.gif",
@@ -11284,7 +13272,12 @@
       "gempId": "2_130",
       "side": "Dark",
       "rarity": "R2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Commence Primary Ignition",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/commenceprimaryignition.gif",
@@ -11304,7 +13297,12 @@
       "id": 6186,
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Commence Primary Ignition (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/commenceprimaryignition.gif",
@@ -11322,7 +13320,12 @@
       "gempId": "209_45",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Commence Primary Ignition (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Dark/large/commenceprimaryignition.gif",
@@ -11340,7 +13343,12 @@
       "gempId": "8_137",
       "side": "Dark",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Compact Firepower",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/compactfirepower.gif",
@@ -11361,7 +13369,12 @@
       "gempId": "3_119",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "ComScan Detection",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/comscandetection.gif",
@@ -11377,7 +13390,12 @@
       "id": 6188,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "ComScan Detection (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/comscandetection.gif",
@@ -11397,7 +13415,12 @@
       "gempId": "9_177",
       "side": "Dark",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "Concussion Missiles",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/concussionmissiles.gif",
@@ -11421,7 +13444,12 @@
       "id": 6189,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "Concussion Missiles (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/concussionmissiles.gif",
@@ -11441,7 +13469,12 @@
       "gempId": "13_62",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Conduct Your Search",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/conductyoursearch.gif",
@@ -11469,7 +13502,12 @@
       "gempId": "2_152",
       "side": "Dark",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Conquest",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/conquest.gif",
@@ -11507,7 +13545,12 @@
       "id": 6190,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Conquest (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/conquest.gif",
@@ -11535,7 +13578,12 @@
       "gempId": "200_133",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Conquest (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/conquest.gif",
@@ -11574,7 +13622,12 @@
       "id": 6191,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "Contract Killers / Feared Throughout The Galaxy",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/contractkillers.gif",
@@ -11602,7 +13655,12 @@
       "gempId": "12_146",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Control",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/control.gif",
@@ -11638,7 +13696,12 @@
       "gempId": "4_139",
       "side": "Dark",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Control",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/control.gif",
@@ -11670,7 +13733,12 @@
       "gempId": "10_34",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "Control & Set For Stun",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Dark/large/control&setforstun.gif",
@@ -11706,7 +13774,12 @@
       "gempId": "7_248",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Coordinated Attack",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/coordinatedattack.gif",
@@ -11727,7 +13800,12 @@
       "id": 6192,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Coordinated Attack (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/coordinatedattack.gif",
@@ -11747,7 +13825,12 @@
       "gempId": "8_95",
       "side": "Dark",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Corporal Avarik",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/corporalavarik.gif",
@@ -11783,7 +13866,12 @@
       "gempId": "4_98",
       "side": "Dark",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Corporal Derdram",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/corporalderdram.gif",
@@ -11820,7 +13908,12 @@
       "id": 6193,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Corporal Derdram (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/corporalderdram.gif",
@@ -11846,7 +13939,12 @@
       "gempId": "8_96",
       "side": "Dark",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Corporal Drazin",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/corporaldrazin.gif",
@@ -11881,7 +13979,12 @@
       "gempId": "8_97",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Corporal Drelosyn",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/corporaldrelosyn.gif",
@@ -11917,7 +14020,12 @@
       "gempId": "7_171",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Corporal Grenwick",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/corporalgrenwick.gif",
@@ -11949,7 +14057,12 @@
       "gempId": "8_98",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Corporal Misik",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/corporalmisik.gif",
@@ -11985,7 +14098,12 @@
       "gempId": "8_99",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Corporal Oberk",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/corporaloberk.gif",
@@ -12022,7 +14140,12 @@
       "gempId": "7_172",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Corporal Prescott",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/corporalprescott.gif",
@@ -12057,7 +14180,12 @@
       "gempId": "4_99",
       "side": "Dark",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Corporal Vandolay",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/corporalvandolay.gif",
@@ -12091,7 +14219,12 @@
       "id": 6194,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Corporal Vandolay (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/corporalvandolay.gif",
@@ -12117,7 +14250,12 @@
       "gempId": "201_23",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Corporal Vandolay (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Dark/large/corporalvandolay.gif",
@@ -12149,7 +14287,12 @@
       "gempId": "4_119",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "<>Corrosive Damage",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/corrosivedamage.gif",
@@ -12173,7 +14316,12 @@
       "gempId": "106_12",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Official Tournament Sealed Deck",
+      "set": "106",
+      "printings": [
+        {
+          "set": "106"
+        }
+      ],
       "front": {
         "title": "•Corulag",
         "imageUrl": "https://res.starwarsccg.org/cards/OfficialTournamentSealedDeck-Dark/large/corulag.gif",
@@ -12202,7 +14350,12 @@
       "gempId": "7_173",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Corulag Operative",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/corulagoperative.gif",
@@ -12231,7 +14384,12 @@
       "id": 6195,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Corulag: ISB Logistics Office",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/corulagisblogisticsoffice.gif",
@@ -12252,7 +14410,12 @@
       "gempId": "12_165",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Coruscant",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/coruscant.gif",
@@ -12281,7 +14444,12 @@
       "gempId": "7_275",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Coruscant",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/coruscant.gif",
@@ -12305,7 +14473,12 @@
       "gempId": "203_31",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•Coruscant (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Dark/large/coruscant.gif",
@@ -12329,7 +14502,12 @@
       "gempId": "12_100",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Coruscant Guard",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/coruscantguard.gif",
@@ -12363,7 +14541,12 @@
       "id": 6196,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "Coruscant Guard (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/coruscantguard.gif",
@@ -12389,7 +14572,12 @@
       "gempId": "211_17",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Coruscant: 500 Republica",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Dark/large/coruscant500republica.gif",
@@ -12412,7 +14600,12 @@
       "id": 6198,
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Coruscant: Casino",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/coruscantcasino.gif",
@@ -12431,7 +14624,12 @@
       "id": 6199,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Coruscant: Chancellor's Office",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/coruscantchancellorsoffice.gif",
@@ -12453,7 +14651,12 @@
       "gempId": "12_166",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Coruscant: Docking Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/coruscantdockingbay.gif",
@@ -12485,7 +14688,12 @@
       "gempId": "7_276",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Coruscant: Docking Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/coruscantdockingbay.gif",
@@ -12516,7 +14724,12 @@
       "gempId": "12_167",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Coruscant: Galactic Senate",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/coruscantgalacticsenate.gif",
@@ -12541,7 +14754,12 @@
       "gempId": "7_277",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Coruscant: Imperial City",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/coruscantimperialcity.gif",
@@ -12565,7 +14783,12 @@
       "gempId": "201_38",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Coruscant: Imperial City (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Dark/large/coruscantimperialcity.gif",
@@ -12593,7 +14816,12 @@
       "gempId": "7_278",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Coruscant: Imperial Square",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/coruscantimperialsquare.gif",
@@ -12619,7 +14847,12 @@
       "id": 6200,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Coruscant: ISB Central Office",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/coruscantisbcentraloffice.gif",
@@ -12639,7 +14872,12 @@
       "id": 6201,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Coruscant: Palpatine's Quarters",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/coruscantpalpatinesquarters.gif",
@@ -12659,7 +14897,12 @@
       "id": 6202,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Coruscant: Private Platform (Docking Bay)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/coruscantprivateplatformdockingbay.gif",
@@ -12681,7 +14924,12 @@
       "gempId": "211_18",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Coruscant: Private Platform (Docking Bay)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Dark/large/coruscantprivateplatform.gif",
@@ -12704,7 +14952,12 @@
       "id": 6204,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Coruscant: Sub City Lair",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/coruscantsubcitylair.gif",
@@ -12725,7 +14978,12 @@
       "gempId": "203_32",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•Coruscant: Xizor's Palace",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Dark/large/coruscantxizorspalace.gif",
@@ -12756,7 +15014,12 @@
       "id": 6205,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Count Dooku",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/countdooku.gif",
@@ -12786,7 +15049,12 @@
       "gempId": "200_76",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Count Dooku",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/countdooku.gif",
@@ -12831,7 +15099,12 @@
       "gempId": "1_238",
       "side": "Dark",
       "rarity": "C1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Counter Assault",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/counterassault.gif",
@@ -12863,7 +15136,12 @@
       "gempId": "7_249",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Counter Surprise Assault",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/countersurpriseassault.gif",
@@ -12887,7 +15165,12 @@
       "gempId": "8_138",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Counterattack",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/counterattack.gif",
@@ -12906,7 +15189,12 @@
       "gempId": "110_6",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Enhanced Jabba's Palace",
+      "set": "110",
+      "printings": [
+        {
+          "set": "110"
+        }
+      ],
       "front": {
         "title": "Court Of The Vile Gangster / I Shall Enjoy Watching You Die",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedJabbasPalace-Dark/large/courtofthevilegangster.gif",
@@ -12928,7 +15216,12 @@
       "gempId": "3_120",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Crash Landing",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/crashlanding.gif",
@@ -12945,7 +15238,12 @@
       "gempId": "8_121",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Crossfire",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/crossfire.gif",
@@ -12968,7 +15266,12 @@
       "gempId": "13_63",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Crossfire",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/crossfire.gif",
@@ -12987,7 +15290,12 @@
       "id": 6207,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Crossfire (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/crossfire.gif",
@@ -13006,7 +15314,12 @@
       "gempId": "109_9",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Enhanced Cloud City",
+      "set": "109",
+      "printings": [
+        {
+          "set": "109"
+        }
+      ],
       "front": {
         "title": "•Crush The Rebellion",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedCloudCity-Dark/large/crushtherebellion.gif",
@@ -13034,7 +15347,12 @@
       "id": 6208,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Crush The Rebellion (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/crushtherebellion.gif",
@@ -13053,7 +15371,12 @@
       "id": 6209,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Cyclone 1",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/cyclone1.gif",
@@ -13079,7 +15402,12 @@
       "id": 6210,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "Cyclone Walker",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/cyclonewalker.gif",
@@ -13106,7 +15434,12 @@
       "gempId": "6_100",
       "side": "Dark",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "CZ-4",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/cz4.gif",
@@ -13132,7 +15465,12 @@
       "gempId": "7_279",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Dagobah",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/dagobah.gif",
@@ -13156,7 +15494,12 @@
       "gempId": "4_158",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Dagobah: Cave",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/dagobahcave.gif",
@@ -13183,7 +15526,12 @@
       "gempId": "2_84",
       "side": "Dark",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Dannik Jerriko",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/dannikjerriko.gif",
@@ -13210,7 +15558,12 @@
       "id": 6211,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Dannik Jerriko (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/dannikjerriko.gif",
@@ -13237,7 +15590,12 @@
       "gempId": "1_282",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Dantooine",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/dantooine.gif",
@@ -13265,7 +15623,12 @@
       "gempId": "7_174",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Dantooine Operative",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/dantooineoperative.gif",
@@ -13295,7 +15658,12 @@
       "gempId": "2_85",
       "side": "Dark",
       "rarity": "U2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Danz Borin",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/danzborin.gif",
@@ -13328,7 +15696,12 @@
       "id": 6212,
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Danz Borin (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/danzborin.gif",
@@ -13354,7 +15727,12 @@
       "gempId": "1_239",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Dark Collaboration",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/darkcollaboration.gif",
@@ -13378,7 +15756,12 @@
       "id": 6213,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Dark Collaboration (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/darkcollaboration.gif",
@@ -13395,7 +15778,12 @@
       "gempId": "5_115",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Dark Deal",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/darkdeal.gif",
@@ -13422,7 +15810,12 @@
       "gempId": "102_6",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Jedi Pack",
+      "set": "102",
+      "printings": [
+        {
+          "set": "102"
+        }
+      ],
       "front": {
         "title": "•Dark Forces",
         "imageUrl": "https://res.starwarsccg.org/cards/JediPack-Dark/large/darkforces.gif",
@@ -13444,7 +15837,12 @@
       "id": 6214,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Dark Forces (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/darkforces.gif",
@@ -13463,7 +15861,12 @@
       "gempId": "1_212",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•••Dark Hours",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/darkhours.gif",
@@ -13484,7 +15887,12 @@
       "gempId": "1_314",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Dark Jedi Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/darkjedilightsaber.gif",
@@ -13511,7 +15919,12 @@
       "id": 6215,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "Dark Jedi Lightsaber (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/darkjedilightsaber.gif",
@@ -13528,7 +15941,12 @@
       "gempId": "211_25",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "Dark Jedi Lightsaber (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Dark/large/darkjedilightsaber.gif",
@@ -13545,7 +15963,12 @@
       "gempId": "1_240",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Dark Jedi Presence",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/darkjedipresence.gif",
@@ -13567,7 +15990,12 @@
       "gempId": "1_241",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Dark Maneuvers",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/darkmaneuvers.gif",
@@ -13592,7 +16020,12 @@
       "gempId": "10_35",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "Dark Maneuvers & Tallon Roll",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Dark/large/darkmaneuvers&tallonroll.gif",
@@ -13613,7 +16046,12 @@
       "gempId": "13_64",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Dark Rage",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/darkrage.gif",
@@ -13639,7 +16077,12 @@
       "id": 6217,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Dark Reconnaissance",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/darkreconnaissance.gif",
@@ -13659,7 +16102,12 @@
       "gempId": "5_135",
       "side": "Dark",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Dark Strike",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/darkstrike.gif",
@@ -13685,7 +16133,12 @@
       "gempId": "2_119",
       "side": "Dark",
       "rarity": "R2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Dark Waters",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/darkwaters.gif",
@@ -13705,7 +16158,12 @@
       "id": 6218,
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Dark Waters & •Krayt Dragon Bones",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/darkwaters&kraytdragonbones.gif",
@@ -13723,7 +16181,12 @@
       "gempId": "11_53",
       "side": "Dark",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Daroe",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/daroe.gif",
@@ -13755,7 +16218,12 @@
       "gempId": "202_9",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 2",
+      "set": "202",
+      "printings": [
+        {
+          "set": "202"
+        }
+      ],
       "front": {
         "title": "•Daroe (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual2-Dark/large/daroe.gif",
@@ -13794,7 +16262,12 @@
       "gempId": "11_54",
       "side": "Dark",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Darth Maul",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/darthmaul.gif",
@@ -13841,7 +16314,12 @@
       "gempId": "11_55",
       "side": "Dark",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Darth Maul (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/darthmaulai.gif",
@@ -13870,7 +16348,12 @@
       "gempId": "14_77",
       "side": "Dark",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Darth Maul With Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/darthmaulwithlightsaber.gif",
@@ -13921,7 +16404,12 @@
       "id": 6220,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Darth Maul With Lightsaber (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/darthmaulwithlightsaber.gif",
@@ -13952,7 +16440,12 @@
       "gempId": "203_26",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•Darth Maul, Lone Hunter",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Dark/large/darthmaullonehunter.gif",
@@ -14006,7 +16499,12 @@
       "gempId": "12_101",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Darth Maul, Young Apprentice",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/darthmaulyoungapprentice.gif",
@@ -14052,7 +16550,12 @@
       "gempId": "12_102",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Darth Maul, Young Apprentice (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/darthmaulyoungapprenticeai.gif",
@@ -14081,7 +16584,12 @@
       "gempId": "14_78",
       "side": "Dark",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Darth Sidious",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/darthsidious.gif",
@@ -14120,7 +16628,12 @@
       "gempId": "14_79",
       "side": "Dark",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Darth Sidious (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/darthsidiousai.gif",
@@ -14148,7 +16661,12 @@
       "gempId": "1_168",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Darth Vader",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/darthvader.gif",
@@ -14197,7 +16715,12 @@
       "id": 6223,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Darth Vader (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/darthvader.gif",
@@ -14225,7 +16748,12 @@
       "gempId": "200_78",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Darth Vader (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/darthvader.gif",
@@ -14274,7 +16802,12 @@
       "gempId": "108_6",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Enhanced Premiere",
+      "set": "108",
+      "printings": [
+        {
+          "set": "108"
+        }
+      ],
       "front": {
         "title": "•Darth Vader With Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedPremiere-Dark/large/darthvaderwithlightsaber.gif",
@@ -14323,7 +16856,12 @@
       "id": 6224,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Darth Vader, Betrayer Of The Jedi",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/darthvaderbetrayerofthejedi.gif",
@@ -14352,7 +16890,12 @@
       "gempId": "7_175",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Darth Vader, Dark Lord Of The Sith",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/darthvaderdarklordofthesith.gif",
@@ -14401,7 +16944,12 @@
       "gempId": "208_30",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Darth Vader, Emperor's Enforcer",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/darthvaderemperorsenforcer.gif",
@@ -14449,7 +16997,12 @@
       "id": 6225,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Darth Vader, More Machine Than Man",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/darthvadermoremachinethanman.gif",
@@ -14478,7 +17031,12 @@
       "gempId": "9_178",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Darth Vader's Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/darthvaderslightsaber.gif",
@@ -14513,7 +17071,12 @@
       "id": 6226,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Darth Vader's Lightsaber (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/darthvaderslightsaber.gif",
@@ -14533,7 +17096,12 @@
       "gempId": "208_59",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Darth Vader's Lightsaber (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/darthvaderslightsaber.gif",
@@ -14569,7 +17137,12 @@
       "gempId": "1_169",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Dathcha",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/dathcha.gif",
@@ -14600,7 +17173,12 @@
       "gempId": "205_11",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Set 5",
+      "set": "205",
+      "printings": [
+        {
+          "set": "205"
+        }
+      ],
       "front": {
         "title": "•Dathcha (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual5-Dark/large/dathcha.gif",
@@ -14631,7 +17209,12 @@
       "id": 6227,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•••Dathomir Witch",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/dathomirwitch.gif",
@@ -14659,7 +17242,12 @@
       "gempId": "12_103",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Daultay Dofine",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/daultaydofine.gif",
@@ -14699,7 +17287,12 @@
       "id": 6228,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Daultay Dofine (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/daultaydofine.gif",
@@ -14728,7 +17321,12 @@
       "gempId": "8_139",
       "side": "Dark",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Dead Ewok",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/deadewok.gif",
@@ -14748,7 +17346,12 @@
       "id": 6229,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Dead Ewok (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/deadewok.gif",
@@ -14768,7 +17371,12 @@
       "gempId": "1_242",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Dead Jawa",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/deadjawa.gif",
@@ -14788,7 +17396,12 @@
       "gempId": "3_99",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Death Mark",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/deathmark.gif",
@@ -14816,7 +17429,12 @@
       "id": 6230,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Death Mark & •Hutt Bounty",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/deathmarkandhuttbounty.gif",
@@ -14833,7 +17451,12 @@
       "gempId": "3_100",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Death Squadron",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/deathsquadron.gif",
@@ -14857,7 +17480,12 @@
       "gempId": "209_47",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Death Squadron Assignment",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Dark/large/deathsquadronassignment.gif",
@@ -14874,7 +17502,12 @@
       "gempId": "7_302",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•••Death Squadron Star Destroyer",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/deathsquadronstardestroyer.gif",
@@ -14913,7 +17546,12 @@
       "gempId": "2_143",
       "side": "Dark",
       "rarity": "R2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Death Star",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/deathstar.gif",
@@ -14939,7 +17577,15 @@
       "gempId": "7_303",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "105"
+        },
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Death Star Assault Squadron",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/deathstarassaultsquadron.gif",
@@ -14974,7 +17620,12 @@
       "gempId": "2_86",
       "side": "Dark",
       "rarity": "C1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•••Death Star Gunner",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/deathstargunner.gif",
@@ -15005,7 +17656,12 @@
       "id": 6232,
       "side": "Dark",
       "rarity": "C1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•••Death Star Gunner (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/deathstargunner.gif",
@@ -15029,7 +17685,12 @@
       "gempId": "9_142",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Death Star II",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/deathstarii.gif",
@@ -15051,7 +17712,12 @@
       "gempId": "9_143",
       "side": "Dark",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Death Star II: Capacitors",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/deathstariicapacitors.gif",
@@ -15076,7 +17742,12 @@
       "gempId": "9_144",
       "side": "Dark",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Death Star II: Coolant Shaft",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/deathstariicoolantshaft.gif",
@@ -15101,7 +17772,12 @@
       "gempId": "9_145",
       "side": "Dark",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Death Star II: Docking Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/deathstariidockingbay.gif",
@@ -15135,7 +17811,12 @@
       "gempId": "9_146",
       "side": "Dark",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Death Star II: Reactor Core",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/deathstariireactorcore.gif",
@@ -15163,7 +17844,12 @@
       "gempId": "9_147",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Death Star II: Throne Room",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/deathstariithroneroom.gif",
@@ -15190,7 +17876,12 @@
       "gempId": "210_43",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•Death Star Reactor Terminal",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Dark/large/deathstarreactorterminal.gif",
@@ -15206,7 +17897,12 @@
       "gempId": "1_213",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Death Star Sentry",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/deathstarsentry.gif",
@@ -15227,7 +17923,12 @@
       "id": 6234,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•Death Star Sentry (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Dark/large/deathstarsentry.gif",
@@ -15246,7 +17947,12 @@
       "gempId": "200_94",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Set 0",
+      "set": "200d",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Death Star Sentry (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/ResetDS-Dark/large/deathstarsentry.gif",
@@ -15270,7 +17976,12 @@
       "gempId": "2_111",
       "side": "Dark",
       "rarity": "R2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Death Star Tractor Beam",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/deathstartractorbeam.gif",
@@ -15293,7 +18004,12 @@
       "gempId": "1_170",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Death Star Trooper",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/deathstartrooper.gif",
@@ -15325,7 +18041,12 @@
       "gempId": "1_283",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Death Star: Central Core",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/deathstarcentralcore.gif",
@@ -15354,7 +18075,12 @@
       "id": 6235,
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Death Star: Central Core (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/deathstarcentralcore.gif",
@@ -15375,7 +18101,12 @@
       "gempId": "2_144",
       "side": "Dark",
       "rarity": "U1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Death Star: Conference Room",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/deathstarconferenceroom.gif",
@@ -15401,7 +18132,12 @@
       "id": 6236,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Death Star: Conference Room (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/deathstarconferenceroom.gif",
@@ -15423,7 +18159,12 @@
       "gempId": "7_280",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Death Star: Detention Block Control Room",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/deathstardetentionblockcontrolroom.gif",
@@ -15454,7 +18195,12 @@
       "gempId": "1_284",
       "side": "Dark",
       "rarity": "C1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Death Star: Detention Block Corridor",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/deathstardetentionblockcorridor.gif",
@@ -15491,7 +18237,12 @@
       "gempId": "1_285",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Death Star: Docking Bay 327",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/deathstardockingbay327.gif",
@@ -15525,7 +18276,12 @@
       "gempId": "101_4",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Premiere Introductory Two Player Game",
+      "set": "101",
+      "printings": [
+        {
+          "set": "101"
+        }
+      ],
       "front": {
         "title": "•Death Star: Docking Control Room 327",
         "imageUrl": "https://res.starwarsccg.org/cards/PremiereIntroductoryTwoPlayerGame-Dark/large/deathstardockingcontrolroom327.gif",
@@ -15572,7 +18328,12 @@
       "gempId": "1_286",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Death Star: Level 4 Military Corridor",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/deathstarlevel4militarycorridor.gif",
@@ -15599,7 +18360,12 @@
       "gempId": "1_287",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Death Star: War Room",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/deathstarwarroom.gif",
@@ -15625,7 +18391,12 @@
       "id": 6237,
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Death Star: War Room (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/deathstarwarroom.gif",
@@ -15646,7 +18417,12 @@
       "gempId": "208_48",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Death Star: War Room (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/deathstarwarroom.gif",
@@ -15673,7 +18449,12 @@
       "gempId": "206_10",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 6",
+      "set": "206",
+      "printings": [
+        {
+          "set": "206"
+        }
+      ],
       "front": {
         "title": "•••Death Trooper (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual6-Dark/large/deathtrooper.gif",
@@ -15698,7 +18479,12 @@
       "gempId": "3_121",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Debris Zone",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/debriszone.gif",
@@ -15714,7 +18500,12 @@
       "id": 6239,
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Debris Zone (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/debriszone.gif",
@@ -15734,7 +18525,12 @@
       "gempId": "13_65",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "Deep Hatred",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/deephatred.gif",
@@ -15755,7 +18551,12 @@
       "id": 6240,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "Deep Hatred (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/deephatred.gif",
@@ -15775,7 +18576,12 @@
       "gempId": "2_87",
       "side": "Dark",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•••Defel",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/defel.gif",
@@ -15799,7 +18605,12 @@
       "id": 6241,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Defense of Muunilinst",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/defenseofmuunilinst.gif",
@@ -15818,7 +18629,12 @@
       "gempId": "4_140",
       "side": "Dark",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Defensive Fire",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/defensivefire.gif",
@@ -15846,7 +18662,12 @@
       "gempId": "10_36",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Defensive Fire & •Hutt Smooch",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Dark/large/defensivefire&huttsmooch.gif",
@@ -15865,7 +18686,12 @@
       "id": 6242,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Defensive Fire (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/defensivefire.gif",
@@ -15885,7 +18711,12 @@
       "gempId": "200_118",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Defensive Fire (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/defensivefire.gif",
@@ -15910,7 +18741,12 @@
       "gempId": "3_94",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Deflector Shield Generators",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/deflectorshieldgenerators.gif",
@@ -15929,7 +18765,12 @@
       "id": 6243,
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Deflector Shield Generators (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/deflectorshieldgenerators.gif",
@@ -15948,7 +18789,12 @@
       "gempId": "203_29",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "Deflector Shield Generators (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Dark/large/deflectorshieldgenerators.gif",
@@ -15967,7 +18813,12 @@
       "gempId": "6_143",
       "side": "Dark",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Den Of Thieves",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/denofthieves.gif",
@@ -15988,7 +18839,12 @@
       "id": 6244,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Den Of Thieves & •Special Delivery",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/denofthieves&specialdelivery.gif",
@@ -16003,7 +18859,12 @@
       "id": 6245,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Den Of Thieves (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/denofthieves.gif",
@@ -16022,7 +18883,12 @@
       "gempId": "4_100",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Dengar",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/dengar.gif",
@@ -16068,7 +18934,12 @@
       "id": 6246,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Dengar (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/dengar.gif",
@@ -16094,7 +18965,12 @@
       "gempId": "205_23",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 5",
+      "set": "205",
+      "printings": [
+        {
+          "set": "205"
+        }
+      ],
       "front": {
         "title": "•Dengar (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual5-Dark/large/dengar.gif",
@@ -16141,7 +19017,12 @@
       "gempId": "109_10",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Enhanced Cloud City",
+      "set": "109",
+      "printings": [
+        {
+          "set": "109"
+        }
+      ],
       "front": {
         "title": "•Dengar In Punishing One",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedCloudCity-Dark/large/dengarinpunishingone.gif",
@@ -16180,7 +19061,12 @@
       "gempId": "110_7",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Enhanced Jabba's Palace",
+      "set": "110",
+      "printings": [
+        {
+          "set": "110"
+        }
+      ],
       "front": {
         "title": "•Dengar With Blaster Carbine",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedJabbasPalace-Dark/large/dengarwithblastercarbine.gif",
@@ -16220,7 +19106,12 @@
       "id": 6247,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Dengar With Blaster Carbine (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/dengarwithblastercarbine.gif",
@@ -16247,7 +19138,12 @@
       "gempId": "200_79",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Dengar With Blaster Carbine (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/dengarwithblastercarbine.gif",
@@ -16289,7 +19185,12 @@
       "gempId": "4_176",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Dengar's Blaster Carbine",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/dengarsblastercarbine.gif",
@@ -16319,7 +19220,12 @@
       "gempId": "6_175",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Dengar's Modified Riot Gun",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/dengarsmodifiedriotgun.gif",
@@ -16343,7 +19249,12 @@
       "id": 6248,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Deployment Orders",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/deploymentorders.gif",
@@ -16363,7 +19274,12 @@
       "gempId": "7_281",
       "side": "Dark",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "<>Desert",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/desert.gif",
@@ -16387,7 +19303,12 @@
       "gempId": "7_225",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Desilijic Tattoo",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/desilijictattoo.gif",
@@ -16412,7 +19333,12 @@
       "id": 6249,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Desilijic Tattoo (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/desilijictattoo.gif",
@@ -16431,7 +19357,12 @@
       "gempId": "5_116",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Despair",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/despair.gif",
@@ -16457,7 +19388,12 @@
       "id": 6250,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Despair (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/despair.gif",
@@ -16476,7 +19412,12 @@
       "gempId": "201_28",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Despair (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Dark/large/despair.gif",
@@ -16496,7 +19437,12 @@
       "gempId": "9_122",
       "side": "Dark",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Desperate Counter",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/desperatecounter.gif",
@@ -16523,7 +19469,12 @@
       "id": 6251,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Desperate Counter (v)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/desperatecounter.gif",
@@ -16543,7 +19494,12 @@
       "gempId": "7_226",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Destroyed Homestead",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/destroyedhomestead.gif",
@@ -16565,7 +19521,12 @@
       "gempId": "12_104",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Destroyer Droid",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/destroyerdroid.gif",
@@ -16608,7 +19569,12 @@
       "gempId": "1_301",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Devastator",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/devastator.gif",
@@ -16649,7 +19615,12 @@
       "id": 6252,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Devastator (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/devastator.gif",
@@ -16677,7 +19648,12 @@
       "gempId": "7_312",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Dewback",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/dewback.gif",
@@ -16698,7 +19674,12 @@
       "id": 6253,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Dewback (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/dewback.gif",
@@ -16723,7 +19704,12 @@
       "gempId": "14_115",
       "side": "Dark",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•••DFS Squadron Starfighter",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/dfssquadronstarfighter.gif",
@@ -16764,7 +19750,12 @@
       "gempId": "14_116",
       "side": "Dark",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•DFS-1015",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/dfs1015.gif",
@@ -16798,7 +19789,12 @@
       "gempId": "14_117",
       "side": "Dark",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•DFS-1308",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/dfs1308.gif",
@@ -16832,7 +19828,12 @@
       "gempId": "14_118",
       "side": "Dark",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•DFS-327",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/dfs327.gif",
@@ -16866,7 +19867,12 @@
       "gempId": "2_110",
       "side": "Dark",
       "rarity": "R2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Dianoga",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/dianoga.gif",
@@ -16891,7 +19897,12 @@
       "id": 6254,
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Dianoga (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/dianoga.gif",
@@ -16917,7 +19928,12 @@
       "gempId": "12_147",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Dioxis",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/dioxis.gif",
@@ -16941,7 +19957,12 @@
       "gempId": "3_122",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Direct Hit",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/directhit.gif",
@@ -16959,7 +19980,12 @@
       "gempId": "207_20",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 7",
+      "set": "207",
+      "printings": [
+        {
+          "set": "207"
+        }
+      ],
       "front": {
         "title": "•Director Orson Krennic",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual7-Dark/large/directororsonkrennic.gif",
@@ -16994,7 +20020,12 @@
       "gempId": "1_214",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Disarmed",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/disarmed.gif",
@@ -17018,7 +20049,12 @@
       "gempId": "7_319",
       "side": "Dark",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Disruptor Pistol",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/disruptorpistol.gif",
@@ -17041,7 +20077,12 @@
       "gempId": "1_171",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Djas Puhr",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/djaspuhr.gif",
@@ -17078,7 +20119,12 @@
       "id": 6255,
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Djas Puhr (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/djaspuhr.gif",
@@ -17105,7 +20151,12 @@
       "gempId": "201_24",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Djas Puhr (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Dark/large/djaspuhr.gif",
@@ -17140,7 +20191,12 @@
       "gempId": "12_131",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Do They Have A Code Clearance?",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/dotheyhaveacodeclearance.gif",
@@ -17164,7 +20220,12 @@
       "gempId": "13_66",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Do They Have A Code Clearance?",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/dotheyhaveacodeclearance.gif",
@@ -17184,7 +20245,12 @@
       "id": 6256,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•Do They Have A Code Clearance? (Coruscant) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Dark/large/dotheyhaveacodeclearancev.gif",
@@ -17204,7 +20270,12 @@
       "id": 6257,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•Do They Have A Code Clearance? (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Dark/large/dotheyhaveacodeclearance.gif",
@@ -17225,7 +20296,12 @@
       "gempId": "7_176",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Dodo Bodonawieedo",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/dodobodonawieedo.gif",
@@ -17261,7 +20337,12 @@
       "gempId": "9_155",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Dominator",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/dominator.gif",
@@ -17295,7 +20376,12 @@
       "id": 6258,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Dominator (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/dominator.gif",
@@ -17324,7 +20410,12 @@
       "gempId": "8_140",
       "side": "Dark",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Don't Move!",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/dontmove.gif",
@@ -17340,7 +20431,12 @@
       "id": 6260,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Dooku's Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/dookuslightsaber.gif",
@@ -17360,7 +20456,12 @@
       "gempId": "200_142",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Dooku's Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/dookuslightsaber.gif",
@@ -17392,7 +20493,12 @@
       "id": 6261,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Dooku's Solar Sailer",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/dookussolarsailer.gif",
@@ -17422,7 +20528,12 @@
       "gempId": "5_136",
       "side": "Dark",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Double Back",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/doubleback.gif",
@@ -17485,7 +20596,12 @@
       "gempId": "208_43",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "Double Back (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/doubleback.gif",
@@ -17520,7 +20636,12 @@
       "gempId": "6_176",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Double Laser Cannon",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/doublelasercannon.gif",
@@ -17544,7 +20665,12 @@
       "gempId": "5_137",
       "side": "Dark",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Double-Crossing, No-Good Swindler",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/doublecrossingnogoodswindler.gif",
@@ -17565,7 +20691,12 @@
       "gempId": "211_19",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•D'Qar",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Dark/large/dqar.gif",
@@ -17588,7 +20719,12 @@
       "gempId": "209_35",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Dr. Chelli Lona Aphra",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Dark/large/drchellilonaaphra.gif",
@@ -17613,7 +20749,12 @@
       "gempId": "1_172",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Dr. Evazan",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/drevazan.gif",
@@ -17651,7 +20792,12 @@
       "gempId": "10_37",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Dr. Evazan & •Ponda Baba",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Dark/large/drevazan&pondababa.gif",
@@ -17684,7 +20830,12 @@
       "gempId": "7_320",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Dr. Evazan's Sawed-off Blaster",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/drevazanssawedoffblaster.gif",
@@ -17712,7 +20863,12 @@
       "gempId": "4_109",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Dragonsnake",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/dragonsnake.gif",
@@ -17742,7 +20898,12 @@
       "gempId": "7_227",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Dreaded Imperial Starfleet",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/dreadedimperialstarfleet.gif",
@@ -17766,7 +20927,12 @@
       "id": 6264,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Dreaded Imperial Starfleet (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/dreadedimperialstarfleet.gif",
@@ -17785,7 +20951,12 @@
       "gempId": "106_13",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Official Tournament Sealed Deck",
+      "set": "106",
+      "printings": [
+        {
+          "set": "106"
+        }
+      ],
       "front": {
         "title": "Dreadnaught-Class Heavy Cruiser",
         "imageUrl": "https://res.starwarsccg.org/cards/OfficialTournamentSealedDeck-Dark/large/dreadnaughtclassheavycruiser.gif",
@@ -17823,7 +20994,12 @@
       "gempId": "1_202",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Droid Detector",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/droiddetector.gif",
@@ -17839,7 +21015,12 @@
       "gempId": "14_96",
       "side": "Dark",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Droid Racks",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/droidracks.gif",
@@ -17862,7 +21043,12 @@
       "id": 6265,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Droid Racks (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/droidracks.gif",
@@ -17882,7 +21068,12 @@
       "gempId": "208_39",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Droid Racks (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/droidracks.gif",
@@ -17906,7 +21097,12 @@
       "gempId": "12_181",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Droid Starfighter",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/droidstarfighter.gif",
@@ -17943,7 +21139,12 @@
       "gempId": "14_127",
       "side": "Dark",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "Droid Starfighter Laser Cannons",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/droidstarfighterlasercannons.gif",
@@ -17970,7 +21171,12 @@
       "id": 6266,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "Droid Walker",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/droidwalker.gif",
@@ -17997,7 +21203,12 @@
       "id": 6267,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "Droideka",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/droideka.gif",
@@ -18027,7 +21238,12 @@
       "gempId": "200_80",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "Droideka",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/droideka.gif",
@@ -18057,7 +21273,12 @@
       "gempId": "14_102",
       "side": "Dark",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Drop Your Weapons",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/dropyourweapons.gif",
@@ -18078,7 +21299,12 @@
       "gempId": "12_132",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Drop!",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/drop.gif",
@@ -18106,7 +21332,12 @@
       "id": 6268,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Drop! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/drop.gif",
@@ -18126,7 +21357,12 @@
       "gempId": "203_30",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•Drop! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Dark/large/drop.gif",
@@ -18154,7 +21390,12 @@
       "gempId": "9_107",
       "side": "Dark",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•DS-181-3",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/ds1813.gif",
@@ -18183,7 +21424,12 @@
       "gempId": "9_108",
       "side": "Dark",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•DS-181-4",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/ds1814.gif",
@@ -18217,7 +21463,12 @@
       "id": 6269,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•DS-61-11 In Black 11",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/ds6111inblack11.gif",
@@ -18245,7 +21496,12 @@
       "gempId": "1_173",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•DS-61-2",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/ds612.gif",
@@ -18278,7 +21534,12 @@
       "gempId": "1_174",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•DS-61-3",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/ds613.gif",
@@ -18313,7 +21574,12 @@
       "gempId": "2_88",
       "side": "Dark",
       "rarity": "R2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•DS-61-4",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/ds614.gif",
@@ -18344,7 +21610,12 @@
       "id": 6270,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•DS-61-5",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/ds615.gif",
@@ -18369,7 +21640,12 @@
       "gempId": "200_77",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•DS-61-5",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/ds615.gif",
@@ -18397,7 +21673,12 @@
       "id": 6271,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "DSD1 Dwarf Spider Droid",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/dsd1dwarfspiderdroid.gif",
@@ -18428,7 +21709,12 @@
       "gempId": "11_96",
       "side": "Dark",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Dud Bolt's Podracer",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/dudboltspodracer.gif",
@@ -18448,7 +21734,12 @@
       "gempId": "6_153",
       "side": "Dark",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Dune Sea Sabacc",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/duneseasabacc.gif",
@@ -18471,7 +21762,12 @@
       "gempId": "7_313",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•••Dune Walker",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/dunewalker.gif",
@@ -18507,7 +21803,12 @@
       "id": 6272,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "<>Dungeon (Prison)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/dungeonprison.gif",
@@ -18527,7 +21828,12 @@
       "id": 6273,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Durge",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/durge.gif",
@@ -18556,7 +21862,12 @@
       "id": 6274,
       "side": "Dark",
       "rarity": "F",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Durge's NovaSword Fighter",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/durgesnovaswordfighter.gif",
@@ -18584,7 +21895,12 @@
       "gempId": "5_138",
       "side": "Dark",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "E Chu Ta",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/echuta.gif",
@@ -18607,7 +21923,12 @@
       "gempId": "5_97",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•E-3PO",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/e3po.gif",
@@ -18633,7 +21954,12 @@
       "id": 6275,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•E-3PO (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/e3po.gif",
@@ -18659,7 +21985,12 @@
       "gempId": "3_159",
       "side": "Dark",
       "rarity": "C1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "E-web Blaster",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/ewebblaster.gif",
@@ -18681,7 +22012,12 @@
       "gempId": "8_122",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "<>Early Warning Network",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/earlywarningnetwork.gif",
@@ -18723,7 +22059,12 @@
       "gempId": "12_105",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Edcel Bar Gane",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/edcelbargane.gif",
@@ -18754,7 +22095,12 @@
       "gempId": "8_141",
       "side": "Dark",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Eee Chu Wawa!",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/eeechuwawa.gif",
@@ -18776,7 +22122,12 @@
       "gempId": "1_175",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "EG-6 (Eegee-Six)",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/eg6.gif",
@@ -18803,7 +22154,12 @@
       "gempId": "3_95",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Electro-Rangefinder",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/electrorangefinder.gif",
@@ -18819,7 +22175,12 @@
       "gempId": "1_243",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Elis Helrot",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/elishelrot.gif",
@@ -18840,7 +22201,12 @@
       "id": 6276,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Elis in Hinthra",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/elisinhinthra.gif",
@@ -18868,7 +22234,12 @@
       "gempId": "200_134",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Elis in Hinthra",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/elisinhinthra.gif",
@@ -18923,7 +22294,12 @@
       "gempId": "8_100",
       "side": "Dark",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•••Elite Squadron Stormtrooper",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/elitesquadronstormtrooper.gif",
@@ -18954,7 +22330,12 @@
       "id": 6277,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•••Elite Squadron Stormtrooper (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/elitesquadronstormtrooper.gif",
@@ -18984,7 +22365,12 @@
       "gempId": "1_244",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Emergency Deployment",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/emergencydeployment.gif",
@@ -19004,7 +22390,12 @@
       "id": 6278,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Emergency Deployment (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/emergencydeployment.gif",
@@ -19021,7 +22412,12 @@
       "gempId": "9_109",
       "side": "Dark",
       "rarity": "UR",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Emperor Palpatine",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/emperorpalpatine.gif",
@@ -19063,7 +22459,12 @@
       "gempId": "205_12",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 5",
+      "set": "205",
+      "printings": [
+        {
+          "set": "205"
+        }
+      ],
       "front": {
         "title": "•Emperor Palpatine, Foreseer",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual5-Dark/large/emperorpalpatineforeseer.gif",
@@ -19105,7 +22506,12 @@
       "gempId": "9_156",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Emperor's Personal Shuttle",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/emperorspersonalshuttle.gif",
@@ -19142,7 +22548,12 @@
       "gempId": "9_123",
       "side": "Dark",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Emperor's Power",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/emperorspower.gif",
@@ -19165,7 +22576,12 @@
       "id": 6279,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Emperor's Power (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/emperorspower.gif",
@@ -19184,7 +22600,12 @@
       "gempId": "8_123",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Empire's New Order",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/empiresneworder.gif",
@@ -19212,7 +22633,12 @@
       "id": 6280,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Empire's New Order (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/empiresneworder.gif",
@@ -19231,7 +22657,12 @@
       "gempId": "5_139",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•End This Destructive Conflict",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/endthisdestructiveconflict.gif",
@@ -19256,7 +22687,12 @@
       "gempId": "8_157",
       "side": "Dark",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Endor",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/endor.gif",
@@ -19289,7 +22725,12 @@
       "gempId": "8_142",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Endor Occupation",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/endoroccupation.gif",
@@ -19313,7 +22754,12 @@
       "gempId": "8_167",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "Endor Operations / Imperial Outpost",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/endoroperations.gif",
@@ -19335,7 +22781,12 @@
       "gempId": "9_124",
       "side": "Dark",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Endor Shield",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/endorshield.gif",
@@ -19358,7 +22809,12 @@
       "id": 6282,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Endor Shield (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/endorshield.gif",
@@ -19377,7 +22833,12 @@
       "gempId": "201_29",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Endor Shield (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Dark/large/endorshield.gif",
@@ -19416,7 +22877,12 @@
       "gempId": "8_158",
       "side": "Dark",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Endor: Ancient Forest",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/endorancientforest.gif",
@@ -19442,7 +22908,12 @@
       "gempId": "8_159",
       "side": "Dark",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Endor: Back Door",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/endorbackdoor.gif",
@@ -19474,7 +22945,12 @@
       "gempId": "8_160",
       "side": "Dark",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Endor: Bunker",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/endorbunker.gif",
@@ -19506,7 +22982,12 @@
       "gempId": "8_161",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Endor: Dark Forest",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/endordarkforest.gif",
@@ -19532,7 +23013,12 @@
       "gempId": "8_162",
       "side": "Dark",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Endor: Dense Forest",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/endordenseforest.gif",
@@ -19559,7 +23045,12 @@
       "gempId": "8_163",
       "side": "Dark",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Endor: Ewok Village",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/endorewokvillage.gif",
@@ -19587,7 +23078,12 @@
       "gempId": "8_164",
       "side": "Dark",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Endor: Forest Clearing",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/endorforestclearing.gif",
@@ -19613,7 +23109,12 @@
       "gempId": "8_165",
       "side": "Dark",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•••Endor: Great Forest",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/endorgreatforest.gif",
@@ -19640,7 +23141,12 @@
       "gempId": "8_166",
       "side": "Dark",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Endor: Landing Platform (Docking Bay)",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/endorlandingplatformdockingbay.gif",
@@ -19674,7 +23180,12 @@
       "gempId": "14_128",
       "side": "Dark",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "Energy Shell Launchers",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/energyshelllaunchers.gif",
@@ -19701,7 +23212,12 @@
       "gempId": "13_67",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Energy Walls",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/energywalls.gif",
@@ -19732,7 +23248,12 @@
       "gempId": "2_158",
       "side": "Dark",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Enhanced TIE Laser Cannon",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/enhancedtielasercannon.gif",
@@ -19757,7 +23278,12 @@
       "gempId": "12_133",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•••Enter The Bureaucrat",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/enterthebureaucrat.gif",
@@ -19788,7 +23314,12 @@
       "gempId": "6_101",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Ephant Mon",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/ephantmon.gif",
@@ -19826,7 +23357,12 @@
       "gempId": "5_129",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Epic Duel",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/epicduel.gif",
@@ -19841,7 +23377,12 @@
       "id": 6283,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Epic Duel (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/epicduel.gif",
@@ -19859,7 +23400,12 @@
       "gempId": "102_7",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Jedi Pack",
+      "set": "102",
+      "printings": [
+        {
+          "set": "102"
+        }
+      ],
       "front": {
         "title": "•Eriadu",
         "imageUrl": "https://res.starwarsccg.org/cards/JediPack-Dark/large/eriadu.gif",
@@ -19882,7 +23428,12 @@
       "gempId": "7_177",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Eriadu Operative",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/eriaduoperative.gif",
@@ -19912,7 +23463,12 @@
       "gempId": "12_134",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Establish Control",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/establishcontrol.gif",
@@ -19942,7 +23498,12 @@
       "id": 6284,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "Establish Control (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/establishcontrol.gif",
@@ -19962,7 +23523,12 @@
       "gempId": "200_106",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "Establish Control (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/establishcontrol.gif",
@@ -19994,7 +23560,12 @@
       "gempId": "8_124",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Establish Secret Base",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/establishsecretbase.gif",
@@ -20016,7 +23587,12 @@
       "id": 6285,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Establish Secret Base (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/establishsecretbase.gif",
@@ -20035,7 +23611,12 @@
       "gempId": "207_25",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 7",
+      "set": "207",
+      "printings": [
+        {
+          "set": "207"
+        }
+      ],
       "front": {
         "title": "•Establish Secret Base (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual7-Dark/large/establishsecretbase.gif",
@@ -20059,7 +23640,12 @@
       "gempId": "6_102",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•EV-9D9",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/ev9d9.gif",
@@ -20091,7 +23677,12 @@
       "gempId": "1_245",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Evacuate?",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/evacuate.gif",
@@ -20107,7 +23698,12 @@
       "id": 6286,
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "Evacuate? (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/evacuate.gif",
@@ -20124,7 +23720,12 @@
       "gempId": "2_131",
       "side": "Dark",
       "rarity": "U1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Evader",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/evader.gif",
@@ -20147,7 +23748,12 @@
       "gempId": "10_38",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "Evader & Monnok",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Dark/large/evader&monnok.gif",
@@ -20168,7 +23774,12 @@
       "id": 6287,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Everything Is Going As Planned",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/everythingisgoingasplanned.gif",
@@ -20184,7 +23795,12 @@
       "id": 6288,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "<>Execution Arena (Pit)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/executionarenapit.gif",
@@ -20206,7 +23822,12 @@
       "gempId": "4_167",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Executor",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/executor.gif",
@@ -20251,7 +23872,12 @@
       "gempId": "4_159",
       "side": "Dark",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Executor: Comm Station",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/executorcommstation.gif",
@@ -20279,7 +23905,12 @@
       "gempId": "4_160",
       "side": "Dark",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Executor: Control Station",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/executorcontrolstation.gif",
@@ -20307,7 +23938,12 @@
       "gempId": "7_282",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Executor: Docking Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/executordockingbay.gif",
@@ -20341,7 +23977,12 @@
       "gempId": "4_161",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Executor: Holotheatre",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/executorholotheatre.gif",
@@ -20369,7 +24010,12 @@
       "gempId": "4_162",
       "side": "Dark",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Executor: Main Corridor",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/executormaincorridor.gif",
@@ -20397,7 +24043,12 @@
       "gempId": "4_163",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Executor: Meditation Chamber",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/executormeditationchamber.gif",
@@ -20424,7 +24075,12 @@
       "id": 6289,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Executor: Meditation Chamber (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/executormeditationchamber.gif",
@@ -20447,7 +24103,12 @@
       "gempId": "3_123",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Exhaustion",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/exhaustion.gif",
@@ -20465,7 +24126,12 @@
       "gempId": "1_215",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Expand The Empire",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/expandtheempire.gif",
@@ -20491,7 +24157,12 @@
       "id": 6290,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Expand The Empire (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/expandtheempire.gif",
@@ -20510,7 +24181,12 @@
       "gempId": "3_124",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Exposure",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/exposure.gif",
@@ -20527,7 +24203,12 @@
       "gempId": "204_57",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "F-11D Blaster Rifle",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Dark/large/f11dblasterrifle.gif",
@@ -20555,7 +24236,12 @@
       "gempId": "4_120",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Failure At The Cave",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/failureatthecave.gif",
@@ -20583,7 +24269,12 @@
       "gempId": "203_35",
       "side": "Dark",
       "rarity": "F",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•Falleen's Fist",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Dark/large/falleensfist.gif",
@@ -20619,7 +24310,12 @@
       "id": 6291,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "••Fanblade Starfighter",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/fanbladestarfighter.gif",
@@ -20647,7 +24343,12 @@
       "gempId": "13_68",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Fanfare",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/fanfare.gif",
@@ -20696,7 +24397,12 @@
       "gempId": "11_69",
       "side": "Dark",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Fanfare",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/fanfare.gif",
@@ -20745,7 +24451,12 @@
       "id": 6292,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•Fanfare (Tatooine) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Dark/large/fanfaretatooine.gif",
@@ -20765,7 +24476,12 @@
       "gempId": "200_95",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 0",
+      "set": "200d",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Fanfare (Tatooine) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/ResetDS-Dark/large/fanfaretatooine.gif",
@@ -20784,7 +24500,12 @@
       "id": 6294,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•Fanfare (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Dark/large/fanfare.gif",
@@ -20804,7 +24525,12 @@
       "gempId": "200_95",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 0",
+      "set": "200d",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Fanfare (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/ResetDS-Dark/large/fanfare.gif",
@@ -20852,7 +24578,12 @@
       "gempId": "4_141",
       "side": "Dark",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Fear",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/fear.gif",
@@ -20869,7 +24600,12 @@
       "id": 6295,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Fear (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/Fear.gif",
@@ -20889,7 +24625,12 @@
       "gempId": "13_69",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Fear Is My Ally",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/fearismyally.gif",
@@ -20915,7 +24656,12 @@
       "gempId": "1_216",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Fear Will Keep Them In Line",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/fearwillkeeptheminline.gif",
@@ -20938,7 +24684,12 @@
       "gempId": "1_176",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Feltipern Trevagg",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/feltiperntrevagg.gif",
@@ -20977,7 +24728,12 @@
       "gempId": "7_321",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Feltipern Trevagg's Stun Rifle",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/feltiperntrevaggsstunrifle.gif",
@@ -21003,7 +24759,12 @@
       "id": 6296,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Feltipern Trevagg's Stun Rifle (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/feltiperntrevaggsstunrifle.gif",
@@ -21022,7 +24783,12 @@
       "id": 6297,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Fett's Blaster Rifle",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/fettsblasterrifle.gif",
@@ -21042,7 +24808,12 @@
       "gempId": "4_121",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Field Promotion",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/fieldpromotion.gif",
@@ -21061,7 +24832,12 @@
       "id": 6298,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Field Promotion (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/fieldpromotion.gif",
@@ -21080,7 +24856,12 @@
       "gempId": "9_93",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Fighter Cover",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/fightercover.gif",
@@ -21100,7 +24881,12 @@
       "gempId": "9_94",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Fighters Coming In",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/fighterscomingin.gif",
@@ -21121,7 +24907,12 @@
       "gempId": "14_97",
       "side": "Dark",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Fighters Straight Ahead",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/fightersstraightahead.gif",
@@ -21145,7 +24936,12 @@
       "gempId": "204_54",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Finalizer",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Dark/large/finalizer.gif",
@@ -21186,7 +24982,12 @@
       "gempId": "7_228",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Firepower",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/firepower.gif",
@@ -21210,7 +25011,12 @@
       "id": 6299,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•Firepower (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Dark/large/firepower.gif",
@@ -21230,7 +25036,12 @@
       "gempId": "209_52",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•••First Order Special Forces TIE",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Dark/large/firstorderspecialforcestie.gif",
@@ -21257,7 +25068,12 @@
       "gempId": "204_40",
       "side": "Dark",
       "rarity": "C3",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "First Order Stormtrooper",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Dark/large/firstorderstormtrooper.gif",
@@ -21289,7 +25105,12 @@
       "gempId": "7_229",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•First Strike",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/firststrike.gif",
@@ -21314,7 +25135,12 @@
       "gempId": "4_122",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Flagship",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/flagship.gif",
@@ -21337,7 +25163,12 @@
       "id": 6301,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Flagship (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/flagship.gif",
@@ -21356,7 +25187,12 @@
       "gempId": "9_157",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Flagship Executor",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/flagshipexecutor.gif",
@@ -21403,7 +25239,15 @@
       "gempId": "9_125",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "107"
+        },
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Flagship Operations",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/flagshipoperations.gif",
@@ -21428,7 +25272,12 @@
       "id": 6302,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Flagship Operations (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/flagshipoperations.gif",
@@ -21447,7 +25296,12 @@
       "gempId": "7_314",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Flare-S Racing Swoop",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/flaresracingswoop.gif",
@@ -21472,7 +25326,12 @@
       "gempId": "7_250",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Flawless Marksmanship",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/flawlessmarksmanship.gif",
@@ -21492,7 +25351,12 @@
       "id": 6303,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Fleet Security Protocols",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/fleetsecurityprotocols.gif",
@@ -21511,7 +25375,12 @@
       "gempId": "5_140",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Flight Escort",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/flightescort.gif",
@@ -21529,7 +25398,12 @@
       "gempId": "7_216",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "••Floating Refinery",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/floatingrefinery.gif",
@@ -21546,7 +25420,12 @@
       "gempId": "204_39",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•FN-2003",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Dark/large/fn2003.gif",
@@ -21579,7 +25458,12 @@
       "gempId": "208_31",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•FN-2199 (Nines)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/fn2199nines.gif",
@@ -21614,7 +25498,12 @@
       "gempId": "5_141",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Focused Attack",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/focusedattack.gif",
@@ -21635,7 +25524,12 @@
       "gempId": "7_283",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Fondor",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/fondor.gif",
@@ -21663,7 +25557,12 @@
       "gempId": "5_142",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Force Field",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/forcefield.gif",
@@ -21685,7 +25584,12 @@
       "id": 6304,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Force Field (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/forcefield.gif",
@@ -21705,7 +25609,12 @@
       "gempId": "200_119",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Force Field (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/forcefield.gif",
@@ -21731,7 +25640,12 @@
       "gempId": "204_49",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Force Freeze",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Dark/large/forcefreeze.gif",
@@ -21752,7 +25666,12 @@
       "gempId": "9_136",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Force Lightning",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/forcelightning.gif",
@@ -21773,7 +25692,12 @@
       "gempId": "9_179",
       "side": "Dark",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "Force Pike",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/forcepike.gif",
@@ -21794,7 +25718,12 @@
       "gempId": "13_70",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Force Push",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/forcepush.gif",
@@ -21814,7 +25743,12 @@
       "id": 6305,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Force Push (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/forcepush.gif",
@@ -21834,7 +25768,12 @@
       "gempId": "200_120",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Force Push (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/forcepush.gif",
@@ -21855,7 +25794,12 @@
       "gempId": "5_117",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Forced Landing",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/forcedlanding.gif",
@@ -21875,7 +25819,12 @@
       "id": 6306,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Forced Landing (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/forcedlanding.gif",
@@ -21894,7 +25843,12 @@
       "gempId": "106_14",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Official Tournament Sealed Deck",
+      "set": "106",
+      "printings": [
+        {
+          "set": "106"
+        }
+      ],
       "front": {
         "title": "•Forced Servitude",
         "imageUrl": "https://res.starwarsccg.org/cards/OfficialTournamentSealedDeck-Dark/large/forcedservitude.gif",
@@ -21915,7 +25869,12 @@
       "id": 6307,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Forced Servitude (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/forcedservitude.gif",
@@ -21931,7 +25890,12 @@
       "gempId": "7_284",
       "side": "Dark",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "<>Forest",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/forest.gif",
@@ -21958,7 +25922,12 @@
       "gempId": "6_103",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Fozec",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/fozec.gif",
@@ -21992,7 +25961,12 @@
       "id": 6308,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Fozec (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/fozec.gif",
@@ -22017,7 +25991,12 @@
       "gempId": "8_143",
       "side": "Dark",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Freeze!",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/freeze.gif",
@@ -22034,7 +26013,12 @@
       "id": 6309,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Freeze! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/freeze.gif",
@@ -22054,7 +26038,12 @@
       "gempId": "3_101",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Frostbite",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/frostbite.gif",
@@ -22076,7 +26065,12 @@
       "gempId": "3_102",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Frozen Dinner",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/frozendinner.gif",
@@ -22101,7 +26095,12 @@
       "id": 6310,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "Frozen Dinner (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/frozendinner.gif",
@@ -22120,7 +26119,12 @@
       "gempId": "4_142",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Frustration",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/frustration.gif",
@@ -22140,7 +26144,12 @@
       "id": 6311,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Frustration (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/frustration.gif",
@@ -22160,7 +26169,12 @@
       "gempId": "1_246",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Full Scale Alert",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/fullscalealert.gif",
@@ -22177,7 +26191,12 @@
       "gempId": "3_125",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Furry Fury",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/furryfury.gif",
@@ -22202,7 +26221,12 @@
       "gempId": "1_203",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Fusion Generator Supply Tanks",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/fusiongeneratorsupplytanks.gif",
@@ -22218,7 +26242,12 @@
       "id": 6312,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Fusion Generator Supply Tanks (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/fusiongeneratorsupplytanks.gif",
@@ -22234,7 +26263,12 @@
       "gempId": "3_86",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "FX-10 (Effex-ten)",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/fx10effexten.gif",
@@ -22258,7 +26292,12 @@
       "gempId": "1_315",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Gaderffii Stick",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/gaderffiistick.gif",
@@ -22275,7 +26314,12 @@
       "gempId": "6_104",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Gailid",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/gailid.gif",
@@ -22309,7 +26353,12 @@
       "id": 6313,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Galactic Domination",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/galacticdomination.gif",
@@ -22328,7 +26377,12 @@
       "id": 6314,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Galen Marek, Starkiller",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/galenmarekstarkiller.gif",
@@ -22355,7 +26409,12 @@
       "id": 6315,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Galen Marek, Starkiller (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/galenmarekstarkillerai.gif",
@@ -22382,7 +26441,12 @@
       "id": 6316,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Galen's Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/galenslightsaber.gif",
@@ -22400,7 +26464,12 @@
       "id": 6317,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Galen's Lightsaber, Vader's Gift",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/galenslightsabervadersgift.gif",
@@ -22417,7 +26486,12 @@
       "gempId": "9_148",
       "side": "Dark",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Gall",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/gall.gif",
@@ -22446,7 +26520,12 @@
       "gempId": "11_56",
       "side": "Dark",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Gamall Wironicc",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/gamallwironicc.gif",
@@ -22475,7 +26554,12 @@
       "gempId": "6_177",
       "side": "Dark",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Gamorrean Ax",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/gamorreanax.gif",
@@ -22492,7 +26576,12 @@
       "gempId": "6_105",
       "side": "Dark",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Gamorrean Guard",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/gamorreanguard.gif",
@@ -22519,7 +26608,12 @@
       "gempId": "12_106",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Gardulla The Hutt",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/gardullathehutt.gif",
@@ -22552,7 +26646,12 @@
       "id": 6318,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Gardulla the Hutt (v)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/gardullathehutt.gif",
@@ -22578,7 +26677,12 @@
       "gempId": "1_177",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Garindan",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/garindan.gif",
@@ -22608,7 +26712,12 @@
       "id": 6319,
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Garindan (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/garindan.gif",
@@ -22632,7 +26741,12 @@
       "gempId": "7_178",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Gela Yeens",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/gelayeens.gif",
@@ -22664,7 +26778,12 @@
       "id": 6320,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Gela Yeens (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/gelayeens.gif",
@@ -22690,7 +26809,12 @@
       "gempId": "203_27",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•General Grievous",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Dark/large/generalgrievous.gif",
@@ -22731,7 +26855,12 @@
       "gempId": "203_27",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•General Grievous (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Dark/large/generalgrievoush.gif",
@@ -22762,7 +26891,12 @@
       "gempId": "203_27",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•General Grievous (OAI)",
         "imageUrl": "https://res.starwarsccg.org/cards/OfficialAI-Dark/large/generalgrievous.gif",
@@ -22793,7 +26927,12 @@
       "gempId": "204_41",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•General Hux",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Dark/large/generalhux.gif",
@@ -22839,7 +26978,12 @@
       "id": 6323,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•General Nevar",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/generalnevar.gif",
@@ -22863,7 +27007,12 @@
       "gempId": "202_10",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 2",
+      "set": "202",
+      "printings": [
+        {
+          "set": "202"
+        }
+      ],
       "front": {
         "title": "•General Nevar",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual2-Dark/large/generalnevar.gif",
@@ -22898,7 +27047,12 @@
       "gempId": "1_178",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•General Tagge",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/generaltagge.gif",
@@ -22938,7 +27092,12 @@
       "id": 6324,
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•General Tagge (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/generaltagge.gif",
@@ -22965,7 +27124,12 @@
       "gempId": "3_87",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•General Veers",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/generalveers.gif",
@@ -23004,7 +27168,12 @@
       "id": 6325,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•General Veers (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/generalveers.gif",
@@ -23033,7 +27202,12 @@
       "gempId": "200_81",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•General Veers (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/generalveers.gif",
@@ -23076,7 +27250,12 @@
       "id": 6326,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Geonosis",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/geonosis.gif",
@@ -23096,7 +27275,12 @@
       "id": 6327,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Geonosis: Docking Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/geonosisdockingbay.gif",
@@ -23117,7 +27301,12 @@
       "id": 6328,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Geonosis: Petranaki Arena",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/geonosispetranakiarena.gif",
@@ -23137,7 +27326,12 @@
       "id": 6329,
       "side": "Dark",
       "rarity": "F",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Geonosis: Rocky Plains",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/geonosisrockyplains.gif",
@@ -23157,7 +27351,12 @@
       "id": 6330,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Geonosis: Separatist Council Room",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/geonosissepartistcouncilroom.gif",
@@ -23180,7 +27379,12 @@
       "gempId": "11_57",
       "side": "Dark",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Ghana Gleemort",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/ghanagleemort.gif",
@@ -23211,7 +27415,12 @@
       "gempId": "2_132",
       "side": "Dark",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Ghhhk",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/ghhhk.gif",
@@ -23244,7 +27453,12 @@
       "gempId": "10_39",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "Ghhhk & Those Rebels Won't Escape Us",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Dark/large/ghhhk&thoserebelswontescapeus.gif",
@@ -23267,7 +27481,12 @@
       "id": 6331,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Gift Of The Master",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/giftofthemaster.gif",
@@ -23286,7 +27505,12 @@
       "gempId": "6_106",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Giran",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/giran.gif",
@@ -23310,7 +27534,12 @@
       "id": 6332,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Give Yourself to the Dark Side",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/giveyourselftothedarkside.gif",
@@ -23328,7 +27557,12 @@
       "gempId": "8_144",
       "side": "Dark",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Go For Help!",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/goforhelp.gif",
@@ -23346,7 +27580,12 @@
       "gempId": "11_58",
       "side": "Dark",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Gragra",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/gragra.gif",
@@ -23374,7 +27613,12 @@
       "gempId": "10_40",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Grand Admiral Thrawn",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Dark/large/grandadmiralthrawn.gif",
@@ -23418,7 +27662,12 @@
       "id": 6333,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Grand Admiral Thrawn (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/grandadmiralthrawn.gif",
@@ -23448,7 +27697,12 @@
       "gempId": "207_21",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 7",
+      "set": "207",
+      "printings": [
+        {
+          "set": "207"
+        }
+      ],
       "front": {
         "title": "•Grand Admiral Thrawn (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual7-Dark/large/grandadmiralthrawn.gif",
@@ -23492,7 +27746,12 @@
       "gempId": "1_179",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Grand Moff Tarkin",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/grandmofftarkin.gif",
@@ -23534,7 +27793,12 @@
       "id": 6334,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Grand Moff Tarkin (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/grandmofftarkin.gif",
@@ -23562,7 +27826,12 @@
       "gempId": "200_82",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Grand Moff Tarkin (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/grandmofftarkin.gif",
@@ -23599,7 +27868,12 @@
       "gempId": "1_247",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Gravel Storm",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/gravelstorm.gif",
@@ -23615,7 +27889,12 @@
       "id": 6335,
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Gravel Storm (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/gravelstorm.gif",
@@ -23632,7 +27911,12 @@
       "gempId": "102_8",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Jedi Pack",
+      "set": "102",
+      "printings": [
+        {
+          "set": "102"
+        }
+      ],
       "front": {
         "title": "•Gravity Shadow",
         "imageUrl": "https://res.starwarsccg.org/cards/JediPack-Dark/large/gravityshadow.gif",
@@ -23650,7 +27934,12 @@
       "gempId": "7_179",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Greeata",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/greeata.gif",
@@ -23688,7 +27977,12 @@
       "gempId": "2_89",
       "side": "Dark",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Greedo",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/greedo.gif",
@@ -23720,7 +28014,12 @@
       "id": 6336,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Greedo (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/greedo.gif",
@@ -23745,7 +28044,12 @@
       "gempId": "204_42",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Greedo (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Dark/large/greedo.gif",
@@ -23780,7 +28084,12 @@
       "id": 6337,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Greedo with Blaster Pistol",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/greedowithblasterpistol.gif",
@@ -23804,7 +28113,12 @@
       "id": 6338,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Grievous' Lightsabers",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/grievouslightsabers.gif",
@@ -23822,7 +28136,12 @@
       "id": 6339,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Grievous, Hunter Of Jedi",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/grievoushunterofjedi.gif",
@@ -23848,7 +28167,12 @@
       "gempId": "12_107",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Grotto Werribee",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/grottowerribee.gif",
@@ -23883,7 +28207,12 @@
       "id": 6340,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Grotto Werribee (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/grottowerribee.gif",
@@ -23910,7 +28239,12 @@
       "id": 6341,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Guild of Assassins",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/guildofassassins.gif",
@@ -23929,7 +28263,12 @@
       "gempId": "10_41",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Guri",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Dark/large/guri.gif",
@@ -23969,7 +28308,12 @@
       "id": 6342,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Guri (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/guri.gif",
@@ -23998,7 +28342,12 @@
       "gempId": "14_103",
       "side": "Dark",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Halt!",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/halt.gif",
@@ -24022,7 +28371,12 @@
       "gempId": "1_316",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Han Seeker",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/hanseeker.gif",
@@ -24041,7 +28395,12 @@
       "id": 6343,
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Han Seeker (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/hanseeker.gif",
@@ -24057,7 +28416,12 @@
       "id": 6344,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•He Always Wins!",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/healwayswins.gif",
@@ -24073,7 +28437,12 @@
       "gempId": "3_126",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "He Hasn't Come Back Yet",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/hehasntcomebackyet.gif",
@@ -24090,7 +28459,12 @@
       "gempId": "4_123",
       "side": "Dark",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "He Is Not Ready",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/heisnotready.gif",
@@ -24109,7 +28483,12 @@
       "id": 6345,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "He Is Not Ready (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/heisnotready.gif",
@@ -24128,7 +28507,12 @@
       "gempId": "5_143",
       "side": "Dark",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Heart Of The Chasm",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/heartofthechasm.gif",
@@ -24154,7 +28538,12 @@
       "gempId": "7_251",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Heavy Fire Zone",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/heavyfirezone.gif",
@@ -24175,7 +28564,12 @@
       "gempId": "9_180",
       "side": "Dark",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "Heavy Turbolaser Battery",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/heavyturbolaserbattery.gif",
@@ -24196,7 +28590,12 @@
       "gempId": "2_90",
       "side": "Dark",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Hem Dazon",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/hemdazon.gif",
@@ -24220,7 +28619,12 @@
       "id": 6346,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Hem Dazon (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/hemdazon.gif",
@@ -24244,7 +28648,12 @@
       "gempId": "6_107",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Herat",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/herat.gif",
@@ -24286,7 +28695,12 @@
       "gempId": "6_108",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Hermi Odle",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/hermiodle.gif",
@@ -24310,7 +28724,12 @@
       "id": 6347,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Hermi Odle (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/hermiodle.gif",
@@ -24335,7 +28754,12 @@
       "gempId": "5_144",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "He's All Yours, Bounty Hunter",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/hesallyoursbountyhunter.gif",
@@ -24354,7 +28778,12 @@
       "id": 6348,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "He's All Yours, Bounty Hunter (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/hesallyoursbountyhunter.gif",
@@ -24374,7 +28803,12 @@
       "gempId": "211_13",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "He's All Yours, Bounty Hunter (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Dark/large/hesallyoursbountyhunter.gif",
@@ -24393,7 +28827,12 @@
       "id": 6350,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•He's No Jedi",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/hesnojedi.gif",
@@ -24413,7 +28852,12 @@
       "gempId": "6_154",
       "side": "Dark",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Hidden Weapons",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/hiddenweapons.gif",
@@ -24439,7 +28883,12 @@
       "gempId": "3_103",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•High Anxiety",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/highanxiety.gif",
@@ -24466,7 +28915,12 @@
       "gempId": "8_145",
       "side": "Dark",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•High-speed Tactics",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/highspeedtactics.gif",
@@ -24485,7 +28939,12 @@
       "gempId": "11_70",
       "side": "Dark",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•His Name Is Anakin",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/hisnameisanakin.gif",
@@ -24509,7 +28968,12 @@
       "gempId": "11_81",
       "side": "Dark",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Hit Racer",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/hitracer.gif",
@@ -24536,7 +29000,12 @@
       "gempId": "4_143",
       "side": "Dark",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "••HoloNet Transmission",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/holonettransmission.gif",
@@ -24573,7 +29042,12 @@
       "gempId": "7_217",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Homing Beacon",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/homingbeacon.gif",
@@ -24593,7 +29067,12 @@
       "gempId": "205_13",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 5",
+      "set": "205",
+      "printings": [
+        {
+          "set": "205"
+        }
+      ],
       "front": {
         "title": "•Hondo Ohnaka",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual5-Dark/large/hondoohnaka.gif",
@@ -24624,7 +29103,12 @@
       "gempId": "8_146",
       "side": "Dark",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Hot Pursuit",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/hotpursuit.gif",
@@ -24645,7 +29129,12 @@
       "gempId": "3_143",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Hoth",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/hoth.gif",
@@ -24672,7 +29161,12 @@
       "id": 6352,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Hoth Blockade",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/hothblockade.gif",
@@ -24691,7 +29185,12 @@
       "gempId": "3_144",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Hoth: Defensive Perimeter (3rd Marker)",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/hothdefensiveperimeter.gif",
@@ -24713,7 +29212,12 @@
       "gempId": "3_145",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Hoth: Echo Command Center (War Room)",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/hothechocommandcenterwarroom.gif",
@@ -24739,7 +29243,12 @@
       "gempId": "3_146",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Hoth: Echo Corridor",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/hothechocorridor.gif",
@@ -24765,7 +29274,12 @@
       "gempId": "3_147",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Hoth: Echo Docking Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/hothechodockingbay.gif",
@@ -24798,7 +29312,12 @@
       "gempId": "3_148",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Hoth: Ice Plains (5th Marker)",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/hothiceplains.gif",
@@ -24819,7 +29338,12 @@
       "id": 6355,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Hoth: Ice Plains (5th Marker) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/hothiceplains.gif",
@@ -24842,7 +29366,12 @@
       "gempId": "208_49",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Hoth: Ice Plains (5th Marker) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/hothiceplains.gif",
@@ -24864,7 +29393,12 @@
       "gempId": "104_4",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Empire Strikes Back Introductory Two Player Game",
+      "set": "104",
+      "printings": [
+        {
+          "set": "104"
+        }
+      ],
       "front": {
         "title": "•Hoth: Mountains (6th Marker)",
         "imageUrl": "https://res.starwarsccg.org/cards/EmpireStrikesBackIntroductoryTwoPlayerGame-Dark/large/hothmountains.gif",
@@ -24889,7 +29423,12 @@
       "gempId": "3_149",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Hoth: North Ridge (4th Marker)",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/hothnorthridge.gif",
@@ -24911,7 +29450,12 @@
       "gempId": "3_150",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Hoth: Wampa Cave (7th Marker)",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/hothwampacave.gif",
@@ -24933,7 +29477,12 @@
       "gempId": "4_168",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Hound's Tooth",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/houndstooth.gif",
@@ -24969,7 +29518,12 @@
       "id": 6360,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Hound's Tooth (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/houndstooth.gif",
@@ -24997,7 +29551,12 @@
       "gempId": "200_135",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Hound's Tooth (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/houndstooth.gif",
@@ -25034,7 +29593,12 @@
       "gempId": "5_145",
       "side": "Dark",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Human Shield",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/humanshield.gif",
@@ -25055,7 +29619,12 @@
       "gempId": "7_297",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Hunt Down And Destroy The Jedi / Their Fire Has Gone Out Of The Universe",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/huntdownanddestroythejedi.gif",
@@ -25076,7 +29645,12 @@
       "id": 6362,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "Hunt Down And Destroy The Jedi / Their Fire Has Gone Out Of The Universe (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/huntdownanddestroythejedi.gif",
@@ -25104,7 +29678,12 @@
       "gempId": "7_252",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Hunting Party",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/huntingparty.gif",
@@ -25126,7 +29705,12 @@
       "gempId": "204_50",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Hunting Party (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Dark/large/huntingparty.gif",
@@ -25151,7 +29735,12 @@
       "gempId": "6_144",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Hutt Bounty",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/huttbounty.gif",
@@ -25173,7 +29762,12 @@
       "id": 6363,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Hutt Bounty (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/huttbounty.gif",
@@ -25192,7 +29786,12 @@
       "gempId": "112_11",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Jabba's Palace Sealed Deck",
+      "set": "112",
+      "printings": [
+        {
+          "set": "112"
+        }
+      ],
       "front": {
         "title": "•Hutt Influence",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalaceSealedDeck-Dark/large/huttinfluence.gif",
@@ -25213,7 +29812,12 @@
       "id": 6364,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Hutt Influence (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/huttinfluence.gif",
@@ -25232,7 +29836,12 @@
       "gempId": "6_155",
       "side": "Dark",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Hutt Smooch",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/huttsmooch.gif",
@@ -25250,7 +29859,12 @@
       "gempId": "102_9",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Jedi Pack",
+      "set": "102",
+      "printings": [
+        {
+          "set": "102"
+        }
+      ],
       "front": {
         "title": "Hyperoute Navigation Chart",
         "imageUrl": "https://res.starwarsccg.org/cards/JediPack-Dark/large/hyperoutenavigationchart.gif",
@@ -25265,7 +29879,12 @@
       "gempId": "2_120",
       "side": "Dark",
       "rarity": "U1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Hyperwave Scan",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/hyperwavescan.gif",
@@ -25288,7 +29907,12 @@
       "id": 6366,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Hyperwave Scan (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/hyperwavescan.gif",
@@ -25307,7 +29931,12 @@
       "gempId": "2_112",
       "side": "Dark",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Hypo",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/hypo.gif",
@@ -25330,7 +29959,12 @@
       "gempId": "5_118",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•I Am Your Father",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/iamyourfather.gif",
@@ -25363,7 +29997,12 @@
       "id": 6367,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•I Am Your Father (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/iamyourfather.gif",
@@ -25383,7 +30022,12 @@
       "gempId": "205_17",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 5",
+      "set": "205",
+      "printings": [
+        {
+          "set": "205"
+        }
+      ],
       "front": {
         "title": "•I Am Your Father (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual5-Dark/large/iamyourfather.gif",
@@ -25412,7 +30056,12 @@
       "gempId": "7_253",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•I Can't Shake Him!",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/icantshakehim.gif",
@@ -25448,7 +30097,12 @@
       "id": 6368,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•I Can't Shake Him! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/icantshakehim.gif",
@@ -25468,7 +30122,12 @@
       "gempId": "200_121",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•I Can't Shake Him! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/icantshakehim.gif",
@@ -25493,7 +30152,12 @@
       "gempId": "1_217",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "I Find Your Lack Of Faith Disturbing",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/ifindyourlackoffaithdisturbing.gif",
@@ -25513,7 +30177,12 @@
       "id": 6369,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "I Find Your Lack Of Faith Disturbing (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Dark/large/ifindyourlackoffaithdisturbing.gif",
@@ -25532,7 +30201,12 @@
       "gempId": "200_97",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Set 0",
+      "set": "200d",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•I Find Your Lack Of Faith Disturbing (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/ResetDS-Dark/large/ifindyourlackoffaithdisturbing.gif",
@@ -25554,7 +30228,12 @@
       "gempId": "5_119",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•I Had No Choice",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/ihadnochoice.gif",
@@ -25578,7 +30257,12 @@
       "gempId": "1_248",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "I Have You Now",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/ihaveyounow.gif",
@@ -25602,7 +30286,12 @@
       "id": 6370,
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "I Have You Now (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/ihaveyounow.gif",
@@ -25619,7 +30308,12 @@
       "gempId": "210_33",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•I Never Ask That Question",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Dark/large/ineveraskthatquestion.gif",
@@ -25639,7 +30333,12 @@
       "id": 6372,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•I Want Every Part Of This Ship Checked",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/iwanteverypartofthisshipchecked.gif",
@@ -25658,7 +30357,12 @@
       "gempId": "208_57",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "I Want That Map / And Now You'll Give It To Me",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/iwantthatmap.gif",
@@ -25686,7 +30390,12 @@
       "gempId": "4_124",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•I Want That Ship",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/iwantthatship.gif",
@@ -25709,7 +30418,12 @@
       "id": 6374,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•I Want That Ship (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/iwantthatship.gif",
@@ -25728,7 +30442,12 @@
       "gempId": "11_71",
       "side": "Dark",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•I Will Find Them Quickly, Master",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/iwillfindthemquicklymaster.gif",
@@ -25755,7 +30474,12 @@
       "gempId": "208_40",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•I Will Finish What You Started",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/iwillfinishwhatyoustarted.gif",
@@ -25787,7 +30511,12 @@
       "gempId": "7_180",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Iasa, The Traitor Of Jawa Canyon",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/iasathetraitorofjawacanyon.gif",
@@ -25821,7 +30550,12 @@
       "gempId": "3_104",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Ice Storm",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/icestorm.gif",
@@ -25847,7 +30581,12 @@
       "gempId": "3_127",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•I'd Just As Soon Kiss A Wookiee",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/idjustassoonkissawookiee.gif",
@@ -25872,7 +30611,12 @@
       "gempId": "11_80",
       "side": "Dark",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•If The Trace Was Correct",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/ifthetracewascorrect.gif",
@@ -25898,7 +30642,12 @@
       "id": 6375,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•If The Trace Was Correct (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/ifthetracewascorrect.gif",
@@ -25916,7 +30665,12 @@
       "gempId": "211_60",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•••IG MagnaGuard",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Dark/large/igmagnaguard.gif",
@@ -25945,7 +30699,12 @@
       "id": 6377,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•••IG-100 MagnaGuard",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/ig100magnaguard.gif",
@@ -25972,7 +30731,12 @@
       "gempId": "4_169",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•IG-2000",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/ig2000.gif",
@@ -26012,7 +30776,12 @@
       "id": 6378,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•IG-2000 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/ig2000.gif",
@@ -26038,7 +30807,12 @@
       "id": 6379,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "IG-227 'Hailfire' Droid Tank",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/ig227hailfiredroidtank.gif",
@@ -26067,7 +30841,12 @@
       "gempId": "4_101",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•IG-88",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/ig88.gif",
@@ -26110,7 +30889,12 @@
       "id": 6380,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•IG-88 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/ig88.gif",
@@ -26140,7 +30924,12 @@
       "gempId": "200_83",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•IG-88 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/ig88.gif",
@@ -26186,7 +30975,12 @@
       "gempId": "110_8",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Enhanced Jabba's Palace",
+      "set": "110",
+      "printings": [
+        {
+          "set": "110"
+        }
+      ],
       "front": {
         "title": "•IG-88 In IG-2000",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedJabbasPalace-Dark/large/ig88inig2000.gif",
@@ -26218,7 +31012,12 @@
       "gempId": "109_11",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Enhanced Cloud City",
+      "set": "109",
+      "printings": [
+        {
+          "set": "109"
+        }
+      ],
       "front": {
         "title": "•IG-88 With Riot Gun",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedCloudCity-Dark/large/ig88withriotgun.gif",
@@ -26258,7 +31057,12 @@
       "id": 6381,
       "side": "Dark",
       "rarity": "P",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•IG-88, Renegade Droid",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/ig88renegadedroid.gif",
@@ -26289,7 +31093,12 @@
       "gempId": "4_177",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•IG-88's Neural Inhibitor",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/ig88sneuralinhibitor.gif",
@@ -26315,7 +31124,12 @@
       "id": 6382,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•IG-88's Neural Inhibitor (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/ig88sneuralinhibitor.gif",
@@ -26335,7 +31149,12 @@
       "gempId": "4_178",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•IG-88's Pulse Cannon",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/ig88spulsecannon.gif",
@@ -26366,7 +31185,12 @@
       "id": 6383,
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•I'll Take Them Myself",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/illtakethemmyself.gif",
@@ -26382,7 +31206,12 @@
       "gempId": "2_133",
       "side": "Dark",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•I'm On The Leader",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/imontheleader.gif",
@@ -26402,7 +31231,12 @@
       "id": 6384,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•I'm On The Leader (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/imontheleader.gif",
@@ -26422,7 +31256,12 @@
       "gempId": "11_72",
       "side": "Dark",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•I'm Sorry",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/imsorry.gif",
@@ -26451,7 +31290,12 @@
       "id": 6385,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•I'm Sorry (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/imsorry.gif",
@@ -26470,7 +31314,12 @@
       "gempId": "7_181",
       "side": "Dark",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "IM4-099 (Eyeemmfour)",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/im4099.gif",
@@ -26493,7 +31342,12 @@
       "gempId": "3_105",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Image Of The Dark Lord",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/imageofthedarklord.gif",
@@ -26523,7 +31377,12 @@
       "id": 6386,
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Image Of The Dark Lord (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/imageofthedarklord.gif",
@@ -26542,7 +31401,12 @@
       "gempId": "200_107",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Image Of The Dark Lord (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/imageofthedarklord.gif",
@@ -26576,7 +31440,12 @@
       "gempId": "4_144",
       "side": "Dark",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Imbalance",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/imbalance.gif",
@@ -26593,7 +31462,12 @@
       "id": 6387,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Imbalance & •Kintan Strider",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/imbalance&kintanstrider.gif",
@@ -26612,7 +31486,12 @@
       "gempId": "200_122",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Imbalance & •Kintan Strider",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/imbalance&kintanstrider.gif",
@@ -26636,7 +31515,12 @@
       "gempId": "8_125",
       "side": "Dark",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Imperial Academy Training",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/imperialacademytraining.gif",
@@ -26658,7 +31542,12 @@
       "id": 6388,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Imperial Academy Training (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/imperialacademytraining.gif",
@@ -26676,7 +31565,12 @@
       "id": 6389,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Imperial Aces",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/imperialaces.gif",
@@ -26695,7 +31589,12 @@
       "gempId": "8_126",
       "side": "Dark",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Imperial Arrest Order",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/imperialarrestorder.gif",
@@ -26737,7 +31636,12 @@
       "gempId": "12_135",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Imperial Arrest Order & •Secret Plans",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/imperialarrestorder&secretplans.gif",
@@ -26777,7 +31681,12 @@
       "gempId": "12_148",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Imperial Artillery",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/imperialartillery.gif",
@@ -26796,7 +31705,12 @@
       "gempId": "1_249",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Imperial Barrier",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/imperialbarrier.gif",
@@ -26823,7 +31737,12 @@
       "gempId": "1_317",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Imperial Blaster",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/imperialblaster.gif",
@@ -26855,7 +31774,12 @@
       "gempId": "1_250",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Imperial Code Cylinder",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/imperialcodecylinder.gif",
@@ -26876,7 +31800,12 @@
       "id": 6390,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "Imperial Code Cylinder (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/imperialcodecylinder.gif",
@@ -26893,7 +31822,12 @@
       "gempId": "9_137",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Imperial Command",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/imperialcommand.gif",
@@ -26930,7 +31864,12 @@
       "gempId": "2_91",
       "side": "Dark",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Imperial Commander",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/imperialcommander.gif",
@@ -26958,7 +31897,12 @@
       "gempId": "5_120",
       "side": "Dark",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Imperial Decree",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/imperialdecree.gif",
@@ -26985,7 +31929,12 @@
       "id": 6391,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Imperial Decree (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/imperialdecree.gif",
@@ -27004,7 +31953,12 @@
       "gempId": "200_108",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "Imperial Decree (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/imperialdecree.gif",
@@ -27026,7 +31980,12 @@
       "id": 6392,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Imperial Detainment",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/imperialdetainment.gif",
@@ -27044,7 +32003,12 @@
       "id": 6393,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•Imperial Detention",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Dark/large/imperialdetention.gif",
@@ -27064,7 +32028,12 @@
       "gempId": "200_98",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 0",
+      "set": "200d",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Imperial Detention (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/ResetDS-Dark/large/imperialdetention.gif",
@@ -27083,7 +32052,12 @@
       "gempId": "3_106",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "••Imperial Domination",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/imperialdomination.gif",
@@ -27103,7 +32077,12 @@
       "id": 6395,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "••Imperial Domination (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/imperialdomination.gif",
@@ -27119,7 +32098,12 @@
       "gempId": "201_30",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Imperial Enforcement",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Dark/large/imperialenforcement.gif",
@@ -27139,7 +32123,12 @@
       "id": 6396,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Imperial Entanglements / No One To Stop Us This Time",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/imperialentanglements.gif",
@@ -27167,7 +32156,12 @@
       "gempId": "201_39",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "Imperial Entanglements / No One To Stop Us This Time",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Dark/large/imperialentanglements.gif",
@@ -27189,7 +32183,12 @@
       "gempId": "3_88",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Imperial Gunner",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/imperialgunner.gif",
@@ -27219,7 +32218,12 @@
       "gempId": "4_102",
       "side": "Dark",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•••Imperial Helmsman",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/imperialhelmsman.gif",
@@ -27244,7 +32248,12 @@
       "gempId": "2_145",
       "side": "Dark",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Imperial Holotable",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/imperialholotable.gif",
@@ -27271,7 +32280,12 @@
       "gempId": "2_121",
       "side": "Dark",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Imperial Justice",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/imperialjustice.gif",
@@ -27294,7 +32308,12 @@
       "id": 6398,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Imperial Justice (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/imperialjustice.gif",
@@ -27313,7 +32332,12 @@
       "gempId": "200_109",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "Imperial Justice (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/imperialjustice.gif",
@@ -27338,7 +32362,12 @@
       "gempId": "7_298",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Imperial Occupation / Imperial Control",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/imperialoccupation.gif",
@@ -27359,7 +32388,12 @@
       "id": 6400,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Imperial Occupation / Imperial Control (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/imperialoccupation.gif",
@@ -27387,7 +32421,12 @@
       "gempId": "1_180",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Imperial Pilot",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/imperialpilot.gif",
@@ -27411,7 +32450,12 @@
       "id": 6401,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Imperial Pilot (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/imperialpilot.gif",
@@ -27435,7 +32479,12 @@
       "gempId": "7_230",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Imperial Propaganda",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/imperialpropaganda.gif",
@@ -27462,7 +32511,12 @@
       "id": 6402,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "Imperial Propaganda (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/imperialpropaganda.gif",
@@ -27482,7 +32536,12 @@
       "gempId": "1_251",
       "side": "Dark",
       "rarity": "C1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Imperial Reinforcements",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/imperialreinforcements.gif",
@@ -27499,7 +32558,12 @@
       "id": 6403,
       "side": "Dark",
       "rarity": "C1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Imperial Reinforcements (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/imperialreinforcements.gif",
@@ -27515,7 +32579,12 @@
       "id": 6404,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Imperial Security Bureau",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/imperialsecuritybureau.gif",
@@ -27534,7 +32603,12 @@
       "gempId": "2_92",
       "side": "Dark",
       "rarity": "C3",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Imperial Squad Leader",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/imperialsquadleader.gif",
@@ -27567,7 +32641,12 @@
       "id": 6405,
       "side": "Dark",
       "rarity": "C1",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Imperial Stockpile",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/imperialstockpile.gif",
@@ -27582,7 +32661,12 @@
       "id": 6406,
       "side": "Dark",
       "rarity": "C3",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "Imperial Stormtrooper",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/imperialstormtrooper.gif",
@@ -27608,7 +32692,12 @@
       "gempId": "3_128",
       "side": "Dark",
       "rarity": "C1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Imperial Supply",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/imperialsupply.gif",
@@ -27626,7 +32715,12 @@
       "gempId": "1_181",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Imperial Trooper Guard",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/imperialtrooperguard.gif",
@@ -27653,7 +32747,12 @@
       "gempId": "5_98",
       "side": "Dark",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Imperial Trooper Guard Dainsom",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/imperialtrooperguarddainsom.gif",
@@ -27691,7 +32790,12 @@
       "gempId": "8_147",
       "side": "Dark",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Imperial Tyranny",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/imperialtyranny.gif",
@@ -27711,7 +32815,12 @@
       "id": 6407,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Imperial Tyranny (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/imperialtyranny.gif",
@@ -27731,7 +32840,12 @@
       "gempId": "104_5",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Empire Strikes Back Introductory Two Player Game",
+      "set": "104",
+      "printings": [
+        {
+          "set": "104"
+        }
+      ],
       "front": {
         "title": "Imperial Walker",
         "imageUrl": "https://res.starwarsccg.org/cards/EmpireStrikesBackIntroductoryTwoPlayerGame-Dark/large/imperialwalker.gif",
@@ -27756,7 +32870,12 @@
       "id": 6409,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Imperial War Machine",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/imperialwarmachine.gif",
@@ -27775,7 +32894,12 @@
       "gempId": "1_302",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Imperial-Class Star Destroyer",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/imperialclassstardestroyer.gif",
@@ -27813,7 +32937,12 @@
       "id": 6410,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Imperial-Class Star Destroyer (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/imperialclassstardestroyer.gif",
@@ -27840,7 +32969,12 @@
       "gempId": "7_254",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•In Range",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/inrange.gif",
@@ -27861,7 +32995,12 @@
       "id": 6411,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•In The Hands Of The ISB",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/inthehandsoftheisb.gif",
@@ -27880,7 +33019,12 @@
       "gempId": "9_126",
       "side": "Dark",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Inconsequential Losses",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/inconsequentiallosses.gif",
@@ -27903,7 +33047,12 @@
       "id": 6412,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Inconsequential Losses (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/inconsequentiallosses.gif",
@@ -27922,7 +33071,12 @@
       "gempId": "14_80",
       "side": "Dark",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "Infantry Battle Droid",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/infantrybattledroid.gif",
@@ -27961,7 +33115,12 @@
       "gempId": "3_160",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Infantry Mine",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/infantrymine.gif",
@@ -27979,7 +33138,12 @@
       "gempId": "2_134",
       "side": "Dark",
       "rarity": "U1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Informant",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/informant.gif",
@@ -28002,7 +33166,12 @@
       "id": 6413,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Informant (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/informant.gif",
@@ -28022,7 +33191,12 @@
       "gempId": "6_145",
       "side": "Dark",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Information Exchange",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/informationexchange.gif",
@@ -28042,7 +33216,12 @@
       "id": 6414,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Information Exchange (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/informationexchange.gif",
@@ -28060,7 +33239,12 @@
       "id": 6415,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Insidious Prisoner",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/insidiousprisoner.gif",
@@ -28075,7 +33259,12 @@
       "gempId": "211_11",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Insidious Prisoner",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Dark/large/insidiousprisoner.gif",
@@ -28093,7 +33282,12 @@
       "gempId": "9_127",
       "side": "Dark",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Insignificant Rebellion",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/insignificantrebellion.gif",
@@ -28116,7 +33310,12 @@
       "id": 6417,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Insignificant Rebellion (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/insignificantrebellion.gif",
@@ -28135,7 +33334,12 @@
       "gempId": "9_95",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Intensify The Forward Batteries",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/intensifytheforwardbatteries.gif",
@@ -28155,7 +33359,12 @@
       "gempId": "5_108",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Interrogation Array",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/interrogationarray.gif",
@@ -28179,7 +33388,12 @@
       "gempId": "7_322",
       "side": "Dark",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Intruder Missile",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/intrudermissile.gif",
@@ -28203,7 +33417,12 @@
       "gempId": "14_113",
       "side": "Dark",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "Invasion / In Complete Control",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/invasion.gif",
@@ -28231,7 +33450,12 @@
       "gempId": "211_23",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Invisible Hand",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Dark/large/invisiblehand.gif",
@@ -28261,7 +33485,12 @@
       "gempId": "211_20",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Invisible Hand: Bridge",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Dark/large/invisiblehandbridge.gif",
@@ -28286,7 +33515,12 @@
       "gempId": "211_21",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Invisible Hand: Docking Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Dark/large/invisiblehanddockingbay.gif",
@@ -28312,7 +33546,12 @@
       "gempId": "211_22",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Invisible Hand: Hallway 328",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Dark/large/invisiblehandhallway328.gif",
@@ -28340,7 +33579,12 @@
       "gempId": "211_27",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Invisible Hand: Observatory Entrance",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Dark/large/invisiblehandobservatoryentrance.gif",
@@ -28365,7 +33609,12 @@
       "gempId": "1_318",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Ion Cannon",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/ioncannon.gif",
@@ -28396,7 +33645,12 @@
       "id": 6424,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "ISB Blaster Pistol",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/isbblasterpistol.gif",
@@ -28415,7 +33669,12 @@
       "id": 6425,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•ISB Central Commander",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/isbcentralcommander.gif",
@@ -28439,7 +33698,12 @@
       "gempId": "7_299",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "ISB Operations / Empire's Sinister Agents",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/isboperations.gif",
@@ -28460,7 +33724,12 @@
       "id": 6427,
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•ISB Sector Commander",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/isbsectorcommander.gif",
@@ -28484,7 +33753,12 @@
       "id": 6428,
       "side": "Dark",
       "rarity": "F",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "<>ISB Sector Office",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/isbsectoroffice.gif",
@@ -28505,7 +33779,12 @@
       "gempId": "2_93",
       "side": "Dark",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•IT-O (Eyetee-Oh)",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/ito.gif",
@@ -28535,7 +33814,12 @@
       "id": 6429,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•IT-O (Eyetee-Oh) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/ito.gif",
@@ -28561,7 +33845,12 @@
       "gempId": "8_148",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "It's An Older Code",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/itsanoldercode.gif",
@@ -28582,7 +33871,12 @@
       "gempId": "1_252",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "It's Worse",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/itsworse.gif",
@@ -28604,7 +33898,12 @@
       "id": 6430,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "It's Worse (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/itsworse.gif",
@@ -28621,7 +33920,12 @@
       "gempId": "1_253",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "I've Got A Problem Here",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/ivegotaproblemhere.gif",
@@ -28638,7 +33942,12 @@
       "gempId": "1_218",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "I've Lost Artoo!",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/ivelostartoo.gif",
@@ -28660,7 +33969,12 @@
       "id": 6431,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "I've Lost Artoo! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/ivelostartoo.gif",
@@ -28676,7 +33990,12 @@
       "gempId": "7_182",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Jabba",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/jabba.gif",
@@ -28714,7 +34033,12 @@
       "gempId": "13_71",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Jabba Desilijic Tiure",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/jabbadesilijictiure.gif",
@@ -28752,7 +34076,12 @@
       "gempId": "6_109",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Jabba The Hutt",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/jabbathehutt.gif",
@@ -28786,7 +34115,12 @@
       "id": 6432,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Jabba The Hutt (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/jabbathehutt.gif",
@@ -28813,7 +34147,12 @@
       "gempId": "200_84",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Jabba The Hutt (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/jabbathehutt.gif",
@@ -28854,7 +34193,12 @@
       "id": 6433,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Jabba's Haven",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/jabbashaven.gif",
@@ -28869,7 +34213,12 @@
       "gempId": "201_31",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Jabba's Haven",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Dark/large/jabbashaven.gif",
@@ -28895,7 +34244,15 @@
       "gempId": "7_231",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "105"
+        },
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Jabba's Influence",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/jabbasinfluence.gif",
@@ -28917,7 +34274,12 @@
       "id": 6434,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Jabba's Influence (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/jabbasinfluence.gif",
@@ -28936,7 +34298,12 @@
       "gempId": "6_156",
       "side": "Dark",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Jabba's Palace Sabacc",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/jabbaspalacesabacc.gif",
@@ -28955,7 +34322,12 @@
       "gempId": "6_162",
       "side": "Dark",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Jabba's Palace: Audience Chamber",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/jabbaspalaceaudiencechamber.gif",
@@ -28994,7 +34366,12 @@
       "gempId": "6_163",
       "side": "Dark",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Jabba's Palace: Droid Workshop",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/jabbaspalacedroidworkshop.gif",
@@ -29024,7 +34401,12 @@
       "gempId": "6_164",
       "side": "Dark",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Jabba's Palace: Dungeon",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/jabbaspalacedungeon.gif",
@@ -29058,7 +34440,12 @@
       "gempId": "6_165",
       "side": "Dark",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Jabba's Palace: Entrance Cavern",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/jabbaspalaceentrancecavern.gif",
@@ -29089,7 +34476,12 @@
       "gempId": "112_12",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Jabba's Palace Sealed Deck",
+      "set": "112",
+      "printings": [
+        {
+          "set": "112"
+        }
+      ],
       "front": {
         "title": "•Jabba's Palace: Lower Passages",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalaceSealedDeck-Dark/large/jabbaspalacelowerpassages.gif",
@@ -29118,7 +34510,12 @@
       "gempId": "6_166",
       "side": "Dark",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Jabba's Palace: Rancor Pit",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/jabbaspalacerancorpit.gif",
@@ -29148,7 +34545,12 @@
       "gempId": "10_42",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Jabba's Prize/Jabba's Prize",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Dark/large/jabbasprizefront.gif",
@@ -29184,7 +34586,12 @@
       "gempId": "6_172",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Jabba's Sail Barge",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/jabbassailbarge.gif",
@@ -29215,7 +34622,12 @@
       "id": 6436,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Jabba's Sail Barge (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/jabbassailbarge.gif",
@@ -29241,7 +34653,12 @@
       "gempId": "204_56",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Jabba's Sail Barge (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Dark/large/jabbassailbarge.gif",
@@ -29276,7 +34693,12 @@
       "gempId": "6_167",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Jabba's Sail Barge: Passenger Deck",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/jabbassailbargepassengerdeck.gif",
@@ -29303,7 +34725,12 @@
       "gempId": "7_304",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Jabba's Space Cruiser",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/jabbasspacecruiser.gif",
@@ -29339,7 +34766,12 @@
       "id": 6437,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Jabba's Space Cruiser (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/jabbasspacecruiser.gif",
@@ -29368,7 +34800,12 @@
       "gempId": "210_34",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•Jabba's Space Cruiser (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Dark/large/jabbasspacecruiser.gif",
@@ -29396,7 +34833,12 @@
       "gempId": "7_255",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Jabba's Through With You",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/jabbasthroughwithyou.gif",
@@ -29446,7 +34888,12 @@
       "gempId": "202_12",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 2",
+      "set": "202",
+      "printings": [
+        {
+          "set": "202"
+        }
+      ],
       "front": {
         "title": "•Jabba's Trophies",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual2-Dark/large/jabbastrophies.gif",
@@ -29464,7 +34911,12 @@
       "gempId": "7_256",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Jabba's Twerps",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/jabbastwerps.gif",
@@ -29485,7 +34937,12 @@
       "gempId": "204_51",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Jakku",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Dark/large/jakku.gif",
@@ -29515,7 +34972,12 @@
       "gempId": "204_52",
       "side": "Dark",
       "rarity": "C1",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Jakku: Landing Site",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Dark/large/jakkulandingsite.gif",
@@ -29543,7 +35005,12 @@
       "gempId": "204_53",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Jakku: Tuanul Village",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Dark/large/jakkutuanulvillage.gif",
@@ -29571,7 +35038,12 @@
       "id": 6439,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Jango Fett",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/jangofett.gif",
@@ -29600,7 +35072,12 @@
       "gempId": "201_25",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Jango Fett",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Dark/large/jangofett.gif",
@@ -29636,7 +35113,12 @@
       "id": 6440,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Jango Fett, The Assassin",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/jangofetttheassassin.gif",
@@ -29661,7 +35143,12 @@
       "id": 6441,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Jango Fett, The Assassin (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/jangofetttheassassinai.gif",
@@ -29687,7 +35174,12 @@
       "gempId": "9_110",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Janus Greejatus",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/janusgreejatus.gif",
@@ -29724,7 +35216,12 @@
       "id": 6442,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Janus Greejatus (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/janusgreejatus.gif",
@@ -29748,7 +35245,12 @@
       "gempId": "12_108",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Jawa",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/jawa.gif",
@@ -29779,7 +35281,12 @@
       "gempId": "1_182",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Jawa",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/jawa.gif",
@@ -29808,7 +35315,12 @@
       "gempId": "2_159",
       "side": "Dark",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Jawa Blaster",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/jawablaster.gif",
@@ -29828,7 +35340,12 @@
       "gempId": "1_219",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Jawa Pack",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/jawapack.gif",
@@ -29855,7 +35372,12 @@
       "id": 6443,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Jawa Pack (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/jawapack.gif",
@@ -29871,7 +35393,12 @@
       "gempId": "208_50",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Jedha",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/jedha.gif",
@@ -29899,7 +35426,12 @@
       "gempId": "209_49",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Jedha: Jedha City",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Dark/large/jedhajedhacity.gif",
@@ -29921,7 +35453,12 @@
       "gempId": "6_140",
       "side": "Dark",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•••Jet Pack",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/jetpack.gif",
@@ -29943,7 +35480,12 @@
       "id": 6445,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•••Jet Pack (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/jetpack.gif",
@@ -29959,7 +35501,12 @@
       "gempId": "110_9",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Enhanced Jabba's Palace",
+      "set": "110",
+      "printings": [
+        {
+          "set": "110"
+        }
+      ],
       "front": {
         "title": "•Jodo Kast",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedJabbasPalace-Dark/large/jodokast.gif",
@@ -29993,7 +35540,12 @@
       "id": 6446,
       "side": "Dark",
       "rarity": "P",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Jodo Kast (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/jodokast.gif",
@@ -30019,7 +35571,12 @@
       "gempId": "11_82",
       "side": "Dark",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Join Me!",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/joinme.gif",
@@ -30036,7 +35593,12 @@
       "id": 6447,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Join Me! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/joinme.gif",
@@ -30052,7 +35614,12 @@
       "id": 6448,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Join Us Or Die",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/joinusordie.gif",
@@ -30071,7 +35638,12 @@
       "gempId": "6_110",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•J'Quille",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/jquille.gif",
@@ -30106,7 +35678,12 @@
       "id": 6449,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•J'Quille (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/jquille.gif",
@@ -30131,7 +35708,12 @@
       "gempId": "9_158",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Judicator",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/judicator.gif",
@@ -30170,7 +35752,12 @@
       "gempId": "7_285",
       "side": "Dark",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "<>Jungle",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/jungle.gif",
@@ -30196,7 +35783,12 @@
       "id": 6450,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Juno Eclipse, Black Leader",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/junoeclipseblackleader.gif",
@@ -30224,7 +35816,12 @@
       "id": 6451,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Juno Eclipse, Black Leader (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/junoeclipseblackleaderai.gif",
@@ -30253,7 +35850,12 @@
       "gempId": "1_220",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Juri Juice",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/jurijuice.gif",
@@ -30277,7 +35879,12 @@
       "id": 6452,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Justifier",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/justifier.gif",
@@ -30305,7 +35912,12 @@
       "gempId": "2_146",
       "side": "Dark",
       "rarity": "C1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Kashyyyk",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/kashyyyk.gif",
@@ -30333,7 +35945,12 @@
       "gempId": "7_183",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Kashyyyk Operative",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/kashyyykoperative.gif",
@@ -30363,7 +35980,12 @@
       "id": 6453,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Kashyyyk: Forest Maze",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/kashyyykforestmaze.gif",
@@ -30383,7 +36005,12 @@
       "id": 6454,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Kashyyyk: Skyhook Platform",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/kashyyykskyhookplatform.gif",
@@ -30402,7 +36029,12 @@
       "id": 6455,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Kashyyyk: Slaving Camp Headquarters",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/kashyyykslavingcampheadquarters.gif",
@@ -30423,7 +36055,12 @@
       "id": 6456,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Kashyyyk: Wookiee Slaving Camp",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/kashyyykwookieeslavingcamp.gif",
@@ -30444,7 +36081,12 @@
       "id": 6457,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Katana",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/katana.gif",
@@ -30473,7 +36115,12 @@
       "gempId": "12_109",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Keder The Black",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/kedertheblack.gif",
@@ -30514,7 +36161,12 @@
       "id": 6458,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Keder The Black (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/kedertheblack.gif",
@@ -30543,7 +36195,12 @@
       "gempId": "1_288",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Kessel",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/kessel.gif",
@@ -30571,7 +36228,12 @@
       "gempId": "7_184",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Kessel Operative",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/kesseloperative.gif",
@@ -30600,7 +36262,12 @@
       "id": 6459,
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "Kessel Surveillance System",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/kesselsurveillancesystem.gif",
@@ -30615,7 +36282,12 @@
       "id": 6460,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Kessel: Spice Mines - Administrator's Office",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/kesselspiceminesadministratorsoffice.gif",
@@ -30635,7 +36307,12 @@
       "id": 6461,
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Kessel: Spice Mines - Docking Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/kesselspiceminesdockingbay.gif",
@@ -30656,7 +36333,12 @@
       "id": 6462,
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Kessel: Spice Mines - Extraction Facility",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/kesselspiceminesextractionfacility.gif",
@@ -30677,7 +36359,12 @@
       "id": 6463,
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Kessel: Spice Mines - Prison",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/kesselspiceminesprison.gif",
@@ -30698,7 +36385,12 @@
       "gempId": "1_221",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Ket Maliss",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/ketmaliss.gif",
@@ -30721,7 +36413,12 @@
       "id": 6464,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Ket Maliss (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/ketmaliss.gif",
@@ -30736,7 +36433,12 @@
       "id": 6465,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Ket Maliss, Shadow Killer",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/ketmalissshadowkiller.gif",
@@ -30761,7 +36463,12 @@
       "gempId": "2_147",
       "side": "Dark",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Kiffex",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/kiffex.gif",
@@ -30789,7 +36496,12 @@
       "gempId": "7_185",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Kiffex Operative",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/kiffexoperative.gif",
@@ -30820,7 +36532,12 @@
       "gempId": "12_149",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Kill Them Immediately",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/killthemimmediately.gif",
@@ -30842,7 +36559,12 @@
       "gempId": "1_254",
       "side": "Dark",
       "rarity": "C1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Kintan Strider",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/kintanstrider.gif",
@@ -30866,7 +36588,12 @@
       "gempId": "10_43",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Kir Kanos",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Dark/large/kirkanos.gif",
@@ -30901,7 +36628,12 @@
       "gempId": "208_32",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Kir Kanos (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/kirkanos.gif",
@@ -30942,7 +36674,12 @@
       "id": 6466,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Kir Kanos With Force Pike",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/kirkanoswithforcepike.gif",
@@ -30969,7 +36706,12 @@
       "gempId": "6_111",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Kithaba",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/kithaba.gif",
@@ -31002,7 +36744,12 @@
       "gempId": "1_183",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Kitik Keed'kak",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/kitikkeedkak.gif",
@@ -31026,7 +36773,12 @@
       "id": 6467,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Kitik Keed'kak (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/kitikkeedkak.gif",
@@ -31047,7 +36799,12 @@
       "gempId": "6_112",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Klaatu",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/klaatu.gif",
@@ -31075,7 +36832,12 @@
       "gempId": "4_125",
       "side": "Dark",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Knowledge And Defense",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/knowledgeanddefense.gif",
@@ -31101,7 +36863,12 @@
       "id": 6468,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Knowledge And Defense (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/knowledgeanddefense.gif",
@@ -31121,7 +36888,12 @@
       "gempId": "200_110",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Knowledge And Defense (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/knowledgeanddefense.gif",
@@ -31143,7 +36915,12 @@
       "gempId": "7_211",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Krayt Dragon",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/kraytdragon.gif",
@@ -31170,7 +36947,12 @@
       "gempId": "2_122",
       "side": "Dark",
       "rarity": "U1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Krayt Dragon Bones",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/kraytdragonbones.gif",
@@ -31197,7 +36979,12 @@
       "id": 6469,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Krayt Dragon Bones (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/kraytdragonbones.gif",
@@ -31216,7 +37003,12 @@
       "gempId": "209_36",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Krennic, Death Star Commandant",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Dark/large/krennicdeathstarcommandant.gif",
@@ -31241,7 +37033,12 @@
       "gempId": "7_286",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Kuat",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/kuat.gif",
@@ -31268,7 +37065,12 @@
       "gempId": "7_232",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Kuat Drive Yards",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/kuatdriveyards.gif",
@@ -31308,7 +37110,12 @@
       "id": 6471,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Kuat Drive Yards (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/kuatdriveyards.gif",
@@ -31327,7 +37134,12 @@
       "gempId": "200_111",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Kuat Drive Yards (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/kuatdriveyards.gif",
@@ -31384,7 +37196,12 @@
       "gempId": "204_43",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Kylo Ren",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Dark/large/kyloren.gif",
@@ -31422,7 +37239,12 @@
       "gempId": "209_37",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Kylo Ren With Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Dark/large/kylorenwithlightsaber.gif",
@@ -31452,7 +37274,12 @@
       "gempId": "204_55",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Kylo Ren's Command Shuttle",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Dark/large/kylorenscommandshuttle.gif",
@@ -31492,7 +37319,12 @@
       "gempId": "204_58",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Kylo Ren's Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Dark/large/kylorenslightsaber.gif",
@@ -31523,7 +37355,12 @@
       "gempId": "210_35",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•Kylo Ren's TIE Silencer",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Dark/large/kylorenstiesilencer.gif",
@@ -31550,7 +37387,12 @@
       "gempId": "1_184",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Labria",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/labria.gif",
@@ -31582,7 +37424,12 @@
       "id": 6474,
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Labria (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/labria.gif",
@@ -31603,7 +37450,12 @@
       "gempId": "211_3",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Lady Proxima",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Dark/large/ladyproxima.gif",
@@ -31626,7 +37478,12 @@
       "id": 6476,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Lady Valarian",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/ladyvalarian.gif",
@@ -31647,7 +37504,12 @@
       "gempId": "8_168",
       "side": "Dark",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "Lambda-Class Shuttle",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/lambdaclassshuttle.gif",
@@ -31682,7 +37544,12 @@
       "gempId": "12_150",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Lana Dobreed",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/lanadobreed.gif",
@@ -31706,7 +37573,12 @@
       "id": 6477,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Lana Dobreed & •Sacrifice",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/lanadobreed&sacrifice.gif",
@@ -31726,7 +37598,12 @@
       "gempId": "209_48",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Lana Dobreed & •Sacrifice",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Dark/large/lanadobreedsacrifice.gif",
@@ -31746,7 +37623,12 @@
       "gempId": "5_99",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Lando Calrissian",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/landocalrissian.gif",
@@ -31782,7 +37664,12 @@
       "id": 6479,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Lando Calrissian (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/landocalrissian.gif",
@@ -31811,7 +37698,12 @@
       "gempId": "4_145",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Lando System?",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/landosystem.gif",
@@ -31827,7 +37719,12 @@
       "id": 6480,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Lando System? (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/landosystem.gif",
@@ -31847,7 +37744,12 @@
       "gempId": "12_187",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Laser Cannon Battery",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/lasercannonbattery.gif",
@@ -31875,7 +37777,12 @@
       "gempId": "2_113",
       "side": "Dark",
       "rarity": "U2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "••Laser Gate",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/lasergate.gif",
@@ -31895,7 +37802,12 @@
       "id": 6481,
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "••Laser Gate (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/lasergate.gif",
@@ -31914,7 +37826,12 @@
       "gempId": "1_319",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Laser Projector",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/laserprojector.gif",
@@ -31931,7 +37848,12 @@
       "gempId": "1_222",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Lateral Damage",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/lateraldamage.gif",
@@ -31965,7 +37887,12 @@
       "gempId": "11_59",
       "side": "Dark",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Lathe",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/lathe.gif",
@@ -31997,7 +37924,12 @@
       "gempId": "9_128",
       "side": "Dark",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Leave Them To Me",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/leavethemtome.gif",
@@ -32021,7 +37953,12 @@
       "gempId": "13_72",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Leave Them To Me",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/leavethemtome.gif",
@@ -32041,7 +37978,12 @@
       "id": 6482,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•Leave Them To Me (Death Star II) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Dark/large/leavethemtomev.gif",
@@ -32060,7 +38002,12 @@
       "id": 6483,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•Leave Them To Me (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Dark/large/leavethemtome.gif",
@@ -32080,7 +38027,12 @@
       "gempId": "2_160",
       "side": "Dark",
       "rarity": "R2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Leia Seeker",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/leiaseeker.gif",
@@ -32102,7 +38054,12 @@
       "id": 6484,
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Leia Seeker (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/leiaseeker.gif",
@@ -32122,7 +38079,12 @@
       "gempId": "13_73",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "Let Them Make The First Move / At Last We Will Have Revenge",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/letthemmakethefirstmove.gif",
@@ -32149,7 +38111,12 @@
       "id": 6486,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "Let's Pass On That",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/letspassonthat.gif",
@@ -32169,7 +38136,12 @@
       "gempId": "5_146",
       "side": "Dark",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Levitation Attack",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/levitationattack.gif",
@@ -32189,7 +38161,12 @@
       "id": 6487,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Levitation Attack (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/levitationattack.gif",
@@ -32209,7 +38186,12 @@
       "gempId": "8_101",
       "side": "Dark",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Arnet",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/lieutenantarnet.gif",
@@ -32243,7 +38225,12 @@
       "gempId": "3_89",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Cabbel",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/lieutenantcabbel.gif",
@@ -32271,7 +38258,12 @@
       "gempId": "5_100",
       "side": "Dark",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Cecius",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/lieutenantcecius.gif",
@@ -32303,7 +38295,12 @@
       "id": 6488,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Cecius (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/lieutenantcecius.gif",
@@ -32328,7 +38325,12 @@
       "gempId": "4_103",
       "side": "Dark",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Commander Ardan",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/lieutenantcommanderardan.gif",
@@ -32363,7 +38365,12 @@
       "gempId": "208_33",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Dopheld Mitaka",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/lieutenantdopheldmitaka.gif",
@@ -32389,7 +38396,12 @@
       "gempId": "9_111",
       "side": "Dark",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Endicott",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/lieutenantendicott.gif",
@@ -32417,7 +38429,12 @@
       "gempId": "8_102",
       "side": "Dark",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Grond",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/lieutenantgrond.gif",
@@ -32453,7 +38470,12 @@
       "id": 6489,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Grond (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/lieutenantgrond.gif",
@@ -32479,7 +38501,12 @@
       "gempId": "9_112",
       "side": "Dark",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Hebsly",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/lieutenanthebsly.gif",
@@ -32508,7 +38535,12 @@
       "gempId": "8_103",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Renz",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/lieutenantrenz.gif",
@@ -32542,7 +38574,12 @@
       "id": 6490,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Renz (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/lieutenantrenz.gif",
@@ -32567,7 +38604,12 @@
       "gempId": "5_101",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Sheckil",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/lieutenantsheckil.gif",
@@ -32601,7 +38643,12 @@
       "gempId": "4_104",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Suba",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/lieutenantsuba.gif",
@@ -32632,7 +38679,12 @@
       "gempId": "1_185",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Tanbris",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/lieutenanttanbris.gif",
@@ -32657,7 +38709,12 @@
       "gempId": "4_105",
       "side": "Dark",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Venka",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/lieutenantvenka.gif",
@@ -32688,7 +38745,12 @@
       "gempId": "209_38",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Venka (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Dark/large/lieutenantvenka.gif",
@@ -32717,7 +38779,12 @@
       "gempId": "8_104",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Watts",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/lieutenantwatts.gif",
@@ -32749,7 +38816,12 @@
       "id": 6492,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Watts (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/lieutenantwatts.gif",
@@ -32775,7 +38847,12 @@
       "gempId": "1_308",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Lift Tube",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/lifttube.gif",
@@ -32801,7 +38878,12 @@
       "gempId": "1_320",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Light Repeating Blaster Rifle",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/lightrepeatingblasterrifle.gif",
@@ -32831,7 +38913,12 @@
       "gempId": "3_129",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Lightsaber Deficiency",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/lightsaberdeficiency.gif",
@@ -32850,7 +38937,12 @@
       "id": 6493,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "Lightsaber Deficiency (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/lightsaberdeficiency.gif",
@@ -32870,7 +38962,12 @@
       "gempId": "11_83",
       "side": "Dark",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Lightsaber Parry",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/lightsaberparry.gif",
@@ -32891,7 +38988,12 @@
       "gempId": "1_255",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Limited Resources",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/limitedresources.gif",
@@ -32918,7 +39020,12 @@
       "gempId": "1_186",
       "side": "Dark",
       "rarity": "C1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "LIN-V8M (Elleyein-Veeateemm)",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/linv8m.gif",
@@ -32945,7 +39052,12 @@
       "gempId": "2_94",
       "side": "Dark",
       "rarity": "U2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Lirin Car'n",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/lirincarn.gif",
@@ -32974,7 +39086,12 @@
       "gempId": "12_151",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Little Real Power",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/littlerealpower.gif",
@@ -32998,7 +39115,12 @@
       "gempId": "7_186",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Lobel",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/lobel.gif",
@@ -33020,7 +39142,12 @@
       "gempId": "7_187",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Lobot",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/lobot.gif",
@@ -33046,7 +39173,12 @@
       "gempId": "1_256",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Local Trouble",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/localtrouble.gif",
@@ -33065,7 +39197,12 @@
       "id": 6494,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Local Trouble (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/localtrouble.gif",
@@ -33082,7 +39219,12 @@
       "gempId": "4_126",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Location, Location, Location",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/locationlocationlocation.gif",
@@ -33105,7 +39247,12 @@
       "id": 6495,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Location, Location, Location (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/locationlocationlocation.gif",
@@ -33124,7 +39271,12 @@
       "gempId": "1_257",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Lone Pilot",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/lonepilot.gif",
@@ -33149,7 +39301,12 @@
       "id": 6496,
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Lone Pilot (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/lonepilot.gif",
@@ -33166,7 +39323,12 @@
       "gempId": "1_258",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Lone Warrior",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/lonewarrior.gif",
@@ -33185,7 +39347,12 @@
       "gempId": "1_259",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Look Sir, Droids",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/looksirdroids.gif",
@@ -33201,7 +39368,12 @@
       "id": 6497,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Look Sir, Droids (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/looksirdroids.gif",
@@ -33218,7 +39390,12 @@
       "gempId": "13_74",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Lord Maul",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/lordmaul.gif",
@@ -33267,7 +39444,12 @@
       "gempId": "208_34",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Lord Maul With Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/lordmaulwithlightsaber.gif",
@@ -33311,7 +39493,12 @@
       "id": 6498,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Lord Sidious",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/lordsidious.gif",
@@ -33340,7 +39527,12 @@
       "gempId": "208_35",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Lord Sidious",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/lordsidious.gif",
@@ -33391,7 +39583,12 @@
       "gempId": "9_113",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Lord Vader",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/lordvader.gif",
@@ -33445,7 +39642,12 @@
       "id": 6499,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Lord Vader (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/lordvader.gif",
@@ -33475,7 +39677,12 @@
       "gempId": "4_127",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Lost In Space",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/lostinspace.gif",
@@ -33499,7 +39706,12 @@
       "gempId": "12_110",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Lott Dod",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/lottdod.gif",
@@ -33543,7 +39755,12 @@
       "gempId": "2_95",
       "side": "Dark",
       "rarity": "C1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Lt. Pol Treidum",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/ltpoltreidum.gif",
@@ -33574,7 +39791,12 @@
       "gempId": "201_26",
       "side": "Dark",
       "rarity": "C1",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Lt. Pol Treidum (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Dark/large/ltpoltreidum.gif",
@@ -33604,7 +39826,12 @@
       "gempId": "211_4",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Lt. Poldin Lehuse",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Dark/large/ltpoldinlehuse.gif",
@@ -33629,7 +39856,12 @@
       "gempId": "2_96",
       "side": "Dark",
       "rarity": "U1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Lt. Shann Childsen",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/ltshannchildsen.gif",
@@ -33657,7 +39889,12 @@
       "gempId": "1_321",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Luke Seeker",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/lukeseeker.gif",
@@ -33677,7 +39914,12 @@
       "gempId": "205_14",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 5",
+      "set": "205",
+      "printings": [
+        {
+          "set": "205"
+        }
+      ],
       "front": {
         "title": "•Luke Skywalker, The Emperor's Prize/Luke Skywalker, The Emperor's Prize",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual5-Dark/large/lukeskywalkertheemperorsprizefront.gif",
@@ -33715,7 +39957,12 @@
       "gempId": "1_223",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Luke? Luuuuke!",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/lukeluuuuke.gif",
@@ -33740,7 +39987,12 @@
       "id": 6502,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Luke? Luuuuke! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/lukeluuuuke.gif",
@@ -33756,7 +40008,12 @@
       "id": 6503,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Luuke",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/luuke.gif",
@@ -33784,7 +40041,12 @@
       "gempId": "7_188",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Lyn Me",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/lynme.gif",
@@ -33812,7 +40074,12 @@
       "id": 6504,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Maarek Stele, The Emperor's Reach",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/maareksteletheemperorsreach.gif",
@@ -33841,7 +40108,12 @@
       "gempId": "200_85",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Maarek Stele, The Emperor's Reach",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/maareksteletheemperorsreach.gif",
@@ -33884,7 +40156,12 @@
       "gempId": "1_224",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Macroscan",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/macroscan.gif",
@@ -33904,7 +40181,12 @@
       "gempId": "210_37",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "Macroscan (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Dark/large/macroscan.gif",
@@ -33920,7 +40202,12 @@
       "gempId": "2_114",
       "side": "Dark",
       "rarity": "R2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Magnetic Suction Tube",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/magneticsuctiontube.gif",
@@ -33937,7 +40224,12 @@
       "gempId": "8_149",
       "side": "Dark",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Main Course",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/maincourse.gif",
@@ -33958,7 +40250,12 @@
       "gempId": "8_105",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Major Hewex",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/majorhewex.gif",
@@ -33988,7 +40285,12 @@
       "id": 6506,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Major Hewex (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/majorhewex.gif",
@@ -34013,7 +40315,12 @@
       "gempId": "8_106",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Major Marquand",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/majormarquand.gif",
@@ -34047,7 +40354,12 @@
       "gempId": "9_114",
       "side": "Dark",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Major Mianda",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/majormianda.gif",
@@ -34081,7 +40393,12 @@
       "gempId": "9_115",
       "side": "Dark",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Major Rhymer",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/majorrhymer.gif",
@@ -34113,7 +40430,12 @@
       "gempId": "9_116",
       "side": "Dark",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Major Turr Phennir",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/majorturrphennir.gif",
@@ -34145,7 +40467,12 @@
       "gempId": "7_189",
       "side": "Dark",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Makurth",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/makurth.gif",
@@ -34173,7 +40500,12 @@
       "gempId": "6_113",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Malakili",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/malakili.gif",
@@ -34197,7 +40529,12 @@
       "id": 6507,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Malakili (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/malakili.gif",
@@ -34221,7 +40558,12 @@
       "gempId": "12_168",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Malastare",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/malastare.gif",
@@ -34253,7 +40595,12 @@
       "gempId": "5_109",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Mandalorian Armor",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/mandalorianarmor.gif",
@@ -34272,7 +40619,12 @@
       "id": 6508,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Mandalorian Armor (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/mandalorianarmor.gif",
@@ -34292,7 +40644,12 @@
       "gempId": "2_123",
       "side": "Dark",
       "rarity": "R2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Maneuver Check",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/maneuvercheck.gif",
@@ -34312,7 +40669,12 @@
       "id": 6509,
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Maneuver Check (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/maneuvercheck.gif",
@@ -34331,7 +40693,12 @@
       "gempId": "208_58",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Mara Jade In VT-49 Decimator",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/marajadeinvt49decimator.gif",
@@ -34361,7 +40728,12 @@
       "id": 6510,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Mara Jade With Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/marajadewithlightsaber.gif",
@@ -34390,7 +40762,12 @@
       "gempId": "200_86",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Mara Jade With Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/marajadewithlightsaber.gif",
@@ -34429,7 +40806,12 @@
       "gempId": "110_10",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Enhanced Jabba's Palace",
+      "set": "110",
+      "printings": [
+        {
+          "set": "110"
+        }
+      ],
       "front": {
         "title": "•Mara Jade, The Emperor's Hand",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedJabbasPalace-Dark/large/marajadetheemperorshand.gif",
@@ -34502,7 +40884,12 @@
       "gempId": "110_11",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Enhanced Jabba's Palace",
+      "set": "110",
+      "printings": [
+        {
+          "set": "110"
+        }
+      ],
       "front": {
         "title": "•Mara Jade's Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedJabbasPalace-Dark/large/marajadeslightsaber.gif",
@@ -34534,7 +40921,12 @@
       "id": 6511,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Mara Jade's Lightsaber (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/marajadeslightsaber.gif",
@@ -34550,7 +40942,12 @@
       "id": 6512,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Marquand In Blizzard 6",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/marquandinblizzard6.gif",
@@ -34577,7 +40974,12 @@
       "gempId": "210_38",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•Marquand In Blizzard 6",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Dark/large/marquandinblizzard6.gif",
@@ -34602,7 +41004,12 @@
       "id": 6514,
       "side": "Dark",
       "rarity": "F",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "Massassi Warrior",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/massassiwarrior.gif",
@@ -34626,7 +41033,12 @@
       "gempId": "14_104",
       "side": "Dark",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Master, Destroyers!",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/masterdestroyers.gif",
@@ -34651,7 +41063,12 @@
       "gempId": "7_257",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Masterful Move",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/masterfulmove.gif",
@@ -34688,7 +41105,12 @@
       "gempId": "12_152",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Masterful Move & •Endor Occupation",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/masterfulmove&endoroccupation.gif",
@@ -34727,7 +41149,12 @@
       "gempId": "12_153",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Maul Strikes",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/maulstrikes.gif",
@@ -34762,7 +41189,12 @@
       "id": 6515,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "Maul's Cape",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/maulscape.gif",
@@ -34781,7 +41213,12 @@
       "gempId": "13_75",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Maul's Double-Bladed Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/maulsdoublebladedlightsaber.gif",
@@ -34821,7 +41258,12 @@
       "gempId": "11_67",
       "side": "Dark",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Maul's Electrobinoculars",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/maulselectrobinoculars.gif",
@@ -34844,7 +41286,12 @@
       "gempId": "11_99",
       "side": "Dark",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Maul's Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/maulslightsaber.gif",
@@ -34884,7 +41331,12 @@
       "gempId": "12_182",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Maul's Sith Infiltrator",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/maulssithinfiltrator.gif",
@@ -34931,7 +41383,12 @@
       "gempId": "12_183",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Maul's Sith Infiltrator (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/maulssithinfiltratorai.gif",
@@ -34957,7 +41414,12 @@
       "id": 6517,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Maul's Sith Speeder",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/maulssithspeeder.gif",
@@ -34984,7 +41446,12 @@
       "gempId": "112_13",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Jabba's Palace Sealed Deck",
+      "set": "112",
+      "printings": [
+        {
+          "set": "112"
+        }
+      ],
       "front": {
         "title": "Mercenary Pilot",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalaceSealedDeck-Dark/large/mercenarypilot.gif",
@@ -35015,7 +41482,12 @@
       "id": 6518,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "Mercenary Pilot (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/mercenarypilot.gif",
@@ -35039,7 +41511,12 @@
       "id": 6519,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "Mercenary Shadow Pirate",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/mercenaryshadowpirate.gif",
@@ -35065,7 +41542,12 @@
       "id": 6520,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Mercenary Slavers",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/mercenaryslavers.gif",
@@ -35081,7 +41563,12 @@
       "gempId": "207_28",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Set 7",
+      "set": "207",
+      "printings": [
+        {
+          "set": "207"
+        }
+      ],
       "front": {
         "title": "•Meson Martinet",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual7-Dark/large/mesonmartinet.gif",
@@ -35119,7 +41606,12 @@
       "gempId": "3_107",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Meteor Impact?",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/meteorimpact.gif",
@@ -35141,7 +41633,12 @@
       "gempId": "112_14",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Jabba's Palace Sealed Deck",
+      "set": "112",
+      "printings": [
+        {
+          "set": "112"
+        }
+      ],
       "front": {
         "title": "•Mighty Jabba",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalaceSealedDeck-Dark/large/mightyjabba.gif",
@@ -35176,7 +41673,12 @@
       "gempId": "1_187",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•M'iiyoom Onith",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/miiyoomonith.gif",
@@ -35205,7 +41707,12 @@
       "gempId": "12_136",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Mind Tricks Don't Work On Me",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/mindtricksdontworkonme.gif",
@@ -35230,7 +41737,12 @@
       "gempId": "4_170",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Mist Hunter",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/misthunter.gif",
@@ -35267,7 +41779,12 @@
       "id": 6521,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Mist Hunter (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/misthunter.gif",
@@ -35295,7 +41812,12 @@
       "gempId": "211_1",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Mitth'raw'nuruodo",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Dark/large/mitthrawnuruodo.gif",
@@ -35323,7 +41845,12 @@
       "gempId": "9_129",
       "side": "Dark",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Mobilization Points",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/mobilizationpoints.gif",
@@ -35358,7 +41885,12 @@
       "gempId": "2_157",
       "side": "Dark",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Mobquet A-1 Deluxe Floater",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/mobqueta1deluxefloater.gif",
@@ -35386,7 +41918,12 @@
       "gempId": "9_117",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Moff Jerjerrod",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/moffjerjerrod.gif",
@@ -35428,7 +41965,12 @@
       "id": 6523,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Moff Tarkin, Death Star Commandant",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/mofftarkindeathstarcommandant.gif",
@@ -35457,7 +41999,12 @@
       "gempId": "1_225",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Molator",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/molator.gif",
@@ -35486,7 +42033,12 @@
       "id": 6524,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Molator (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/molator.gif",
@@ -35502,7 +42054,12 @@
       "gempId": "1_260",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Moment Of Triumph",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/momentoftriumph.gif",
@@ -35520,7 +42077,12 @@
       "gempId": "9_149",
       "side": "Dark",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Mon Calamari",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/moncalamari.gif",
@@ -35548,7 +42110,12 @@
       "gempId": "2_135",
       "side": "Dark",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Monnok",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/monnok.gif",
@@ -35576,7 +42143,12 @@
       "id": 6525,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Moruth Doole, Kessel Administrator",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/moruthdoolekesseladministrator.gif",
@@ -35596,7 +42168,12 @@
       "gempId": "6_178",
       "side": "Dark",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Mos Eisley Blaster",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/moseisleyblaster.gif",
@@ -35622,7 +42199,12 @@
       "gempId": "2_97",
       "side": "Dark",
       "rarity": "U2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Mosep",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/mosep.gif",
@@ -35650,7 +42232,12 @@
       "gempId": "5_121",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Mostly Armless",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/mostlyarmless.gif",
@@ -35680,7 +42267,12 @@
       "gempId": "12_137",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Motion Supported",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/motionsupported.gif",
@@ -35711,7 +42303,12 @@
       "gempId": "102_10",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Jedi Pack",
+      "set": "102",
+      "printings": [
+        {
+          "set": "102"
+        }
+      ],
       "front": {
         "title": "•Motti",
         "imageUrl": "https://res.starwarsccg.org/cards/JediPack-Dark/large/motti.gif",
@@ -35744,7 +42341,12 @@
       "gempId": "3_108",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Mournful Roar",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/mournfulroar.gif",
@@ -35774,7 +42376,12 @@
       "gempId": "1_188",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "MSE-6 'Mouse' Droid",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/mse6mousedroid.gif",
@@ -35797,7 +42404,12 @@
       "gempId": "4_128",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Much Anger In Him",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/muchangerinhim.gif",
@@ -35817,7 +42429,12 @@
       "id": 6526,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Much Anger In Him (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/muchangerinhim.gif",
@@ -35836,7 +42453,12 @@
       "gempId": "14_122",
       "side": "Dark",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "Multi Troop Transport",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/multitrooptransport.gif",
@@ -35868,7 +42490,12 @@
       "gempId": "6_114",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Murttoc Yine",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/murttocyine.gif",
@@ -35943,7 +42570,12 @@
       "gempId": "210_39",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•Mustafar",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Dark/large/mustafar.gif",
@@ -35966,7 +42598,12 @@
       "gempId": "209_50",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Mustafar: Vader's Castle",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Dark/large/mustafarvaderscastle.gif",
@@ -35987,7 +42624,12 @@
       "id": 6529,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Muunilinst",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/muunilinst.gif",
@@ -36007,7 +42649,12 @@
       "id": 6530,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Muunilinst: Banking Clan Headquarters",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/muunilinstbankingclanheadquarters.gif",
@@ -36027,7 +42674,12 @@
       "id": 6531,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Muunilinst: City of Harnaidan",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/muunilinstcityofharnaidan.gif",
@@ -36048,7 +42700,12 @@
       "id": 6532,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Muunilinst: Docking Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/muunilinstdockingbay.gif",
@@ -36069,7 +42726,12 @@
       "id": 6533,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Muunilinst: Separatist Command Center",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/muunilinstseparatistcommandcenter.gif",
@@ -36091,7 +42753,12 @@
       "gempId": "112_15",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Jabba's Palace Sealed Deck",
+      "set": "112",
+      "printings": [
+        {
+          "set": "112"
+        }
+      ],
       "front": {
         "title": "My Kind Of Scum / Fearless And Inventive",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalaceSealedDeck-Dark/large/mykindofscum.gif",
@@ -36113,7 +42780,12 @@
       "gempId": "12_179",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "My Lord, Is That Legal? / I Will Make It Legal",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/mylordisthatlegal.gif",
@@ -36141,7 +42813,12 @@
       "gempId": "9_118",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Myn Kyneugh",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/mynkyneugh.gif",
@@ -36177,7 +42854,12 @@
       "gempId": "208_36",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Myn Kyneugh (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/mynkyneugh.gif",
@@ -36203,7 +42885,12 @@
       "id": 6537,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Myn Kyneugh (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/mynkyneugh.gif",
@@ -36231,7 +42918,12 @@
       "gempId": "4_110",
       "side": "Dark",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Mynock",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/mynock.gif",
@@ -36265,7 +42957,12 @@
       "gempId": "1_189",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Myo",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/myo.gif",
@@ -36294,7 +42991,12 @@
       "gempId": "12_169",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Naboo",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/naboo.gif",
@@ -36323,7 +43025,12 @@
       "gempId": "12_188",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Naboo Blaster",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/nabooblaster.gif",
@@ -36351,7 +43058,12 @@
       "gempId": "12_189",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Naboo Blaster Rifle",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/nabooblasterrifle.gif",
@@ -36382,7 +43094,12 @@
       "gempId": "14_98",
       "side": "Dark",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Naboo Occupation",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/naboooccupation.gif",
@@ -36406,7 +43123,12 @@
       "gempId": "12_170",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Naboo: Battle Plains",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/naboobattleplains.gif",
@@ -36437,7 +43159,12 @@
       "gempId": "12_171",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Naboo: Swamp",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/nabooswamp.gif",
@@ -36462,7 +43189,12 @@
       "gempId": "12_172",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Naboo: Theed Palace Courtyard",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/nabootheedpalacecourtyard.gif",
@@ -36490,7 +43222,12 @@
       "gempId": "12_173",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Naboo: Theed Palace Docking Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/nabootheedpalacedockingbay.gif",
@@ -36523,7 +43260,12 @@
       "gempId": "13_76",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Naboo: Theed Palace Generator",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/nabootheedpalacegenerator.gif",
@@ -36551,7 +43293,12 @@
       "gempId": "13_77",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Naboo: Theed Palace Generator Core",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/nabootheedpalacegeneratorcore.gif",
@@ -36579,7 +43326,12 @@
       "gempId": "14_112",
       "side": "Dark",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Naboo: Theed Palace Hallway",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/nabootheedpalacehallway.gif",
@@ -36624,7 +43376,12 @@
       "gempId": "12_174",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Naboo: Theed Palace Throne Room",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/nabootheedpalacethroneroom.gif",
@@ -36652,7 +43409,12 @@
       "gempId": "6_168",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Nal Hutta",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/nalhutta.gif",
@@ -36687,7 +43449,12 @@
       "gempId": "7_190",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Nal Hutta Operative",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/nalhuttaoperative.gif",
@@ -36717,7 +43484,12 @@
       "gempId": "8_107",
       "side": "Dark",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "Navy Trooper",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/navytrooper.gif",
@@ -36747,7 +43519,12 @@
       "gempId": "8_108",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Navy Trooper Fenson",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/navytrooperfenson.gif",
@@ -36778,7 +43555,12 @@
       "gempId": "8_109",
       "side": "Dark",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•••Navy Trooper Shield Technician",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/navytroopershieldtechnician.gif",
@@ -36809,7 +43591,12 @@
       "gempId": "8_110",
       "side": "Dark",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Navy Trooper Vesden",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/navytroopervesden.gif",
@@ -36841,7 +43628,12 @@
       "gempId": "7_191",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Nebit",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/nebit.gif",
@@ -36870,7 +43662,12 @@
       "gempId": "12_154",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Neimoidian Advisor",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/neimoidianadvisor.gif",
@@ -36983,7 +43780,12 @@
       "gempId": "12_111",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Neimoidian Pilot",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/neimoidianpilot.gif",
@@ -37017,7 +43819,12 @@
       "gempId": "1_261",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Nevar Yalnal",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/nevaryalnal.gif",
@@ -37038,7 +43845,12 @@
       "gempId": "2_136",
       "side": "Dark",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Ng'ok",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/ngok.gif",
@@ -37066,7 +43878,12 @@
       "gempId": "201_32",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Ng'ok War Beast",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Dark/large/ngokwarbeast.gif",
@@ -37094,7 +43911,12 @@
       "gempId": "11_73",
       "side": "Dark",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Ni Chuba Na??",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/nichubana.gif",
@@ -37120,7 +43942,12 @@
       "id": 6538,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Ni Chuba Na?? (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/nichubana.gif",
@@ -37140,7 +43967,12 @@
       "gempId": "7_192",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Niado Duegad",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/niadoduegad.gif",
@@ -37165,7 +43997,12 @@
       "gempId": "6_115",
       "side": "Dark",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Nikto",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/nikto.gif",
@@ -37189,7 +44026,12 @@
       "gempId": "6_116",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Nizuc Bek",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/nizucbek.gif",
@@ -37213,7 +44055,12 @@
       "id": 6539,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Nizuc Bek (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/nizucbek.gif",
@@ -37238,7 +44085,12 @@
       "gempId": "7_233",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•No Bargain",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/nobargain.gif",
@@ -37258,7 +44110,12 @@
       "id": 6540,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•No Bargain (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/nobargain.gif",
@@ -37277,7 +44134,12 @@
       "gempId": "12_155",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•No Civility, Only Politics",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/nocivilityonlypolitics.gif",
@@ -37298,7 +44160,12 @@
       "gempId": "112_16",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Jabba's Palace Sealed Deck",
+      "set": "112",
+      "printings": [
+        {
+          "set": "112"
+        }
+      ],
       "front": {
         "title": "•No Escape",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalaceSealedDeck-Dark/large/noescape.gif",
@@ -37323,7 +44190,12 @@
       "gempId": "13_78",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•No Escape",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/noescape.gif",
@@ -37342,7 +44214,12 @@
       "id": 6541,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•No Escape (Premium) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Dark/large/noescapev.gif",
@@ -37361,7 +44238,12 @@
       "id": 6542,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•No Escape (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Dark/large/noescape.gif",
@@ -37381,7 +44263,12 @@
       "gempId": "13_79",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•No Match For A Sith",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/nomatchforasith.gif",
@@ -37402,7 +44289,12 @@
       "gempId": "12_180",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "No Money, No Parts, No Deal! / You're A Slave?",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/nomoneynopartsnodeal.gif",
@@ -37430,7 +44322,12 @@
       "gempId": "6_157",
       "side": "Dark",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "None Shall Pass",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/noneshallpass.gif",
@@ -37449,7 +44346,12 @@
       "id": 6544,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "None Shall Pass (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/noneshallpass.gif",
@@ -37469,7 +44371,12 @@
       "gempId": "14_67",
       "side": "Dark",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Nothing Can Get Through Our Shield",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/nothingcangetthroughourshield.gif",
@@ -37491,7 +44398,12 @@
       "id": 6545,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Nothing Can Get Through Our Shield (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/nothingcangetthroughourshield.gif",
@@ -37510,7 +44422,12 @@
       "gempId": "12_112",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Nute Gunray",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/nutegunray.gif",
@@ -37546,7 +44463,12 @@
       "id": 6546,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Nute Gunray (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/nutegunray.gif",
@@ -37573,7 +44495,12 @@
       "gempId": "210_40",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•Nute Gunray (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Dark/large/nutegunray.gif",
@@ -37601,7 +44528,12 @@
       "gempId": "14_81",
       "side": "Dark",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Nute Gunray, Neimoidian Viceroy",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/nutegunrayneimoidianviceroy.gif",
@@ -37641,7 +44573,12 @@
       "gempId": "14_82",
       "side": "Dark",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Nute Gunray, Neimoidian Viceroy (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/nutegunrayneimoidianviceroyai.gif",
@@ -37667,7 +44604,12 @@
       "id": 6549,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Nute Gunray's Bounty",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/nutegunraysbounty.gif",
@@ -37687,7 +44629,12 @@
       "gempId": "6_117",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Nysad",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/nysad.gif",
@@ -37709,7 +44656,12 @@
       "gempId": "1_204",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Observation Holocam",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/observationholocam.gif",
@@ -37725,7 +44677,12 @@
       "gempId": "9_159",
       "side": "Dark",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Obsidian 10",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/obsidian10.gif",
@@ -37759,7 +44716,12 @@
       "id": 6550,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Obsidian 10 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/obsidian10.gif",
@@ -37786,7 +44748,12 @@
       "gempId": "5_175",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Obsidian 7",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/obsidian7.gif",
@@ -37820,7 +44787,12 @@
       "gempId": "5_176",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Obsidian 8",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/obsidian8.gif",
@@ -37854,7 +44826,12 @@
       "gempId": "106_15",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Official Tournament Sealed Deck",
+      "set": "106",
+      "printings": [
+        {
+          "set": "106"
+        }
+      ],
       "front": {
         "title": "•••Obsidian Squadron TIE",
         "imageUrl": "https://res.starwarsccg.org/cards/OfficialTournamentSealedDeck-Dark/large/obsidiansquadrontie.gif",
@@ -37889,7 +44866,12 @@
       "id": 6551,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Occupied Territory",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/occupiedterritory.gif",
@@ -37908,7 +44890,12 @@
       "gempId": "2_98",
       "side": "Dark",
       "rarity": "C1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Officer Evax",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/officerevax.gif",
@@ -37936,7 +44923,12 @@
       "id": 6552,
       "side": "Dark",
       "rarity": "C1",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Officer Evax (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/officerevax.gif",
@@ -37961,7 +44953,12 @@
       "gempId": "3_130",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Oh, Switch Off",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/ohswitchoff.gif",
@@ -37982,7 +44979,12 @@
       "gempId": "8_127",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Ominous Rumors",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/ominousrumors.gif",
@@ -38007,7 +45009,12 @@
       "id": 6553,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Ominous Rumors (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/ominousrumors.gif",
@@ -38023,7 +45030,12 @@
       "gempId": "1_262",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Ommni Box",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/ommnibox.gif",
@@ -38041,7 +45053,12 @@
       "gempId": "10_44",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "Ommni Box & It's Worse",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Dark/large/ommnibox&itsworse.gif",
@@ -38063,7 +45080,12 @@
       "id": 6554,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•On The Hunt",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/onthehunt.gif",
@@ -38079,7 +45101,12 @@
       "gempId": "12_156",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•On The Payroll Of The Trade Federation",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/onthepayrollofthetradefederation.gif",
@@ -38099,7 +45126,12 @@
       "id": 6555,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•One Beautiful Thing",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/onebeautifulthing.gif",
@@ -38118,7 +45150,12 @@
       "id": 6556,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•One Bright Spot",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/onebrightspot.gif",
@@ -38138,7 +45175,12 @@
       "gempId": "7_212",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•One-Arm",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/onearm.gif",
@@ -38168,7 +45210,12 @@
       "id": 6557,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•One-Arm (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/onearm.gif",
@@ -38194,7 +45241,12 @@
       "gempId": "9_160",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Onyx 1",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/onyx1.gif",
@@ -38231,7 +45283,12 @@
       "gempId": "9_161",
       "side": "Dark",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Onyx 2",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/onyx2.gif",
@@ -38267,7 +45324,12 @@
       "id": 6558,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Onyx 2 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/onyx2.gif",
@@ -38295,7 +45357,12 @@
       "gempId": "200_136",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Onyx 2 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/onyx2.gif",
@@ -38333,7 +45400,12 @@
       "gempId": "2_137",
       "side": "Dark",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Oo-ta Goo-ta, Solo?",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/ootagootasolo.gif",
@@ -38354,7 +45426,12 @@
       "id": 6559,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Oo-ta Goo-ta, Solo? (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/ootagootasolo.gif",
@@ -38374,7 +45451,12 @@
       "gempId": "210_41",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "Oo-ta Goo-ta, Solo? (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Dark/large/ootagootasolo.gif",
@@ -38393,7 +45475,12 @@
       "id": 6561,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "••OOM Command Battle Droid",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/oomcommandbattledroid.gif",
@@ -38422,7 +45509,12 @@
       "gempId": "14_83",
       "side": "Dark",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•OOM-9",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/oom9.gif",
@@ -38466,7 +45558,12 @@
       "id": 6562,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•OOM-9 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/oom9.gif",
@@ -38495,7 +45592,12 @@
       "gempId": "13_80",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Opee Sea Killer",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/opeeseakiller.gif",
@@ -38526,7 +45628,12 @@
       "gempId": "14_99",
       "side": "Dark",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Open Fire!",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/openfire.gif",
@@ -38551,7 +45658,12 @@
       "gempId": "9_138",
       "side": "Dark",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Operational As Planned",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/operationalasplanned.gif",
@@ -38571,7 +45683,12 @@
       "id": 6563,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Operational As Planned (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/operationalasplanned.gif",
@@ -38591,7 +45708,12 @@
       "gempId": "208_44",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Operational As Planned (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/operationalasplanned.gif",
@@ -38613,7 +45735,12 @@
       "gempId": "13_81",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Oppressive Enforcement",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/oppressiveenforcement.gif",
@@ -38634,7 +45761,12 @@
       "gempId": "7_234",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Oppressive Enforcement",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/oppressiveenforcement.gif",
@@ -38660,7 +45792,12 @@
       "gempId": "3_151",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Ord Mantell",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/ordmantell.gif",
@@ -38689,7 +45826,12 @@
       "gempId": "7_193",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Ord Mantell Operative",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/ordmantelloperative.gif",
@@ -38718,7 +45860,12 @@
       "id": 6564,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Order 66",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/order66.gif",
@@ -38738,7 +45885,12 @@
       "gempId": "1_226",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Organa's Ceremonial Necklace",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/organasceremonialnecklace.gif",
@@ -38759,7 +45911,12 @@
       "id": 6565,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Organa's Ceremonial Necklace (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/organasceremonialnecklace.gif",
@@ -38775,7 +45932,12 @@
       "gempId": "12_113",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Orn Free Taa",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/ornfreetaa.gif",
@@ -38811,7 +45973,12 @@
       "gempId": "6_118",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Ortugg",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/ortugg.gif",
@@ -38836,7 +46003,12 @@
       "gempId": "203_28",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•Ortugg (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Dark/large/ortugg.gif",
@@ -38867,7 +46039,12 @@
       "gempId": "7_305",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•OS-72-1 In Obsidian 1",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/os721inobsidian1.gif",
@@ -38901,7 +46078,12 @@
       "gempId": "7_194",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•OS-72-10",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/os7210.gif",
@@ -38933,7 +46115,12 @@
       "gempId": "7_306",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•OS-72-2 In Obsidian 2",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/os722inobsidian2.gif",
@@ -38967,7 +46154,12 @@
       "gempId": "12_138",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Our Blockade Is Perfectly Legal",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/ourblockadeisperfectlylegal.gif",
@@ -38999,7 +46191,12 @@
       "gempId": "3_131",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Our First Catch Of The Day",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/ourfirstcatchoftheday.gif",
@@ -39026,7 +46223,12 @@
       "gempId": "7_195",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Outer Rim Scout",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/outerrimscout.gif",
@@ -39059,7 +46261,12 @@
       "gempId": "8_150",
       "side": "Dark",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Outflank",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/outflank.gif",
@@ -39080,7 +46287,12 @@
       "id": 6566,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Outflank (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/outflank.gif",
@@ -39100,7 +46312,12 @@
       "gempId": "1_263",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Overload",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/overload.gif",
@@ -39122,7 +46339,12 @@
       "gempId": "9_130",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Overseeing It Personally",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/overseeingitpersonally.gif",
@@ -39151,7 +46373,12 @@
       "gempId": "205_18",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 5",
+      "set": "205",
+      "printings": [
+        {
+          "set": "205"
+        }
+      ],
       "front": {
         "title": "•Overseeing It Personally (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual5-Dark/large/overseeingitpersonally.gif",
@@ -39181,7 +46408,12 @@
       "gempId": "7_258",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Overwhelmed",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/overwhelmed.gif",
@@ -39198,7 +46430,12 @@
       "gempId": "14_84",
       "side": "Dark",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•OWO-1 With Backup",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/owo1withbackup.gif",
@@ -39238,7 +46475,12 @@
       "id": 6567,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•P-13 & •P-14",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/p13&p14.gif",
@@ -39268,7 +46510,12 @@
       "gempId": "12_114",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•P-59",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/p59.gif",
@@ -39305,7 +46552,12 @@
       "gempId": "12_115",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•P-60",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/p60.gif",
@@ -39341,7 +46593,12 @@
       "gempId": "12_116",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Passel Argente",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/passelargente.gif",
@@ -39373,7 +46630,12 @@
       "gempId": "7_315",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Patrol Craft",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/patrolcraft.gif",
@@ -39399,7 +46661,12 @@
       "gempId": "8_128",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Perimeter Patrol",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/perimeterpatrol.gif",
@@ -39426,7 +46693,12 @@
       "gempId": "1_264",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Physical Choke",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/physicalchoke.gif",
@@ -39443,7 +46715,12 @@
       "gempId": "8_129",
       "side": "Dark",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Pinned Down",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/pinneddown.gif",
@@ -39465,7 +46742,12 @@
       "id": 6568,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Pinned Down (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/pinneddown.gif",
@@ -39484,7 +46766,12 @@
       "gempId": "11_84",
       "side": "Dark",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Pit Crews",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/pitcrews.gif",
@@ -39508,7 +46795,12 @@
       "gempId": "11_60",
       "side": "Dark",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "Pit Droid",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/pitdroid.gif",
@@ -39534,7 +46826,12 @@
       "gempId": "8_151",
       "side": "Dark",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Pitiful Little Band",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/pitifullittleband.gif",
@@ -39552,7 +46849,12 @@
       "gempId": "7_235",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Planetary Subjugation",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/planetarysubjugation.gif",
@@ -39576,7 +46878,12 @@
       "gempId": "11_85",
       "side": "Dark",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Podracer Collision",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/podracercollision.gif",
@@ -39603,7 +46910,12 @@
       "gempId": "5_147",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Point Man",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/pointman.gif",
@@ -39638,7 +46950,12 @@
       "gempId": "205_20",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 5",
+      "set": "205",
+      "printings": [
+        {
+          "set": "205"
+        }
+      ],
       "front": {
         "title": "Point Man (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual5-Dark/large/pointman.gif",
@@ -39659,7 +46976,12 @@
       "gempId": "1_190",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Ponda Baba",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/pondababa.gif",
@@ -39695,7 +47017,12 @@
       "id": 6569,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Ponda Baba (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/pondababa.gif",
@@ -39721,7 +47048,12 @@
       "gempId": "200_87",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Ponda Baba (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/pondababa.gif",
@@ -39755,7 +47087,12 @@
       "gempId": "7_323",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Ponda Baba's Hold-out Blaster",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/pondababasholdoutblaster.gif",
@@ -39780,7 +47117,12 @@
       "gempId": "3_96",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Portable Fusion Generator",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/portablefusiongenerator.gif",
@@ -39801,7 +47143,12 @@
       "gempId": "6_119",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Pote Snitkin",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/potesnitkin.gif",
@@ -39833,7 +47180,12 @@
       "gempId": "202_11",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 2",
+      "set": "202",
+      "printings": [
+        {
+          "set": "202"
+        }
+      ],
       "front": {
         "title": "•Pote Snitkin (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual2-Dark/large/potesnitkin.gif",
@@ -39867,7 +47219,12 @@
       "gempId": "112_17",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Jabba's Palace Sealed Deck",
+      "set": "112",
+      "printings": [
+        {
+          "set": "112"
+        }
+      ],
       "front": {
         "title": "•Power Of The Hutt",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalaceSealedDeck-Dark/large/powerofthehutt.gif",
@@ -39897,7 +47254,12 @@
       "id": 6570,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Power Of The Sith",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/powerofthesith.gif",
@@ -39917,7 +47279,12 @@
       "gempId": "1_265",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Precise Attack",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/preciseattack.gif",
@@ -39935,7 +47302,12 @@
       "gempId": "4_129",
       "side": "Dark",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Precision Targeting",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/precisiontargeting.gif",
@@ -39955,7 +47327,12 @@
       "id": 6571,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Precision Targeting (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/precisiontargeting.gif",
@@ -39974,7 +47351,12 @@
       "gempId": "13_82",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Prepare For A Surface Attack",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/prepareforasurfaceattack.gif",
@@ -39999,7 +47381,12 @@
       "gempId": "209_42",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Prepare For A Surface Attack (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Dark/large/prepareforasurfaceattack.gif",
@@ -40015,7 +47402,12 @@
       "gempId": "5_148",
       "side": "Dark",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Prepare The Chamber",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/preparethechamber.gif",
@@ -40039,7 +47431,12 @@
       "gempId": "9_139",
       "side": "Dark",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Prepared Defenses",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/prepareddefenses.gif",
@@ -40057,7 +47454,12 @@
       "id": 6573,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Prepared Defenses (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/prepareddefenses.gif",
@@ -40077,7 +47479,12 @@
       "gempId": "1_227",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "••Presence Of The Force",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/presenceoftheforce.gif",
@@ -40104,7 +47511,12 @@
       "gempId": "7_236",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Pride Of The Empire",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/prideoftheempire.gif",
@@ -40132,7 +47544,12 @@
       "id": 6574,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Pride Of The Empire (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/prideoftheempire.gif",
@@ -40153,7 +47570,12 @@
       "gempId": "211_9",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Pride Of The Empire (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Dark/large/prideoftheempire.gif",
@@ -40170,7 +47592,12 @@
       "gempId": "10_45",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Prince Xizor",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Dark/large/princexizor.gif",
@@ -40209,7 +47636,12 @@
       "id": 6576,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Prince Xizor (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/princexizor.gif",
@@ -40238,7 +47670,12 @@
       "gempId": "3_97",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Probe Antennae",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/probeantennae.gif",
@@ -40254,7 +47691,12 @@
       "gempId": "3_90",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Probe Droid",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/probedroid.gif",
@@ -40287,7 +47729,12 @@
       "id": 6577,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Probe Droid (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/probedroid.gif",
@@ -40314,7 +47761,12 @@
       "gempId": "3_161",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Probe Droid Laser",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/probedroidlaser.gif",
@@ -40335,7 +47787,12 @@
       "gempId": "3_132",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Probe Telemetry",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/probetelemetry.gif",
@@ -40354,7 +47811,12 @@
       "id": 6578,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Probe Telemetry (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/probetelemetry.gif",
@@ -40373,7 +47835,12 @@
       "id": 6579,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Probot",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/probot.gif",
@@ -40401,7 +47868,12 @@
       "gempId": "200_88",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Probot",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/probot.gif",
@@ -40436,7 +47908,12 @@
       "gempId": "2_124",
       "side": "Dark",
       "rarity": "U1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Program Trap",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/programtrap.gif",
@@ -40463,7 +47940,12 @@
       "id": 6580,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Program Trap (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/programtrap.gif",
@@ -40482,7 +47964,12 @@
       "gempId": "5_149",
       "side": "Dark",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Projective Telepathy",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/projectivetelepathy.gif",
@@ -40505,7 +47992,12 @@
       "gempId": "1_191",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Prophetess",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/prophetess.gif",
@@ -40532,7 +48024,12 @@
       "id": 6581,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Prophetess (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/prophetess.gif",
@@ -40555,7 +48052,12 @@
       "id": 6582,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "Protocol Failure",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/protocolfailure.gif",
@@ -40575,7 +48077,12 @@
       "gempId": "4_179",
       "side": "Dark",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Proton Bombs",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/protonbombs.gif",
@@ -40596,7 +48103,12 @@
       "gempId": "4_171",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Punishing One",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/punishingone.gif",
@@ -40633,7 +48145,12 @@
       "id": 6583,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Punishing One (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/punishingone.gif",
@@ -40661,7 +48178,12 @@
       "gempId": "207_29",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 7",
+      "set": "207",
+      "printings": [
+        {
+          "set": "207"
+        }
+      ],
       "front": {
         "title": "•Punishing One (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual7-Dark/large/punishingone.gif",
@@ -40699,7 +48221,12 @@
       "gempId": "7_259",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Put All Sections On Alert",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/putallsectionsonalert.gif",
@@ -40717,7 +48244,12 @@
       "gempId": "6_120",
       "side": "Dark",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Quarren",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/quarren.gif",
@@ -40738,7 +48270,12 @@
       "gempId": "13_83",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Qui-Gon's End",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/quigonsend.gif",
@@ -40768,7 +48305,12 @@
       "gempId": "6_146",
       "side": "Dark",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Quick Reflexes",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/quickreflexes.gif",
@@ -40792,7 +48334,12 @@
       "gempId": "11_74",
       "side": "Dark",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Quietly Observing",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/quietlyobserving.gif",
@@ -40818,7 +48365,12 @@
       "id": 6584,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Quietly Observing (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/quietlyobserving.gif",
@@ -40838,7 +48390,12 @@
       "gempId": "211_10",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Quietly Observing (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Dark/large/quietlyobserving.gif",
@@ -40858,7 +48415,12 @@
       "gempId": "207_22",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 7",
+      "set": "207",
+      "printings": [
+        {
+          "set": "207"
+        }
+      ],
       "front": {
         "title": "•Quiggold",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual7-Dark/large/quiggold.gif",
@@ -40891,7 +48453,12 @@
       "gempId": "1_192",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "R1-G4 (Arone-Geefour)",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/r1g4.gif",
@@ -40920,7 +48487,12 @@
       "gempId": "7_196",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•R2-A5 (Artoo-Ayfive)",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/r2a5.gif",
@@ -40949,7 +48521,12 @@
       "id": 6587,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•R2-A5 (Artoo-Ayfive) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/r2a5.gif",
@@ -40976,7 +48553,12 @@
       "gempId": "2_99",
       "side": "Dark",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "R2-Q2 (Artoo-Kyootoo)",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/r2q2.gif",
@@ -41005,7 +48587,12 @@
       "gempId": "2_100",
       "side": "Dark",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•R3-T6 (Arthree-Teesix)",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/r3t6.gif",
@@ -41041,7 +48628,12 @@
       "gempId": "1_193",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "R4-M9 (Arfour-Emmnine)",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/r4m9.gif",
@@ -41068,7 +48660,12 @@
       "gempId": "2_101",
       "side": "Dark",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "R5-A2 (Arfive-Aytoo)",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/r5a2.gif",
@@ -41098,7 +48695,12 @@
       "gempId": "11_61",
       "side": "Dark",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Rachalt Hyst",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/rachalthyst.gif",
@@ -41127,7 +48729,12 @@
       "gempId": "112_18",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Jabba's Palace Sealed Deck",
+      "set": "112",
+      "printings": [
+        {
+          "set": "112"
+        }
+      ],
       "front": {
         "title": "Racing Skiff",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalaceSealedDeck-Dark/large/racingskiff.gif",
@@ -41152,7 +48759,12 @@
       "id": 6588,
       "side": "Dark",
       "rarity": "F",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "Raider Craft",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/raidercraft.gif",
@@ -41179,7 +48791,12 @@
       "gempId": "4_164",
       "side": "Dark",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Raithal",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/raithal.gif",
@@ -41207,7 +48824,12 @@
       "gempId": "7_197",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Raithal Operative",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/raithaloperative.gif",
@@ -41237,7 +48859,12 @@
       "gempId": "2_148",
       "side": "Dark",
       "rarity": "C1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Ralltiir",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/ralltiir.gif",
@@ -41261,7 +48888,12 @@
       "gempId": "7_300",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Ralltiir Operations / In The Hands Of The Empire",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/ralltiiroperations.gif",
@@ -41283,7 +48915,12 @@
       "gempId": "210_42",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "Ralltiir Operations / In The Hands Of The Empire (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Dark/large/ralltiiroperations.gif",
@@ -41304,7 +48941,12 @@
       "id": 6591,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Ralltiir: Spaceport Financial District",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/ralltiirspaceportfinancialdistrict.gif",
@@ -41325,7 +48967,12 @@
       "id": 6592,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Ralltiir: Supply Route",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/ralltiirsupplyroute.gif",
@@ -41345,7 +48992,12 @@
       "id": 6593,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Rally To Our Cause",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/rallytoourcause.gif",
@@ -41364,7 +49016,12 @@
       "gempId": "6_139",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Rancor",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/rancor.gif",
@@ -41392,7 +49049,12 @@
       "id": 6594,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "Rancor Mount",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/rancormount.gif",
@@ -41417,7 +49079,12 @@
       "gempId": "7_198",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Rappertunie",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/rappertunie.gif",
@@ -41445,7 +49112,12 @@
       "gempId": "14_85",
       "side": "Dark",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Rayno Vaca",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/raynovaca.gif",
@@ -41473,7 +49145,12 @@
       "gempId": "1_228",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Reactor Terminal",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/reactorterminal.gif",
@@ -41493,7 +49170,12 @@
       "id": 6595,
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "Reactor Terminal (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Dark/large/reactorterminal.gif",
@@ -41512,7 +49194,12 @@
       "gempId": "7_237",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Rebel Base Occupation",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/rebelbaseoccupation.gif",
@@ -41537,7 +49224,12 @@
       "gempId": "6_121",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Ree-Yees",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/reeyees.gif",
@@ -41575,7 +49267,12 @@
       "gempId": "211_5",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Ree-Yees (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Dark/large/reeyees.gif",
@@ -41603,7 +49300,12 @@
       "gempId": "2_102",
       "side": "Dark",
       "rarity": "U2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Reegesk",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/reegesk.gif",
@@ -41631,7 +49333,12 @@
       "id": 6597,
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Reegesk (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/reegesk.gif",
@@ -41655,7 +49362,12 @@
       "gempId": "5_150",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Release Your Anger",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/releaseyouranger.gif",
@@ -41673,7 +49385,12 @@
       "id": 6598,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Release Your Anger (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/releaseyouranger.gif",
@@ -41694,7 +49411,12 @@
       "gempId": "7_260",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Relentless Pursuit",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/relentlesspursuit.gif",
@@ -41713,7 +49435,12 @@
       "gempId": "8_130",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Relentless Tracking",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/relentlesstracking.gif",
@@ -41735,7 +49462,12 @@
       "id": 6599,
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "<>Remote Depot",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/remotedepot.gif",
@@ -41756,7 +49488,12 @@
       "gempId": "7_287",
       "side": "Dark",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Rendili",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/rendili.gif",
@@ -41785,7 +49522,12 @@
       "gempId": "7_238",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Rendili StarDrive",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/rendilistardrive.gif",
@@ -41806,7 +49548,12 @@
       "gempId": "4_146",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Res Luk Ra'auf",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/reslukraauf.gif",
@@ -41828,7 +49575,12 @@
       "gempId": "2_103",
       "side": "Dark",
       "rarity": "U1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "••Reserve Pilot",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/reservepilot.gif",
@@ -41858,7 +49610,12 @@
       "id": 6600,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "••Reserve Pilot (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/reservepilot.gif",
@@ -41883,7 +49640,12 @@
       "gempId": "6_147",
       "side": "Dark",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Resistance",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/resistance.gif",
@@ -41905,7 +49667,12 @@
       "gempId": "13_84",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Resistance",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/resistance.gif",
@@ -41926,7 +49693,12 @@
       "gempId": "3_109",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Responsibility Of Command",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/responsibilityofcommand.gif",
@@ -41952,7 +49724,12 @@
       "gempId": "1_205",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Restraining Bolt",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/restrainingbolt.gif",
@@ -41969,7 +49746,12 @@
       "gempId": "5_122",
       "side": "Dark",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Restricted Access",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/restrictedaccess.gif",
@@ -41996,7 +49778,12 @@
       "gempId": "2_138",
       "side": "Dark",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Retract The Bridge",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/retractthebridge.gif",
@@ -42019,7 +49806,12 @@
       "gempId": "7_239",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Return To Base",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/returntobase.gif",
@@ -42039,7 +49831,12 @@
       "id": 6601,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Revenge Of The Sith",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/revengeofthesith.gif",
@@ -42057,7 +49854,12 @@
       "id": 6602,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Rise Of The Dark Lord",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/riseofthedarklord.gif",
@@ -42076,7 +49878,12 @@
       "gempId": "9_140",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Rise, My Friend",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/risemyfriend.gif",
@@ -42094,7 +49901,12 @@
       "gempId": "5_151",
       "side": "Dark",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Rite Of Passage",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/riteofpassage.gif",
@@ -42118,7 +49930,12 @@
       "gempId": "7_213",
       "side": "Dark",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Rock Wart",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/rockwart.gif",
@@ -42150,7 +49967,12 @@
       "gempId": "2_104",
       "side": "Dark",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•••Rodian",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/rodian.gif",
@@ -42181,7 +50003,12 @@
       "id": 6603,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•••Rodian (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/rodian.gif",
@@ -42206,7 +50033,12 @@
       "gempId": "4_130",
       "side": "Dark",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "<>Rogue Asteroid",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/rogueasteroid.gif",
@@ -42232,7 +50064,12 @@
       "id": 6604,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Rogue Shadow",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/rogueshadow.gif",
@@ -42258,7 +50095,12 @@
       "gempId": "14_105",
       "side": "Dark",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Rolling, Rolling, Rolling",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/rollingrollingrolling.gif",
@@ -42278,7 +50120,12 @@
       "gempId": "7_316",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Ronto",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/ronto.gif",
@@ -42301,7 +50148,12 @@
       "gempId": "9_131",
       "side": "Dark",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Royal Escort",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/royalescort.gif",
@@ -42326,7 +50178,12 @@
       "id": 6606,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Royal Escort (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/royalescort.gif",
@@ -42345,7 +50202,12 @@
       "gempId": "9_119",
       "side": "Dark",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "Royal Guard",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/royalguard.gif",
@@ -42376,7 +50238,12 @@
       "gempId": "7_199",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•RR'uruurrr",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/rruruurrr.gif",
@@ -42406,7 +50273,12 @@
       "id": 6607,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•R'tic H'weei",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/rtichweei.gif",
@@ -42427,7 +50299,12 @@
       "gempId": "200_89",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•R'tic H'weei",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/rtichweei.gif",
@@ -42461,7 +50338,12 @@
       "gempId": "12_117",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Rune Haako",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/runehaako.gif",
@@ -42503,7 +50385,12 @@
       "gempId": "14_86",
       "side": "Dark",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Rune Haako, Legal Counsel",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/runehaakolegalcounsel.gif",
@@ -42540,7 +50427,12 @@
       "gempId": "14_87",
       "side": "Dark",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Rune Haako, Legal Counsel (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/runehaakolegalcounselai.gif",
@@ -42567,7 +50459,12 @@
       "gempId": "7_200",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Rystall",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/rystall.gif",
@@ -42598,7 +50495,12 @@
       "gempId": "9_162",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Saber 1",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/saber1.gif",
@@ -42637,7 +50539,12 @@
       "gempId": "9_163",
       "side": "Dark",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Saber 2",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/saber2.gif",
@@ -42673,7 +50580,12 @@
       "gempId": "9_164",
       "side": "Dark",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Saber 3",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/saber3.gif",
@@ -42709,7 +50621,12 @@
       "gempId": "9_165",
       "side": "Dark",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Saber 4",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/saber4.gif",
@@ -42744,7 +50661,12 @@
       "id": 6609,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•••Saber Squadron Pilot",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/sabersquadronpilot.gif",
@@ -42768,7 +50690,12 @@
       "id": 6610,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•••Saber Squadron TIE",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/sabersquadrontie.gif",
@@ -42795,7 +50722,12 @@
       "gempId": "7_261",
       "side": "Dark",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Sacrifice",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/sacrifice.gif",
@@ -42813,7 +50745,12 @@
       "id": 6611,
       "side": "Dark",
       "rarity": "F",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Sacrifice (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/sacrifice.gif",
@@ -42833,7 +50770,12 @@
       "gempId": "6_122",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Salacious Crumb",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/salaciouscrumb.gif",
@@ -42857,7 +50799,12 @@
       "id": 6612,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Salacious Crumb (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/salaciouscrumb.gif",
@@ -42878,7 +50825,12 @@
       "gempId": "1_309",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Sandcrawler",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/sandcrawler.gif",
@@ -42904,7 +50856,12 @@
       "id": 6613,
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Sandcrawler (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/sandcrawler.gif",
@@ -42929,7 +50886,12 @@
       "gempId": "2_149",
       "side": "Dark",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•••Sandcrawler: Droid Junkheap",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/sandcrawlerdroidjunkheap.gif",
@@ -42953,7 +50915,12 @@
       "gempId": "13_85",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Sando Aqua Monster",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/sandoaquamonster.gif",
@@ -42981,7 +50948,12 @@
       "gempId": "7_201",
       "side": "Dark",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Sandtrooper",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/sandtrooper.gif",
@@ -43012,7 +50984,12 @@
       "id": 6614,
       "side": "Dark",
       "rarity": "F",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Sandtrooper (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/sandtrooper.gif",
@@ -43037,7 +51014,12 @@
       "gempId": "6_148",
       "side": "Dark",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "<>Sandwhirl",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/sandwhirl.gif",
@@ -43060,7 +51042,15 @@
       "gempId": "7_214",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "107"
+        },
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Sarlacc",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/sarlacc.gif",
@@ -43086,7 +51076,12 @@
       "id": 6615,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Sarlacc (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/sarlacc.gif",
@@ -43108,7 +51103,12 @@
       "id": 6616,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Sate Pestage",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/satepestage.gif",
@@ -43133,7 +51133,12 @@
       "gempId": "207_23",
       "side": "Dark",
       "rarity": "F",
-      "set": "Virtual Set 7",
+      "set": "207",
+      "printings": [
+        {
+          "set": "207"
+        }
+      ],
       "front": {
         "title": "Savage Opress",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual7-Dark/large/savageopress.gif",
@@ -43161,7 +51166,12 @@
       "gempId": "1_266",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Scanning Crew",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/scanningcrew.gif",
@@ -43191,7 +51201,12 @@
       "gempId": "9_166",
       "side": "Dark",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Scimitar 1",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/scimitar1.gif",
@@ -43227,7 +51242,12 @@
       "gempId": "9_167",
       "side": "Dark",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Scimitar 2",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/scimitar2.gif",
@@ -43266,7 +51286,12 @@
       "gempId": "9_168",
       "side": "Dark",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•••Scimitar Squadron TIE",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/scimitarsquadrontie.gif",
@@ -43303,7 +51328,12 @@
       "gempId": "8_179",
       "side": "Dark",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "Scout Blaster",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/scoutblaster.gif",
@@ -43334,7 +51364,12 @@
       "id": 6617,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "Scout Mercenary",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/scoutmercenary.gif",
@@ -43360,7 +51395,12 @@
       "gempId": "8_152",
       "side": "Dark",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Scout Recon",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/scoutrecon.gif",
@@ -43381,7 +51421,12 @@
       "id": 6618,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Scout Recon (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/scoutrecon.gif",
@@ -43401,7 +51446,12 @@
       "gempId": "3_133",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Scruffy-Looking Nerf Herder",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/scruffylookingnerfherder.gif",
@@ -43426,7 +51476,12 @@
       "gempId": "6_149",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Scum And Villainy",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/scumandvillainy.gif",
@@ -43453,7 +51508,12 @@
       "gempId": "9_169",
       "side": "Dark",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Scythe 1",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/scythe1.gif",
@@ -43488,7 +51548,12 @@
       "gempId": "9_170",
       "side": "Dark",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Scythe 3",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/scythe3.gif",
@@ -43523,7 +51588,12 @@
       "gempId": "9_171",
       "side": "Dark",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•••Scythe Squadron TIE",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/scythesquadrontie.gif",
@@ -43558,7 +51628,12 @@
       "id": 6619,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "SD-17 Homing Missile",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/sd17homingmissile.gif",
@@ -43579,7 +51654,12 @@
       "gempId": "8_131",
       "side": "Dark",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Search And Destroy",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/searchanddestroy.gif",
@@ -43603,7 +51683,12 @@
       "gempId": "11_62",
       "side": "Dark",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Sebulba",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/sebulba.gif",
@@ -43633,7 +51718,12 @@
       "gempId": "11_63",
       "side": "Dark",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Sebulba (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/sebulbaai.gif",
@@ -43657,7 +51747,12 @@
       "id": 6621,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Sebulba (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/sebulba.gif",
@@ -43685,7 +51780,12 @@
       "gempId": "211_6",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Sebulba (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Dark/large/sebulba.gif",
@@ -43710,7 +51810,12 @@
       "id": 6623,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Sebulba (V) (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/sebulbaai.gif",
@@ -43738,7 +51843,12 @@
       "gempId": "211_61",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Sebulba (V) (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Dark/large/sebulbaai.gif",
@@ -43764,7 +51874,12 @@
       "gempId": "11_97",
       "side": "Dark",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Sebulba's Podracer",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/sebulbaspodracer.gif",
@@ -43784,7 +51899,12 @@
       "gempId": "13_86",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Secret Plans",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/secretplans.gif",
@@ -43805,7 +51925,12 @@
       "gempId": "7_240",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Secret Plans",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/secretplans.gif",
@@ -43831,7 +51956,12 @@
       "gempId": "12_118",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Security Battle Droid",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/securitybattledroid.gif",
@@ -43869,7 +51999,12 @@
       "id": 6625,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "Security Battle Droid (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/securitybattledroid.gif",
@@ -43898,7 +52033,12 @@
       "gempId": "8_132",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Security Precautions",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/securityprecautions.gif",
@@ -43924,7 +52064,12 @@
       "id": 6626,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Security Precautions (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/securityprecautions.gif",
@@ -43944,7 +52089,12 @@
       "gempId": "207_26",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 7",
+      "set": "207",
+      "printings": [
+        {
+          "set": "207"
+        }
+      ],
       "front": {
         "title": "•Security Precautions (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual7-Dark/large/securityprecautions.gif",
@@ -43971,7 +52121,12 @@
       "gempId": "3_134",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Self-Destruct Mechanism",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/selfdestructmechanism.gif",
@@ -43988,7 +52143,12 @@
       "id": 6627,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Self-Destruct Mechanism (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/selfdestructmechanism.gif",
@@ -44008,7 +52168,12 @@
       "gempId": "14_100",
       "side": "Dark",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "Senate Hovercam",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/senatehovercam.gif",
@@ -44033,7 +52198,12 @@
       "gempId": "1_229",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Send A Detachment Down",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/sendadetachmentdown.gif",
@@ -44054,7 +52224,12 @@
       "id": 6628,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Send A Detachment Down (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/sendadetachmentdown.gif",
@@ -44071,7 +52246,12 @@
       "gempId": "12_157",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Sense",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/sense.gif",
@@ -44108,7 +52288,12 @@
       "gempId": "1_267",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Sense",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/sense.gif",
@@ -44142,7 +52327,12 @@
       "gempId": "10_46",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "Sense & Uncertain Is The Future",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Dark/large/sense&uncertainisthefuture.gif",
@@ -44169,7 +52359,12 @@
       "gempId": "7_307",
       "side": "Dark",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Sentinel-Class Landing Craft",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/sentinelclasslandingcraft.gif",
@@ -44203,7 +52398,12 @@
       "id": 6629,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "Separatist Uprising / At War With Itself",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/separatistuprising.gif",
@@ -44231,7 +52431,12 @@
       "gempId": "8_111",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Sergeant Barich",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/sergeantbarich.gif",
@@ -44267,7 +52472,12 @@
       "gempId": "8_112",
       "side": "Dark",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Sergeant Elsek",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/sergeantelsek.gif",
@@ -44306,7 +52516,12 @@
       "gempId": "8_113",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Sergeant Irol",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/sergeantirol.gif",
@@ -44341,7 +52556,12 @@
       "id": 6630,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Sergeant Irol (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/sergeantirol.gif",
@@ -44366,7 +52586,12 @@
       "gempId": "7_202",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Sergeant Major Bursk",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/sergeantmajorbursk.gif",
@@ -44399,7 +52624,12 @@
       "id": 6631,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Sergeant Major Bursk (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/sergeantmajorbursk.gif",
@@ -44424,7 +52654,12 @@
       "gempId": "7_203",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Sergeant Major Enfield",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/sergeantmajorenfield.gif",
@@ -44458,7 +52693,12 @@
       "gempId": "7_204",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Sergeant Merril",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/sergeantmerril.gif",
@@ -44491,7 +52731,12 @@
       "gempId": "7_205",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Sergeant Narthax",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/sergeantnarthax.gif",
@@ -44524,7 +52769,12 @@
       "gempId": "211_7",
       "side": "Dark",
       "rarity": "C1",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Sergeant Narthax With E-web Blaster",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Dark/large/sergeantnarthaxwithewebblaster.gif",
@@ -44549,7 +52799,12 @@
       "gempId": "8_114",
       "side": "Dark",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Sergeant Tarl",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/sergeanttarl.gif",
@@ -44582,7 +52837,12 @@
       "gempId": "7_206",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Sergeant Torent",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/sergeanttorent.gif",
@@ -44614,7 +52874,12 @@
       "id": 6633,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Sergeant Torent (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/sergeanttorent.gif",
@@ -44639,7 +52904,12 @@
       "gempId": "8_115",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Sergeant Wallen",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/sergeantwallen.gif",
@@ -44670,7 +52940,12 @@
       "id": 6634,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Sergeant Wallen (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/sergeantwallen.gif",
@@ -44695,7 +52970,12 @@
       "gempId": "1_268",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Set For Stun",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/setforstun.gif",
@@ -44723,7 +53003,12 @@
       "gempId": "111_6",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Third Anthology",
+      "set": "111",
+      "printings": [
+        {
+          "set": "111"
+        }
+      ],
       "front": {
         "title": "Set Your Course For Alderaan / The Ultimate Power In The Universe",
         "imageUrl": "https://res.starwarsccg.org/cards/ThirdAnthology-Dark/large/setyourcourseforalderaan.gif",
@@ -44745,7 +53030,12 @@
       "gempId": "9_181",
       "side": "Dark",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "SFS L-s7.2 TIE Cannon",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/sfsls72tiecannon.gif",
@@ -44769,7 +53059,12 @@
       "gempId": "7_324",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "SFS L-s9.3 Laser Cannons",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/sfsls93lasercannons.gif",
@@ -44796,7 +53091,12 @@
       "id": 6636,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Shada",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/shada.gif",
@@ -44822,7 +53122,12 @@
       "id": 6637,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Shadows Of The Empire",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/shadowsoftheempire.gif",
@@ -44841,7 +53146,12 @@
       "gempId": "209_43",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Shadows Of The Empire",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Dark/large/shadowsoftheempire.gif",
@@ -44857,7 +53167,12 @@
       "gempId": "5_152",
       "side": "Dark",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Shattered Hope",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/shatteredhope.gif",
@@ -44875,7 +53190,12 @@
       "gempId": "5_153",
       "side": "Dark",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Shocking Revelation",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/shockingrevelation.gif",
@@ -44899,7 +53219,12 @@
       "id": 6639,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Shocking Revelation (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/shockingrevelation.gif",
@@ -44919,7 +53244,12 @@
       "gempId": "12_158",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Short Range Fighters & •Watch Your Back!",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/shortrangefighters&watchyourback.gif",
@@ -44969,7 +53299,12 @@
       "gempId": "7_262",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Short-range Fighters",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/shortrangefighters.gif",
@@ -44986,7 +53321,12 @@
       "gempId": "4_131",
       "side": "Dark",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Shot In The Dark",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/shotinthedark.gif",
@@ -45007,7 +53347,12 @@
       "gempId": "4_147",
       "side": "Dark",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Shut Him Up Or Shut Him Down",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/shuthimuporshuthimdown.gif",
@@ -45035,7 +53380,12 @@
       "id": 6641,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Sidious' Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/sidiouslightsaber.gif",
@@ -45054,7 +53404,12 @@
       "gempId": "207_24",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 7",
+      "set": "207",
+      "printings": [
+        {
+          "set": "207"
+        }
+      ],
       "front": {
         "title": "•Sidon Ithano",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual7-Dark/large/sidonithano.gif",
@@ -45088,7 +53443,12 @@
       "gempId": "7_241",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Sienar Fleet Systems",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/sienarfleetsystems.gif",
@@ -45112,7 +53472,12 @@
       "gempId": "14_88",
       "side": "Dark",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Sil Unch",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/silunch.gif",
@@ -45147,7 +53512,12 @@
       "gempId": "3_110",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Silence Is Golden",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/silenceisgolden.gif",
@@ -45171,7 +53541,12 @@
       "gempId": "210_45",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "Silence Is Golden (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Dark/large/silenceisgolden.gif",
@@ -45187,7 +53562,12 @@
       "gempId": "9_120",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Sim Aloo",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/simaloo.gif",
@@ -45214,7 +53594,12 @@
       "id": 6643,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Sim Aloo (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/simaloo.gif",
@@ -45238,7 +53623,12 @@
       "gempId": "205_15",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 5",
+      "set": "205",
+      "printings": [
+        {
+          "set": "205"
+        }
+      ],
       "front": {
         "title": "•Sim Aloo (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual5-Dark/large/simaloo.gif",
@@ -45266,7 +53656,12 @@
       "gempId": "14_123",
       "side": "Dark",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "Single Trooper Aerial Platform",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/singletrooperaerialplatform.gif",
@@ -45295,7 +53690,12 @@
       "gempId": "11_86",
       "side": "Dark",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Sith Fury",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/sithfury.gif",
@@ -45312,7 +53712,12 @@
       "id": 6644,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Sith Fury & End This Destructive Conflict",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/sithfury&endthisdestructiveconflict.gif",
@@ -45328,7 +53733,12 @@
       "id": 6645,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Sith Fury (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/sithfury.gif",
@@ -45348,7 +53758,12 @@
       "gempId": "200_123",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Sith Fury (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/sithfury.gif",
@@ -45396,7 +53811,12 @@
       "gempId": "11_64",
       "side": "Dark",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "Sith Probe Droid",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/sithprobedroid.gif",
@@ -45426,7 +53846,12 @@
       "id": 6646,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "Sith Probe Droid (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/sithprobedroid.gif",
@@ -45455,7 +53880,12 @@
       "gempId": "200_90",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "Sith Probe Droid (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/sithprobedroid.gif",
@@ -45488,7 +53918,12 @@
       "gempId": "6_173",
       "side": "Dark",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Skiff",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/skiff.gif",
@@ -45514,7 +53949,12 @@
       "gempId": "6_123",
       "side": "Dark",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Skrilling",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/skrilling.gif",
@@ -45542,7 +53982,12 @@
       "gempId": "5_177",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Slave I",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/slavei.gif",
@@ -45614,7 +54059,12 @@
       "id": 6647,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Slave I (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/slavei.gif",
@@ -45641,7 +54091,12 @@
       "id": 6648,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Slave I, Symbol Of Fear",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/slaveisymboloffear.gif",
@@ -45668,7 +54123,12 @@
       "gempId": "201_40",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Slave I, Symbol Of Fear",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Dark/large/slaveisymboloffear.gif",
@@ -45713,7 +54173,12 @@
       "gempId": "201_40",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Slave I, Symbol Of Fear (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/OfficialAI-Dark/large/slaveisymboloffear.gif",
@@ -45741,7 +54206,12 @@
       "gempId": "4_111",
       "side": "Dark",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Sleen",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/sleen.gif",
@@ -45785,7 +54255,12 @@
       "gempId": "5_154",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Slip Sliding Away",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/slipslidingaway.gif",
@@ -45802,7 +54277,12 @@
       "id": 6650,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Slip Sliding Away (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/slipslidingaway.gif",
@@ -45822,7 +54302,12 @@
       "gempId": "8_153",
       "side": "Dark",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Sneak Attack",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/sneakattack.gif",
@@ -45840,7 +54325,12 @@
       "id": 6651,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Sneak Attack (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/sneakattack.gif",
@@ -45860,7 +54350,12 @@
       "gempId": "200_124",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Sneak Attack (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/sneakattack.gif",
@@ -45881,7 +54376,12 @@
       "gempId": "2_139",
       "side": "Dark",
       "rarity": "U1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Sniper",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/sniper.gif",
@@ -45903,7 +54403,12 @@
       "gempId": "10_47",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Sniper & •Dark Strike",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Dark/large/sniper&darkstrike.gif",
@@ -45926,7 +54431,12 @@
       "gempId": "10_48",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Snoova",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Dark/large/snoova.gif",
@@ -45963,7 +54473,12 @@
       "gempId": "3_91",
       "side": "Dark",
       "rarity": "C3",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Snowtrooper",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/snowtrooper.gif",
@@ -45995,7 +54510,12 @@
       "gempId": "3_92",
       "side": "Dark",
       "rarity": "C1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•••Snowtrooper Officer",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/snowtrooperofficer.gif",
@@ -46028,7 +54548,12 @@
       "id": 6652,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•So Be It, Jedi",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/sobeitjedi.gif",
@@ -46047,7 +54572,12 @@
       "gempId": "4_148",
       "side": "Dark",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Something Hit Us!",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/somethinghitus.gif",
@@ -46064,7 +54594,12 @@
       "gempId": "9_132",
       "side": "Dark",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Something Special Planned For Them",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/somethingspecialplannedforthem.gif",
@@ -46086,7 +54621,12 @@
       "id": 6653,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Something Special Planned For Them (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/somethingspecialplannedforthem.gif",
@@ -46106,7 +54646,12 @@
       "gempId": "200_112",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Something Special Planned For Them (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/somethingspecialplannedforthem.gif",
@@ -46134,7 +54679,12 @@
       "gempId": "5_155",
       "side": "Dark",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Sonic Bombardment",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/sonicbombardment.gif",
@@ -46162,7 +54712,12 @@
       "id": 6654,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Sonic Bombardment (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/sonicbombardment.gif",
@@ -46179,7 +54734,12 @@
       "gempId": "208_45",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Sonic Bombardment (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/sonicbombardment.gif",
@@ -46210,7 +54770,12 @@
       "gempId": "4_112",
       "side": "Dark",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "<>Space Slug",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/spaceslug.gif",
@@ -46238,7 +54803,12 @@
       "gempId": "7_288",
       "side": "Dark",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "<>Spaceport City",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/spaceportcity.gif",
@@ -46262,7 +54832,12 @@
       "gempId": "7_289",
       "side": "Dark",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "<>Spaceport Docking Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/spaceportdockingbay.gif",
@@ -46294,7 +54869,12 @@
       "id": 6655,
       "side": "Dark",
       "rarity": "F",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "<>Spaceport Docking Bay (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/spaceportdockingbay.gif",
@@ -46315,7 +54895,12 @@
       "gempId": "7_290",
       "side": "Dark",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "<>Spaceport Prefect's Office",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/spaceportprefectsoffice.gif",
@@ -46339,7 +54924,12 @@
       "gempId": "7_291",
       "side": "Dark",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "<>Spaceport Street",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/spaceportstreet.gif",
@@ -46363,7 +54953,12 @@
       "gempId": "5_123",
       "side": "Dark",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Special Delivery",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/specialdelivery.gif",
@@ -46391,7 +54986,12 @@
       "id": 6656,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Special Delivery (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/specialdelivery.gif",
@@ -46410,7 +55010,12 @@
       "gempId": "207_27",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 7",
+      "set": "207",
+      "printings": [
+        {
+          "set": "207"
+        }
+      ],
       "front": {
         "title": "•Specter of the Supreme Leader",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual7-Dark/large/specterofthesupremeleader.gif",
@@ -46446,7 +55051,12 @@
       "gempId": "8_169",
       "side": "Dark",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "Speeder Bike",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/speederbike.gif",
@@ -46474,7 +55084,12 @@
       "gempId": "8_180",
       "side": "Dark",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "Speeder Bike Cannon",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/speederbikecannon.gif",
@@ -46496,7 +55111,12 @@
       "id": 6657,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Spice Mine Operations",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/spicemineoperations.gif",
@@ -46515,7 +55135,12 @@
       "gempId": "2_125",
       "side": "Dark",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Spice Mines Of Kessel",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/spiceminesofkessel.gif",
@@ -46542,7 +55167,12 @@
       "id": 6658,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Spice Mines Of Kessel (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/spiceminesofkessel.gif",
@@ -46561,7 +55191,12 @@
       "gempId": "12_159",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Squabbling Delegates",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/squabblingdelegates.gif",
@@ -46600,7 +55235,12 @@
       "gempId": "14_89",
       "side": "Dark",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•SSA-1015",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/ssa1015.gif",
@@ -46638,7 +55278,12 @@
       "gempId": "14_90",
       "side": "Dark",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•SSA-306",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/ssa306.gif",
@@ -46676,7 +55321,12 @@
       "gempId": "14_91",
       "side": "Dark",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•SSA-719",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/ssa719.gif",
@@ -46714,7 +55364,12 @@
       "gempId": "3_152",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Stalker",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/stalker.gif",
@@ -46752,7 +55407,12 @@
       "id": 6659,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Stalker (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/stalker.gif",
@@ -46780,7 +55440,12 @@
       "gempId": "201_41",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Stalker (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Dark/large/stalker.gif",
@@ -46816,7 +55481,12 @@
       "gempId": "14_129",
       "side": "Dark",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "STAP Blaster Cannons",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/stapblastercannons.gif",
@@ -46843,7 +55513,12 @@
       "id": 6660,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•••Star Destroyer: Command Station",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/stardestroyercommandstation.gif",
@@ -46866,7 +55541,12 @@
       "gempId": "4_165",
       "side": "Dark",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•••Star Destroyer: Launch Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/stardestroyerlaunchbay.gif",
@@ -46892,7 +55572,12 @@
       "gempId": "208_51",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Starkiller Base",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/starkillerbase.gif",
@@ -46922,7 +55607,12 @@
       "gempId": "208_52",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Starkiller Base: Docking Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/starkillerbasedockingbay.gif",
@@ -46956,7 +55646,12 @@
       "gempId": "208_53",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Starkiller Base: Forest",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/starkillerbaseforest.gif",
@@ -46984,7 +55679,12 @@
       "gempId": "208_54",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Starkiller Base: Interrogation Room (Prison)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/starkillerbaseinterrogationroomprison.gif",
@@ -47017,7 +55717,12 @@
       "gempId": "208_55",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Starkiller Base: Shield Control",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/starkillerbaseshieldcontrol.gif",
@@ -47046,7 +55751,12 @@
       "gempId": "11_87",
       "side": "Dark",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Start Your Engines!",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/startyourengines.gif",
@@ -47071,7 +55781,12 @@
       "gempId": "10_49",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Stinger",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Dark/large/stinger.gif",
@@ -47105,7 +55820,12 @@
       "id": 6661,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Stinger (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/stinger.gif",
@@ -47134,7 +55854,12 @@
       "gempId": "200_137",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Stinger (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/stinger.gif",
@@ -47170,7 +55895,12 @@
       "gempId": "3_135",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Stop Motion",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/stopmotion.gif",
@@ -47189,7 +55919,12 @@
       "id": 6662,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Stop Motion (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/stopmotion.gif",
@@ -47208,7 +55943,12 @@
       "id": 6663,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "<>Storm Clouds",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/stormclouds.gif",
@@ -47229,7 +55969,12 @@
       "gempId": "1_194",
       "side": "Dark",
       "rarity": "C3",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Stormtrooper",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/stormtrooper.gif",
@@ -47260,7 +56005,12 @@
       "id": 6664,
       "side": "Dark",
       "rarity": "C3",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Stormtrooper (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/stormtrooper.gif",
@@ -47284,7 +56034,12 @@
       "gempId": "1_206",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Stormtrooper Backpack",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/stormtrooperbackpack.gif",
@@ -47301,7 +56056,12 @@
       "gempId": "106_16",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Official Tournament Sealed Deck",
+      "set": "106",
+      "printings": [
+        {
+          "set": "106"
+        }
+      ],
       "front": {
         "title": "Stormtrooper Cadet",
         "imageUrl": "https://res.starwarsccg.org/cards/OfficialTournamentSealedDeck-Dark/large/stormtroopercadet.gif",
@@ -47326,7 +56086,12 @@
       "gempId": "13_87",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "Stormtrooper Garrison",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/stormtroopergarrison.gif",
@@ -47359,7 +56124,12 @@
       "gempId": "204_44",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•••Stormtrooper Patrol",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Dark/large/stormtrooperpatrol.gif",
@@ -47393,7 +56163,12 @@
       "gempId": "1_207",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Stormtrooper Utility Belt",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/stormtrooperutilitybelt.gif",
@@ -47409,7 +56184,12 @@
       "gempId": "7_242",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Strategic Reserves",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/strategicreserves.gif",
@@ -47430,7 +56210,12 @@
       "id": 6665,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Strategic Reserves (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/strategicreserves.gif",
@@ -47450,7 +56235,12 @@
       "gempId": "112_19",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Jabba's Palace Sealed Deck",
+      "set": "112",
+      "printings": [
+        {
+          "set": "112"
+        }
+      ],
       "front": {
         "title": "Stun Blaster",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalaceSealedDeck-Dark/large/stunblaster.gif",
@@ -47476,7 +56266,12 @@
       "gempId": "2_140",
       "side": "Dark",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Stunning Leader",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/stunningleader.gif",
@@ -47503,7 +56298,12 @@
       "id": 6666,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "Stunning Leader (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/stunningleader.gif",
@@ -47520,7 +56320,12 @@
       "gempId": "4_132",
       "side": "Dark",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Sudden Impact",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/suddenimpact.gif",
@@ -47540,7 +56345,12 @@
       "id": 6667,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Sudden Impact (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/suddenimpact.gif",
@@ -47560,7 +56370,12 @@
       "gempId": "9_150",
       "side": "Dark",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Sullust",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/sullust.gif",
@@ -47588,7 +56403,12 @@
       "gempId": "1_230",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Sunsdown",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/sunsdown.gif",
@@ -47612,7 +56432,12 @@
       "gempId": "10_50",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "Sunsdown & Too Cold For Speeders",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Dark/large/sunsdown&toocoldforspeeders.gif",
@@ -47633,7 +56458,12 @@
       "id": 6668,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Sunsdown (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/sunsdown.gif",
@@ -47649,7 +56479,12 @@
       "gempId": "2_161",
       "side": "Dark",
       "rarity": "R2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Superlaser",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/superlaser.gif",
@@ -47670,7 +56505,12 @@
       "gempId": "9_182",
       "side": "Dark",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "Superlaser Mark II",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/superlasermarkii.gif",
@@ -47692,7 +56532,12 @@
       "gempId": "209_39",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Supreme Leader Snoke",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Dark/large/supremeleadersnoke.gif",
@@ -47719,7 +56564,12 @@
       "gempId": "7_263",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Surface Defense",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/surfacedefense.gif",
@@ -47737,7 +56587,12 @@
       "id": 6670,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Surface Defense (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/surfacedefense.gif",
@@ -47757,7 +56612,12 @@
       "gempId": "200_125",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "Surface Defense (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/surfacedefense.gif",
@@ -47849,7 +56709,12 @@
       "gempId": "5_156",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Surprise",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/surprise.gif",
@@ -47872,7 +56737,12 @@
       "gempId": "7_292",
       "side": "Dark",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "<>Swamp",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/swamp.gif",
@@ -47907,7 +56777,12 @@
       "gempId": "2_126",
       "side": "Dark",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Swilla Corey",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/swillacorey.gif",
@@ -47928,7 +56803,12 @@
       "gempId": "7_207",
       "side": "Dark",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Swoop Mercenary",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/swoopmercenary.gif",
@@ -47952,7 +56832,12 @@
       "gempId": "7_208",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Sy Snootles",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/sysnootles.gif",
@@ -47985,7 +56870,12 @@
       "id": 6671,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Sy Snootles (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/sysnootles.gif",
@@ -48006,7 +56896,12 @@
       "gempId": "1_231",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Tactical Re-Call",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/tacticalrecall.gif",
@@ -48027,7 +56922,12 @@
       "id": 6672,
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Tactical Re-Call (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/tacticalrecall.gif",
@@ -48044,7 +56944,12 @@
       "gempId": "3_136",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Tactical Support",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/tacticalsupport.gif",
@@ -48068,7 +56973,12 @@
       "gempId": "4_149",
       "side": "Dark",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Take Evasive Action",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/takeevasiveaction.gif",
@@ -48096,7 +57006,12 @@
       "id": 6673,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Take Evasive Action (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/takeevasiveaction.gif",
@@ -48116,7 +57031,12 @@
       "gempId": "14_106",
       "side": "Dark",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Take Them Away",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/takethemaway.gif",
@@ -48141,7 +57061,12 @@
       "gempId": "1_269",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Takeel",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/takeel.gif",
@@ -48161,7 +57086,12 @@
       "gempId": "1_270",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Tallon Roll",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/tallonroll.gif",
@@ -48185,7 +57115,12 @@
       "gempId": "14_92",
       "side": "Dark",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "Tank Commander",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/tankcommander.gif",
@@ -48227,7 +57162,12 @@
       "gempId": "3_115",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Target The Main Generator",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/targetthemaingenerator.gif",
@@ -48242,7 +57182,12 @@
       "gempId": "102_11",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Jedi Pack",
+      "set": "102",
+      "printings": [
+        {
+          "set": "102"
+        }
+      ],
       "front": {
         "title": "•Tarkin",
         "imageUrl": "https://res.starwarsccg.org/cards/JediPack-Dark/large/tarkin.gif",
@@ -48269,7 +57214,12 @@
       "id": 6674,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Tarkin (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/tarkin.gif",
@@ -48298,7 +57248,12 @@
       "gempId": "204_45",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Tarkin (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Dark/large/tarkin.gif",
@@ -48335,7 +57290,12 @@
       "id": 6675,
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Tarkin Doctrine",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/tarkindoctrine.gif",
@@ -48351,7 +57311,12 @@
       "gempId": "200_113",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Tarkin Doctrine",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/tarkindoctrine.gif",
@@ -48368,7 +57333,12 @@
       "gempId": "7_243",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Tarkin's Bounty",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/tarkinsbounty.gif",
@@ -48389,7 +57359,12 @@
       "id": 6676,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Tarkin's Bounty (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/tarkinsbounty.gif",
@@ -48408,7 +57383,12 @@
       "gempId": "208_41",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Tarkin's Bounty (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/tarkinsbounty.gif",
@@ -48430,7 +57410,12 @@
       "gempId": "106_17",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Official Tournament Sealed Deck",
+      "set": "106",
+      "printings": [
+        {
+          "set": "106"
+        }
+      ],
       "front": {
         "title": "•Tarkin's Orders",
         "imageUrl": "https://res.starwarsccg.org/cards/OfficialTournamentSealedDeck-Dark/large/tarkinsorders.gif",
@@ -48459,7 +57444,12 @@
       "id": 6677,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Tarkin's Orders (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/tarkinsorders.gif",
@@ -48479,7 +57469,12 @@
       "gempId": "12_175",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Tatooine",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/tatooine.gif",
@@ -48508,7 +57503,12 @@
       "gempId": "1_289",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Tatooine",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/tatooine.gif",
@@ -48536,7 +57536,12 @@
       "gempId": "203_33",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•Tatooine (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Dark/large/tatooine.gif",
@@ -48564,7 +57569,12 @@
       "gempId": "7_244",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Tatooine Occupation",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/tatooineoccupation.gif",
@@ -48589,7 +57599,12 @@
       "gempId": "2_150",
       "side": "Dark",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Bluffs",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/tatooinebluffs.gif",
@@ -48612,7 +57627,12 @@
       "gempId": "1_290",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Cantina",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/tatooinecantina.gif",
@@ -48643,7 +57663,12 @@
       "gempId": "6_169",
       "side": "Dark",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•••Tatooine: Desert",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/tatooinedesert.gif",
@@ -48671,7 +57696,12 @@
       "gempId": "112_20",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Jabba's Palace Sealed Deck",
+      "set": "112",
+      "printings": [
+        {
+          "set": "112"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Desert Heart",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalaceSealedDeck-Dark/large/tatooinedesertheart.gif",
@@ -48698,7 +57728,12 @@
       "gempId": "11_92",
       "side": "Dark",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Desert Landing Site",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/tatooinedesertlandingsite.gif",
@@ -48722,7 +57757,12 @@
       "gempId": "1_291",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Docking Bay 94",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/tatooinedockingbay94.gif",
@@ -48754,7 +57794,12 @@
       "gempId": "6_170",
       "side": "Dark",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Great Pit Of Carkoon",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/tatooinegreatpitofcarkoon.gif",
@@ -48780,7 +57825,12 @@
       "id": 6678,
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Imperial Outpost",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/tatooineimperialoutpost.gif",
@@ -48799,7 +57849,12 @@
       "id": 6679,
       "side": "Dark",
       "rarity": "F",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Imperial Vanguard Camp",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/tatooineimperialvanguardcamp.gif",
@@ -48820,7 +57875,12 @@
       "gempId": "6_171",
       "side": "Dark",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Jabba's Palace",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/tatooinejabbaspalace.gif",
@@ -48856,7 +57916,12 @@
       "gempId": "1_292",
       "side": "Dark",
       "rarity": "C1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Jawa Camp",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/tatooinejawacamp.gif",
@@ -48884,7 +57949,12 @@
       "gempId": "7_293",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Jawa Canyon",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/tatooinejawacanyon.gif",
@@ -48912,7 +57982,12 @@
       "gempId": "1_293",
       "side": "Dark",
       "rarity": "C1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Jundland Wastes",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/tatooinejundlandwastes.gif",
@@ -48940,7 +58015,12 @@
       "gempId": "7_294",
       "side": "Dark",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Krayt Dragon Pass",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/tatooinekraytdragonpass.gif",
@@ -48967,7 +58047,12 @@
       "gempId": "1_294",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Lars' Moisture Farm",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/tatooinelarsmoisturefarm.gif",
@@ -48996,7 +58081,12 @@
       "gempId": "12_176",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Marketplace",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/tatooinemarketplace.gif",
@@ -49025,7 +58115,12 @@
       "gempId": "1_295",
       "side": "Dark",
       "rarity": "C1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Mos Eisley",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/tatooinemoseisley.gif",
@@ -49052,7 +58147,12 @@
       "id": 6680,
       "side": "Dark",
       "rarity": "C1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Mos Eisley (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/tatooinemoseisley.gif",
@@ -49076,7 +58176,12 @@
       "gempId": "11_93",
       "side": "Dark",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Mos Espa",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/tatooinemosespa.gif",
@@ -49104,7 +58209,12 @@
       "id": 6681,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Mos Espa (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/tatooinemosespa.gif",
@@ -49126,7 +58236,12 @@
       "gempId": "208_56",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Mos Espa (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/tatooinemosespa.gif",
@@ -49154,7 +58269,12 @@
       "gempId": "12_177",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Mos Espa Docking Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/tatooinemosespadockingbay.gif",
@@ -49187,7 +58307,12 @@
       "gempId": "11_94",
       "side": "Dark",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Podrace Arena",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/tatooinepodracearena.gif",
@@ -49216,7 +58341,12 @@
       "gempId": "106_18",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Official Tournament Sealed Deck",
+      "set": "106",
+      "printings": [
+        {
+          "set": "106"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Tusken Canyon",
         "imageUrl": "https://res.starwarsccg.org/cards/OfficialTournamentSealedDeck-Dark/large/tatooinetuskencanyon.gif",
@@ -49246,7 +58376,12 @@
       "gempId": "12_178",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Watto's Junkyard",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/tatooinewattosjunkyard.gif",
@@ -49277,7 +58412,12 @@
       "id": 6682,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Watto's Junkyard (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/tatooinewattosjunkyard.gif",
@@ -49298,7 +58438,12 @@
       "gempId": "7_264",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Tauntaun Skull",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/tauntaunskull.gif",
@@ -49320,7 +58465,12 @@
       "gempId": "6_124",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Taym Dren-garen",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/taymdrengaren.gif",
@@ -49354,7 +58504,12 @@
       "gempId": "12_119",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•TC-14",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/tc14.gif",
@@ -49389,7 +58544,12 @@
       "id": 6683,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•T'doshok Hunting Vow",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/tdoshokhuntingvow.gif",
@@ -49408,7 +58568,12 @@
       "gempId": "2_105",
       "side": "Dark",
       "rarity": "U2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Tech Mo'r",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/techmor.gif",
@@ -49440,7 +58605,12 @@
       "gempId": "11_98",
       "side": "Dark",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Teemto Pagalies' Podracer",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/teemtopagaliespodracer.gif",
@@ -49460,7 +58630,12 @@
       "gempId": "12_120",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Televan Koreyy",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/televankoreyy.gif",
@@ -49497,7 +58672,12 @@
       "gempId": "8_170",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Tempest 1",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/tempest1.gif",
@@ -49537,7 +58717,12 @@
       "gempId": "8_171",
       "side": "Dark",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "Tempest Scout",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/tempestscout.gif",
@@ -49573,7 +58758,12 @@
       "gempId": "8_172",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Tempest Scout 1",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/tempestscout1.gif",
@@ -49612,7 +58802,12 @@
       "gempId": "8_173",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Tempest Scout 2",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/tempestscout2.gif",
@@ -49652,7 +58847,12 @@
       "gempId": "8_174",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Tempest Scout 3",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/tempestscout3.gif",
@@ -49689,7 +58889,12 @@
       "gempId": "202_15",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 2",
+      "set": "202",
+      "printings": [
+        {
+          "set": "202"
+        }
+      ],
       "front": {
         "title": "•Tempest Scout 3 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual2-Dark/large/tempestscout3.gif",
@@ -49718,7 +58923,12 @@
       "gempId": "8_175",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Tempest Scout 4",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/tempestscout4.gif",
@@ -49756,7 +58966,12 @@
       "gempId": "8_176",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Tempest Scout 5",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/tempestscout5.gif",
@@ -49793,7 +59008,12 @@
       "gempId": "8_177",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Tempest Scout 6",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/tempestscout6.gif",
@@ -49830,7 +59050,12 @@
       "gempId": "2_127",
       "side": "Dark",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Tentacle",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/tentacle.gif",
@@ -49858,7 +59083,12 @@
       "id": 6684,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Tentacle (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/tentacle.gif",
@@ -49879,7 +59109,12 @@
       "gempId": "12_121",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Tey How",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/teyhow.gif",
@@ -49915,7 +59150,12 @@
       "gempId": "9_135",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•That Thing's Operational",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/thatthingsoperational.gif",
@@ -49934,7 +59174,12 @@
       "gempId": "3_137",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "That's It, The Rebels Are There!",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/thatsittherebelsarethere.gif",
@@ -49951,7 +59196,12 @@
       "gempId": "1_271",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "The Circle Is Now Complete",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/thecircleisnowcomplete.gif",
@@ -49971,7 +59221,12 @@
       "gempId": "4_133",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "The Dark Path",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/thedarkpath.gif",
@@ -49990,7 +59245,12 @@
       "id": 6685,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "The Dark Path (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/thedarkpath.gif",
@@ -50009,7 +59269,12 @@
       "gempId": "210_31",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "The Dark Path (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Dark/large/thedarkpath.gif",
@@ -50025,7 +59290,12 @@
       "gempId": "14_68",
       "side": "Dark",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•The Deflector Shield Is Too Strong",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/thedeflectorshieldistoostrong.gif",
@@ -50048,7 +59318,12 @@
       "gempId": "13_88",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•The Ebb Of Battle",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/theebbofbattle.gif",
@@ -50072,7 +59347,12 @@
       "gempId": "10_51",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•The Emperor",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Dark/large/theemperor.gif",
@@ -50112,7 +59392,12 @@
       "id": 6687,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•The Emperor (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/theemperor.gif",
@@ -50136,7 +59421,12 @@
       "id": 6688,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•The Emperor Is Coming Here?",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/theemperoriscominghere.gif",
@@ -50155,7 +59445,12 @@
       "gempId": "5_124",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•The Emperor's Prize",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/theemperorsprize.gif",
@@ -50179,7 +59474,12 @@
       "id": 6689,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•The Emperor's Prize (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/theemperorsprize.gif",
@@ -50199,7 +59499,12 @@
       "gempId": "9_172",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•The Emperor's Shield",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/theemperorsshield.gif",
@@ -50230,7 +59535,12 @@
       "gempId": "9_173",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•The Emperor's Sword",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/theemperorssword.gif",
@@ -50261,7 +59571,12 @@
       "gempId": "1_272",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "The Empire's Back",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/theempiresback.gif",
@@ -50296,7 +59611,12 @@
       "id": 6690,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "The Empire's Back (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/theempiresback.gif",
@@ -50312,7 +59632,12 @@
       "id": 6691,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•The Force Unleashed",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/theforceunleashed.gif",
@@ -50330,7 +59655,12 @@
       "gempId": "210_46",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•The Grand Inquisitor",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Dark/large/thegrandinquisitor.gif",
@@ -50358,7 +59688,12 @@
       "gempId": "13_89",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•The Hutts Are Gangsters",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/thehuttsaregangsters.gif",
@@ -50384,7 +59719,12 @@
       "id": 6693,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•The Inner Circle",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/theinnercircle.gif",
@@ -50402,7 +59742,12 @@
       "id": 6694,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•The Modal Nodes' Ommni Box",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/themodalnodesommnibox.gif",
@@ -50418,7 +59763,12 @@
       "gempId": "12_139",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•The Phantom Menace",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/thephantommenace.gif",
@@ -50470,7 +59820,12 @@
       "gempId": "12_140",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•The Phantom Menace (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/thephantommenaceai.gif",
@@ -50489,7 +59844,12 @@
       "gempId": "12_160",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•The Point Is Conceded",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/thepointisconceded.gif",
@@ -50509,7 +59869,12 @@
       "id": 6696,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•The Quick And Easy Path",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/thequickandeasypath.gif",
@@ -50528,7 +59893,12 @@
       "gempId": "3_111",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "The Shield Doors Must Be Closed",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/theshielddoorsmustbeclosed.gif",
@@ -50553,7 +59923,12 @@
       "gempId": "11_88",
       "side": "Dark",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•There Is No Conflict",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/thereisnoconflict.gif",
@@ -50571,7 +59946,12 @@
       "gempId": "4_134",
       "side": "Dark",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•There Is No Try",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/thereisnotry.gif",
@@ -50592,7 +59972,12 @@
       "gempId": "13_90",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•There Is No Try",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/thereisnotry.gif",
@@ -50613,7 +59998,12 @@
       "gempId": "10_52",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•There Is No Try & •Oppressive Enforcement",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Dark/large/thereisnotry&oppressiveenforcement.gif",
@@ -50632,7 +60022,12 @@
       "id": 6697,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•There Is No Try & •Oppressive Enforcement (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/thereisnotry&oppressiveenforcement.gif",
@@ -50650,7 +60045,12 @@
       "gempId": "14_107",
       "side": "Dark",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•There They Are!",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/theretheyare.gif",
@@ -50680,7 +60080,12 @@
       "gempId": "2_128",
       "side": "Dark",
       "rarity": "U2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•••There'll Be Hell To Pay",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/therellbehelltopay.gif",
@@ -50709,7 +60114,12 @@
       "gempId": "6_179",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Thermal Detonator",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/thermaldetonator.gif",
@@ -50730,7 +60140,12 @@
       "gempId": "13_91",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•They Must Never Again Leave This City",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/theymustneveragainleavethiscity.gif",
@@ -50751,7 +60166,12 @@
       "gempId": "12_141",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•They Will Be No Match For You",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/theywillbenomatchforyou.gif",
@@ -50775,7 +60195,12 @@
       "gempId": "209_44",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•They Will Be No Match For You (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Dark/large/theywillbenomatchforyou.gif",
@@ -50795,7 +60220,12 @@
       "gempId": "7_265",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•They're Coming In Too Fast!",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/theyrecomingintoofast.gif",
@@ -50816,7 +60246,12 @@
       "gempId": "12_161",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "They're Still Coming Through!",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/theyrestillcomingthrough.gif",
@@ -50845,7 +60280,12 @@
       "gempId": "7_266",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•They've Shut Down The Main Reactor",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/theyveshutdownthemainreactor.gif",
@@ -50864,7 +60304,12 @@
       "gempId": "109_12",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Enhanced Cloud City",
+      "set": "109",
+      "printings": [
+        {
+          "set": "109"
+        }
+      ],
       "front": {
         "title": "This Deal Is Getting Worse All The Time / Pray I Don't Alter It Any Further",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedCloudCity-Dark/large/thisdealisgettingworseallthetime.gif",
@@ -50886,7 +60331,12 @@
       "gempId": "3_112",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•This Is Just Wrong",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/thisisjustwrong.gif",
@@ -50913,7 +60363,12 @@
       "gempId": "14_108",
       "side": "Dark",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•This Is Not Good",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/thisisnotgood.gif",
@@ -50934,7 +60389,12 @@
       "gempId": "12_142",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•This Is Outrageous!",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/thisisoutrageous.gif",
@@ -50962,7 +60422,12 @@
       "gempId": "2_141",
       "side": "Dark",
       "rarity": "U1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "This Is Some Rescue!",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/thisissomerescue.gif",
@@ -50992,7 +60457,12 @@
       "gempId": "5_157",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•This Is Still Wrong",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/thisisstillwrong.gif",
@@ -51020,7 +60490,12 @@
       "gempId": "13_92",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Thok & Thug",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/thok&thug.gif",
@@ -51049,7 +60524,12 @@
       "id": 6700,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Thok & Thug (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/thok&thug.gif",
@@ -51075,7 +60555,12 @@
       "gempId": "4_150",
       "side": "Dark",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Those Rebels Won't Escape Us",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/thoserebelswontescapeus.gif",
@@ -51098,7 +60583,12 @@
       "id": 6701,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "Those Rebels Won't Escape Us (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/thoserebelswontescapeus.gif",
@@ -51117,7 +60607,12 @@
       "id": 6702,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Thrawn's Ysalami",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/thrawnsysalamir.gif",
@@ -51143,7 +60638,12 @@
       "gempId": "13_93",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Through The Corridor",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/throughthecorridor.gif",
@@ -51164,7 +60664,12 @@
       "gempId": "6_125",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Thul Fain",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/thulfain.gif",
@@ -51197,7 +60702,15 @@
       "gempId": "9_174",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "107"
+        },
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Thunderflare",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/thunderflare.gif",
@@ -51237,7 +60750,12 @@
       "id": 6703,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Tibanna Floating Refinery",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/tibannafloatingrefinery.gif",
@@ -51253,7 +60771,12 @@
       "gempId": "5_102",
       "side": "Dark",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Tibanna Gas Miner",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/tibannagasminer.gif",
@@ -51281,7 +60804,12 @@
       "gempId": "1_303",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "TIE Advanced x1",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/tieadvancedx1.gif",
@@ -51317,7 +60845,12 @@
       "gempId": "2_153",
       "side": "Dark",
       "rarity": "U1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "TIE Assault Squadron",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/tieassaultsquadron.gif",
@@ -51347,7 +60880,12 @@
       "gempId": "4_172",
       "side": "Dark",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "TIE Avenger",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/tieavenger.gif",
@@ -51380,7 +60918,12 @@
       "id": 6704,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "TIE Avenger (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/tieavenger.gif",
@@ -51407,7 +60950,12 @@
       "gempId": "4_173",
       "side": "Dark",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "TIE Bomber",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/tiebomber.gif",
@@ -51444,7 +60992,12 @@
       "gempId": "7_308",
       "side": "Dark",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "TIE Defender Mark I",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/tiedefendermarki.gif",
@@ -51480,7 +61033,12 @@
       "gempId": "1_304",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "TIE Fighter",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/tiefighter.gif",
@@ -51515,7 +61073,12 @@
       "id": 6705,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•TIE Fighter Construction Facility",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/tiefighterconstructionfacility.gif",
@@ -51533,7 +61096,12 @@
       "gempId": "9_175",
       "side": "Dark",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "TIE Interceptor",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/tieinterceptor.gif",
@@ -51569,7 +61137,12 @@
       "gempId": "1_305",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "TIE Scout",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/tiescout.gif",
@@ -51607,7 +61180,12 @@
       "gempId": "5_158",
       "side": "Dark",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•TIE Sentry Ships",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/tiesentryships.gif",
@@ -51624,7 +61202,12 @@
       "id": 6706,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•TIE Sentry Ships (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/tiesentryships.gif",
@@ -51645,7 +61228,12 @@
       "gempId": "201_36",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•TIE Sentry Ships (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Dark/large/tiesentryships.gif",
@@ -51668,7 +61256,12 @@
       "gempId": "2_154",
       "side": "Dark",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "TIE Vanguard",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/tievanguard.gif",
@@ -51704,7 +61297,12 @@
       "gempId": "12_122",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Tikkes",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/tikkes.gif",
@@ -51739,7 +61337,12 @@
       "gempId": "1_322",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Timer Mine",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/timermine.gif",
@@ -51757,7 +61360,12 @@
       "gempId": "1_195",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Tonnika Sisters",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/tonnikasisters.gif",
@@ -51798,7 +61406,12 @@
       "gempId": "3_113",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Too Cold For Speeders",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/toocoldforspeeders.gif",
@@ -51821,7 +61434,12 @@
       "gempId": "12_123",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Toonbuck Toora",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/toonbucktoora.gif",
@@ -51853,7 +61471,12 @@
       "id": 6707,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Toonbuck Toora (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/toonbucktoora.gif",
@@ -51880,7 +61503,12 @@
       "gempId": "6_158",
       "side": "Dark",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Torture",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/torture.gif",
@@ -51908,7 +61536,12 @@
       "gempId": "2_115",
       "side": "Dark",
       "rarity": "U1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Tractor Beam",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/tractorbeam.gif",
@@ -51935,7 +61568,12 @@
       "gempId": "12_184",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Trade Federation Battleship",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/tradefederationbattleship.gif",
@@ -51972,7 +61610,12 @@
       "gempId": "12_185",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "<>Trade Federation Droid Control Ship",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/tradefederationdroidcontrolship.gif",
@@ -52010,7 +61653,12 @@
       "gempId": "14_119",
       "side": "Dark",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "Trade Federation Landing Craft",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/tradefederationlandingcraft.gif",
@@ -52053,7 +61701,12 @@
       "gempId": "14_109",
       "side": "Dark",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Trade Federation Tactics",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/tradefederationtactics.gif",
@@ -52073,7 +61726,12 @@
       "id": 6708,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Trade Federation Tactics (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/tradefederationtactics.gif",
@@ -52094,7 +61752,12 @@
       "gempId": "211_14",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Trade Federation Tactics (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Dark/large/tradefederationtactics.gif",
@@ -52114,7 +61777,12 @@
       "id": 6710,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Trained In The Jedi Arts",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/trainedinthejediarts.gif",
@@ -52134,7 +61802,12 @@
       "gempId": "3_138",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Trample",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/trample.gif",
@@ -52158,7 +61831,12 @@
       "gempId": "6_126",
       "side": "Dark",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Trandoshan",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/trandoshan.gif",
@@ -52185,7 +61863,12 @@
       "gempId": "6_159",
       "side": "Dark",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Trap Door",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/trapdoor.gif",
@@ -52203,7 +61886,12 @@
       "gempId": "1_273",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Trinto Duaba",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/trintoduaba.gif",
@@ -52224,7 +61912,12 @@
       "gempId": "5_159",
       "side": "Dark",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Trooper Assault",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/trooperassault.gif",
@@ -52244,7 +61937,12 @@
       "gempId": "1_274",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Trooper Charge",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/troopercharge.gif",
@@ -52264,7 +61962,12 @@
       "gempId": "2_106",
       "side": "Dark",
       "rarity": "R2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Trooper Davin Felth",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/trooperdavinfelth.gif",
@@ -52296,7 +61999,12 @@
       "id": 6711,
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Trooper Davin Felth (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/trooperdavinfelth.gif",
@@ -52321,7 +62029,12 @@
       "gempId": "5_103",
       "side": "Dark",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Trooper Jerrol Blendin",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/trooperjerrolblendin.gif",
@@ -52353,7 +62066,12 @@
       "gempId": "7_267",
       "side": "Dark",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Trooper Sabacc",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/troopersabacc.gif",
@@ -52371,7 +62089,12 @@
       "id": 6712,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Trophy Of A Bounty Hunter",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/trophyofabountyhunter.gif",
@@ -52386,7 +62109,12 @@
       "id": 6713,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "••Trophy Of A Kill",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/trophyofakill.gif",
@@ -52401,7 +62129,12 @@
       "gempId": "14_124",
       "side": "Dark",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•TT-6",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/tt6.gif",
@@ -52441,7 +62174,12 @@
       "gempId": "14_125",
       "side": "Dark",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•TT-9",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/tt9.gif",
@@ -52479,7 +62217,12 @@
       "gempId": "1_323",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Turbolaser Battery",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/turbolaserbattery.gif",
@@ -52506,7 +62249,12 @@
       "gempId": "3_139",
       "side": "Dark",
       "rarity": "C1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Turn It Off! Turn It Off!",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/turnitoffturnitoff.gif",
@@ -52529,7 +62277,12 @@
       "gempId": "201_37",
       "side": "Dark",
       "rarity": "C1",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "Turn It Off! Turn It Off! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Dark/large/turnitoffturnitoff.gif",
@@ -52549,7 +62302,12 @@
       "gempId": "12_124",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Tusken Raider",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/tuskenraider.gif",
@@ -52579,7 +62337,12 @@
       "gempId": "1_196",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Tusken Raider",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/tuskenraider.gif",
@@ -52606,7 +62369,12 @@
       "gempId": "1_275",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Tusken Scavengers",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/tuskenscavengers.gif",
@@ -52626,7 +62394,12 @@
       "gempId": "6_160",
       "side": "Dark",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Twi'lek Advisor",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/twilekadvisor.gif",
@@ -52647,7 +62420,12 @@
       "id": 6714,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Twi'lek Advisor (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/twilekadvisor.gif",
@@ -52667,7 +62445,12 @@
       "gempId": "211_15",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Twi'lek Advisor (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Dark/large/twilekadvisor.gif",
@@ -52687,7 +62470,12 @@
       "gempId": "301_4",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Premium Set",
+      "set": "301",
+      "printings": [
+        {
+          "set": "301"
+        }
+      ],
       "front": {
         "title": "Twin Suns Of Tatooine / Well Trained In The Jedi Arts",
         "imageUrl": "https://res.starwarsccg.org/cards/DemoDeck-Dark/large/twinsunsoftatooine.gif",
@@ -52709,7 +62497,12 @@
       "gempId": "3_153",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Tyrant",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/tyrant.gif",
@@ -52752,7 +62545,12 @@
       "gempId": "2_107",
       "side": "Dark",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•U-3PO (Yoo-Threepio)",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/u3po.gif",
@@ -52784,7 +62582,12 @@
       "gempId": "1_310",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Ubrikkian 9000 Z001",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/ubrikkian9000z001.gif",
@@ -52809,7 +62612,12 @@
       "gempId": "5_104",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Ugloste",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/ugloste.gif",
@@ -52840,7 +62648,12 @@
       "gempId": "5_105",
       "side": "Dark",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Ugnaught",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/ugnaught.gif",
@@ -52875,7 +62688,12 @@
       "gempId": "7_209",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Umpass-stay",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/umpassstay.gif",
@@ -52911,7 +62729,12 @@
       "gempId": "4_151",
       "side": "Dark",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Uncertain Is The Future",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/uncertainisthefuture.gif",
@@ -52928,7 +62751,12 @@
       "gempId": "2_129",
       "side": "Dark",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Undercover",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/undercover.gif",
@@ -52948,7 +62776,12 @@
       "id": 6717,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Undercover (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/undercover.gif",
@@ -52967,7 +62800,12 @@
       "gempId": "4_152",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Unexpected Interruption",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/unexpectedinterruption.gif",
@@ -52987,7 +62825,12 @@
       "id": 6718,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Unexpected Interruption (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Dark/large/unexpectedinterruption.gif",
@@ -53007,7 +62850,12 @@
       "gempId": "13_94",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Unsalvageable",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/unsalvageable.gif",
@@ -53031,7 +62879,12 @@
       "gempId": "2_108",
       "side": "Dark",
       "rarity": "U2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•URoRRuR'R'R",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/urorrurrr.gif",
@@ -53062,7 +62915,12 @@
       "id": 6719,
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•URoRRuR'R'R (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/urorrurrr.gif",
@@ -53086,7 +62944,12 @@
       "gempId": "7_317",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•URoRRuR'R'R's Bantha",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/urorrurrrsbantha.gif",
@@ -53113,7 +62976,12 @@
       "id": 6720,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•URoRRuR'R'R's Bantha (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/urorrurrrsbantha.gif",
@@ -53138,7 +63006,12 @@
       "gempId": "2_162",
       "side": "Dark",
       "rarity": "U1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•URoRRuR'R'R's Hunting Rifle",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/urorrurrrshuntingrifle.gif",
@@ -53169,7 +63042,12 @@
       "gempId": "7_210",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Ur'Ru'r",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/urrur.gif",
@@ -53199,7 +63077,12 @@
       "id": 6721,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Ur'Ru'r (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/urrur.gif",
@@ -53224,7 +63107,12 @@
       "gempId": "1_276",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Utinni!",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/utinni.gif",
@@ -53248,7 +63136,12 @@
       "id": 6722,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Utinni! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/utinni.gif",
@@ -53265,7 +63158,12 @@
       "gempId": "101_5",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Premiere Introductory Two Player Game",
+      "set": "101",
+      "printings": [
+        {
+          "set": "101"
+        }
+      ],
       "front": {
         "title": "•Vader",
         "imageUrl": "https://res.starwarsccg.org/cards/PremiereIntroductoryTwoPlayerGame-Dark/large/vader.gif",
@@ -53306,7 +63204,12 @@
       "id": 6723,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Vader (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/vader.gif",
@@ -53334,7 +63237,12 @@
       "gempId": "11_89",
       "side": "Dark",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Vader's Anger",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/vadersanger.gif",
@@ -53351,7 +63259,12 @@
       "id": 6724,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Vader's Anger (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/vadersanger.gif",
@@ -53371,7 +63284,12 @@
       "gempId": "211_16",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Vader's Anger (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Dark/large/vadersanger.gif",
@@ -53390,7 +63308,12 @@
       "id": 6726,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Vader's Bionic Limbs",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/vadersbioniclimbs.gif",
@@ -53409,7 +63332,12 @@
       "gempId": "5_125",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Vader's Bounty",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/vadersbounty.gif",
@@ -53430,7 +63358,12 @@
       "id": 6727,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Vader's Bounty (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/vadersbounty.gif",
@@ -53449,7 +63382,12 @@
       "gempId": "5_126",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Vader's Cape",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/vaderscape.gif",
@@ -53469,7 +63407,12 @@
       "id": 6728,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Vader's Cape (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/vaderscape.gif",
@@ -53489,7 +63432,12 @@
       "gempId": "1_306",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Vader's Custom TIE",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/vaderscustomtie.gif",
@@ -53530,7 +63478,12 @@
       "gempId": "206_14",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Set 6",
+      "set": "206",
+      "printings": [
+        {
+          "set": "206"
+        }
+      ],
       "front": {
         "title": "•Vader's Custom TIE (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual6-Dark/large/vaderscustomtie.gif",
@@ -53570,7 +63523,12 @@
       "id": 6729,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Vader's Cybernetic Enhancements",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/vaderscyberneticenhancements.gif",
@@ -53590,7 +63548,12 @@
       "gempId": "1_277",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Vader's Eye",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/vaderseye.gif",
@@ -53607,7 +63570,12 @@
       "id": 6730,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Vader's Helmet",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/vadershelmet.gif",
@@ -53627,7 +63595,12 @@
       "gempId": "1_324",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Vader's Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/vaderslightsaber.gif",
@@ -53662,7 +63635,12 @@
       "id": 6731,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Vader's Mask",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/vadersmask.gif",
@@ -53681,7 +63659,12 @@
       "gempId": "101_6",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Premiere Introductory Two Player Game",
+      "set": "101",
+      "printings": [
+        {
+          "set": "101"
+        }
+      ],
       "front": {
         "title": "•Vader's Obsession",
         "imageUrl": "https://res.starwarsccg.org/cards/PremiereIntroductoryTwoPlayerGame-Dark/large/vadersobsession.gif",
@@ -53703,7 +63686,12 @@
       "gempId": "7_309",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Vader's Personal Shuttle",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/vaderspersonalshuttle.gif",
@@ -53746,7 +63734,12 @@
       "id": 6732,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Vader's Personal Shuttle (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/vaderspersonalshuttle.gif",
@@ -53774,7 +63767,12 @@
       "gempId": "200_138",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Vader's Personal Shuttle (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/vaderspersonalshuttle.gif",
@@ -53823,7 +63821,12 @@
       "gempId": "209_40",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Vanee",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Dark/large/vanee.gif",
@@ -53847,7 +63850,12 @@
       "gempId": "6_127",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Vedain",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/vedain.gif",
@@ -53873,7 +63881,12 @@
       "gempId": "104_6",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Empire Strikes Back Introductory Two Player Game",
+      "set": "104",
+      "printings": [
+        {
+          "set": "104"
+        }
+      ],
       "front": {
         "title": "•Veers",
         "imageUrl": "https://res.starwarsccg.org/cards/EmpireStrikesBackIntroductoryTwoPlayerGame-Dark/large/veers.gif",
@@ -53899,7 +63912,12 @@
       "id": 6735,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Veers (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/veers.gif",
@@ -53928,7 +63946,12 @@
       "gempId": "206_11",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 6",
+      "set": "206",
+      "printings": [
+        {
+          "set": "206"
+        }
+      ],
       "front": {
         "title": "•Veers (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual6-Dark/large/veers.gif",
@@ -53971,7 +63994,12 @@
       "gempId": "3_162",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Vehicle Mine",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/vehiclemine.gif",
@@ -53989,7 +64017,12 @@
       "gempId": "6_128",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Velken Tezeri",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/velkentezeri.gif",
@@ -54014,7 +64047,12 @@
       "id": 6736,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Velken Tezeri (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/velkentezeri.gif",
@@ -54039,7 +64077,12 @@
       "gempId": "205_16",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 5",
+      "set": "205",
+      "printings": [
+        {
+          "set": "205"
+        }
+      ],
       "front": {
         "title": "•Velken Tezeri (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual5-Dark/large/velkentezeri.gif",
@@ -54072,7 +64115,12 @@
       "gempId": "7_310",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Vengeance",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/vengeance.gif",
@@ -54111,7 +64159,12 @@
       "gempId": "211_24",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Vengeance (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Dark/large/vengeance.gif",
@@ -54139,7 +64192,12 @@
       "gempId": "6_180",
       "side": "Dark",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Vibro-Ax",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/vibroax.gif",
@@ -54162,7 +64220,12 @@
       "id": 6738,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Victory",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/victory.gif",
@@ -54190,7 +64253,12 @@
       "gempId": "2_155",
       "side": "Dark",
       "rarity": "U1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Victory-Class Star Destroyer",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/victoryclassstardestroyer.gif",
@@ -54227,7 +64295,12 @@
       "gempId": "10_53",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•••Vigo",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Dark/large/vigo.gif",
@@ -54259,7 +64332,12 @@
       "id": 6739,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•••Vigo (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/vigo.gif",
@@ -54280,7 +64358,12 @@
       "gempId": "200_91",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•••Vigo (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/vigo.gif",
@@ -54312,7 +64395,12 @@
       "gempId": "4_113",
       "side": "Dark",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Vine Snake",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/vinesnake.gif",
@@ -54346,7 +64434,12 @@
       "gempId": "10_54",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Virago",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Dark/large/virago.gif",
@@ -54381,7 +64474,12 @@
       "gempId": "9_176",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Visage",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/visage.gif",
@@ -54420,7 +64518,12 @@
       "gempId": "4_135",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Visage Of The Emperor",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/visageoftheemperor.gif",
@@ -54451,7 +64554,12 @@
       "gempId": "6_129",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Vizam",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/vizam.gif",
@@ -54483,7 +64591,12 @@
       "id": 6740,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Vizam (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/vizam.gif",
@@ -54507,7 +64620,12 @@
       "gempId": "12_162",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Vote Now!",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/votenow.gif",
@@ -54529,7 +64647,12 @@
       "gempId": "200_99",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200d",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Vote of No Confidence",
         "imageUrl": "https://res.starwarsccg.org/cards/ResetDS-Dark/large/voteofnoconfidence.gif",
@@ -54549,7 +64672,12 @@
       "gempId": "4_153",
       "side": "Dark",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "••Voyeur",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/voyeur.gif",
@@ -54569,7 +64697,12 @@
       "id": 6741,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "••Voyeur (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/voyeur.gif",
@@ -54589,7 +64722,12 @@
       "gempId": "7_295",
       "side": "Dark",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Wakeelmui",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/wakeelmui.gif",
@@ -54619,7 +64757,12 @@
       "gempId": "3_140",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Walker Barrage",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/walkerbarrage.gif",
@@ -54639,7 +64782,12 @@
       "gempId": "104_7",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Empire Strikes Back Introductory Two Player Game",
+      "set": "104",
+      "printings": [
+        {
+          "set": "104"
+        }
+      ],
       "front": {
         "title": "Walker Garrison",
         "imageUrl": "https://res.starwarsccg.org/cards/EmpireStrikesBackIntroductoryTwoPlayerGame-Dark/large/walkergarrison.gif",
@@ -54655,7 +64803,12 @@
       "id": 6743,
       "side": "Dark",
       "rarity": "P",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "Walker Garrison (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/walkergarrison.gif",
@@ -54674,7 +64827,12 @@
       "gempId": "3_141",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Wall Of Fire",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/walloffire.gif",
@@ -54691,7 +64849,12 @@
       "gempId": "3_93",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Wampa",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/wampa.gif",
@@ -54720,7 +64883,12 @@
       "id": 6744,
       "side": "Dark",
       "rarity": "R2",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Wampa (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/wampa.gif",
@@ -54745,7 +64913,12 @@
       "id": 6745,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•War Has Begun",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Dark/large/warhasbegun.gif",
@@ -54764,7 +64937,12 @@
       "gempId": "4_106",
       "side": "Dark",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Warrant Officer M'Kae",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/warrantofficermkae.gif",
@@ -54793,7 +64971,12 @@
       "id": 6746,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Warrant Officer M'Kae (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/warrantofficermkae.gif",
@@ -54818,7 +65001,12 @@
       "gempId": "7_268",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Watch Your Back!",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/watchyourback.gif",
@@ -54836,7 +65024,12 @@
       "id": 6747,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Watch Your Back! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/watchyourback.gif",
@@ -54856,7 +65049,12 @@
       "gempId": "11_65",
       "side": "Dark",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Watto",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/watto.gif",
@@ -54890,7 +65088,12 @@
       "gempId": "11_66",
       "side": "Dark",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Watto (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/wattoai.gif",
@@ -54913,7 +65116,12 @@
       "id": 6749,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Watto (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/watto.gif",
@@ -54937,7 +65145,12 @@
       "id": 6750,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Watto (V) (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/wattoai.gif",
@@ -54962,7 +65175,12 @@
       "gempId": "11_75",
       "side": "Dark",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Watto's Box",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/wattosbox.gif",
@@ -54987,7 +65205,12 @@
       "gempId": "11_90",
       "side": "Dark",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Watto's Chance Cube",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/wattoschancecube.gif",
@@ -55011,7 +65234,12 @@
       "gempId": "2_142",
       "side": "Dark",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "We Have A Prisoner",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/wehaveaprisoner.gif",
@@ -55033,7 +65261,12 @@
       "id": 6751,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•We Have A Prisoner & •I Can't Shake Him!",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/wehaveaprisoner&icantshakehim.gif",
@@ -55052,7 +65285,12 @@
       "gempId": "12_163",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•We Must Accelerate Our Plans",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/wemustaccelerateourplans.gif",
@@ -55090,7 +65328,12 @@
       "gempId": "11_76",
       "side": "Dark",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•We Shall Double Our Efforts!",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/weshalldoubleourefforts.gif",
@@ -55114,7 +65357,12 @@
       "gempId": "5_160",
       "side": "Dark",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Weapon Levitation",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/weaponlevitation.gif",
@@ -55141,7 +65389,12 @@
       "id": 6752,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Weapon Levitation & The Empire's Back",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/weaponlevitation&theempiresback.gif",
@@ -55160,7 +65413,12 @@
       "gempId": "3_114",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Weapon Malfunction",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/weaponmalfunction.gif",
@@ -55181,7 +65439,12 @@
       "gempId": "13_95",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Weapon Of A Sith",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/weaponofasith.gif",
@@ -55203,7 +65466,12 @@
       "gempId": "5_161",
       "side": "Dark",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Weapon Of An Ungrateful Son",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/weaponofanungratefulson.gif",
@@ -55222,7 +65490,12 @@
       "gempId": "5_127",
       "side": "Dark",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Weather Vane",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/weathervane.gif",
@@ -55244,7 +65517,12 @@
       "id": 6753,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Weather Vane (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/weathervane.gif",
@@ -55263,7 +65541,12 @@
       "gempId": "1_197",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "WED15-I662 'Treadwell' Droid",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/wed151662treadwelldroid.gif",
@@ -55287,7 +65570,12 @@
       "gempId": "2_109",
       "side": "Dark",
       "rarity": "U2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•WED15-l7 'Septoid' Droid",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Dark/large/wed15l7septoiddroid.gif",
@@ -55311,7 +65599,12 @@
       "gempId": "6_130",
       "side": "Dark",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•••Weequay Guard",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/weequayguard.gif",
@@ -55339,7 +65632,12 @@
       "gempId": "6_131",
       "side": "Dark",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•••Weequay Hunter",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/weequayhunter.gif",
@@ -55367,7 +65665,12 @@
       "gempId": "6_132",
       "side": "Dark",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•••Weequay Marksman",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/weequaymarksman.gif",
@@ -55395,7 +65698,12 @@
       "gempId": "6_133",
       "side": "Dark",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•••Weequay Skiff Master",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/weequayskiffmaster.gif",
@@ -55423,7 +65731,12 @@
       "gempId": "6_150",
       "side": "Dark",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Well Guarded",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/wellguarded.gif",
@@ -55444,7 +65757,12 @@
       "id": 6754,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Well Guarded (v)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/wellguarded.gif",
@@ -55460,7 +65778,12 @@
       "gempId": "13_96",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•We'll Let Fate-a Decide, Huh?",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/wellletfateadecidehuh.gif",
@@ -55484,7 +65807,12 @@
       "id": 6755,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•We'll Let Fate-a Decide, Huh? (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Dark/large/wellletfateadecidehuh.gif",
@@ -55505,7 +65833,12 @@
       "gempId": "8_133",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Well-earned Command",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/wellearnedcommand.gif",
@@ -55530,7 +65863,12 @@
       "id": 6756,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Well-earned Command (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/wellearnedcommand.gif",
@@ -55546,7 +65884,12 @@
       "gempId": "1_278",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "We're All Gonna Be A Lot Thinner!",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/wereallgonnabealotthinner.gif",
@@ -55565,7 +65908,12 @@
       "id": 6757,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "We're All Gonna Be A Lot Thinner! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Dark/large/wereallgonnabealotthinner.gif",
@@ -55582,7 +65930,12 @@
       "gempId": "14_110",
       "side": "Dark",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "••We're Hit, Artoo",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Dark/large/werehitartoo.gif",
@@ -55603,7 +65956,12 @@
       "gempId": "9_96",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•We're In Attack Position Now",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/wereinattackpositionnow.gif",
@@ -55626,7 +65984,12 @@
       "gempId": "5_128",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•We're The Bait",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/werethebait.gif",
@@ -55647,7 +66010,12 @@
       "id": 6758,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•We're The Bait (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/werethebait.gif",
@@ -55666,7 +66034,12 @@
       "gempId": "13_97",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Where Are Those Droidekas?!",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/wherearethosedroidekas.gif",
@@ -55689,7 +66062,12 @@
       "id": 6759,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Where Are Those Droidekas?! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/wherearethosedroidekas.gif",
@@ -55709,7 +66087,12 @@
       "gempId": "208_42",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Where Are Those Droidekas?! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/wherearethosedroidekas.gif",
@@ -55733,7 +66116,12 @@
       "id": 6760,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Where Are You Taking Them?",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/whereareyoutakingthem.gif",
@@ -55751,7 +66139,12 @@
       "id": 6761,
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Where Are You Taking This ... Thing?",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/whereareyoutakingthisthing.gif",
@@ -55767,7 +66160,12 @@
       "gempId": "6_134",
       "side": "Dark",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Whiphid",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/whiphid.gif",
@@ -55791,7 +66189,12 @@
       "gempId": "5_162",
       "side": "Dark",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Why Didn't You Tell Me?",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/whydidntyoutellme.gif",
@@ -55819,7 +66222,12 @@
       "id": 6762,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Why Didn't You Tell Me? (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/whydidntyoutellme.gif",
@@ -55839,7 +66247,12 @@
       "gempId": "12_143",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Wipe Them Out, All Of Them",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/wipethemoutallofthem.gif",
@@ -55863,7 +66276,12 @@
       "gempId": "13_98",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Wipe Them Out, All Of Them",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/wipethemoutallofthem.gif",
@@ -55884,7 +66302,12 @@
       "id": 6763,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Wipe Them Out, All Of Them (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/wipethemoutallofthem.gif",
@@ -55903,7 +66326,12 @@
       "id": 6764,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•With Thunderous Applause",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Dark/large/withthunderousapplause.gif",
@@ -55924,7 +66352,12 @@
       "gempId": "6_135",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Wittin",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/wittin.gif",
@@ -55956,7 +66389,12 @@
       "gempId": "7_318",
       "side": "Dark",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Wittin's Sandcrawler",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/wittinssandcrawler.gif",
@@ -55982,7 +66420,12 @@
       "gempId": "7_215",
       "side": "Dark",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•••Womp Rat",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Dark/large/womprat.gif",
@@ -56014,7 +66457,12 @@
       "id": 6765,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "Wookiee Slaving Operation / Indentured To The Empire",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/wookieeslavingoperation.gif",
@@ -56035,7 +66483,12 @@
       "id": 6766,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Wookiee Subjugation",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/wookieesubjugation.gif",
@@ -56052,7 +66505,12 @@
       "gempId": "6_136",
       "side": "Dark",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Wooof",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/wooof.gif",
@@ -56083,7 +66541,12 @@
       "id": 6767,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Wooof (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/wooof.gif",
@@ -56108,7 +66571,12 @@
       "gempId": "201_27",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Wooof (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Dark/large/wooof.gif",
@@ -56144,7 +66612,12 @@
       "gempId": "8_154",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Wounded Warrior",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/woundedwarrior.gif",
@@ -56165,7 +66638,12 @@
       "gempId": "6_161",
       "side": "Dark",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Wounded Wookiee",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/woundedwookiee.gif",
@@ -56185,7 +66663,12 @@
       "id": 6768,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Wounded Wookiee (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/woundedwookiee.gif",
@@ -56205,7 +66688,12 @@
       "gempId": "1_232",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Wrong Turn",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/wrongturn.gif",
@@ -56231,7 +66719,12 @@
       "gempId": "1_198",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Wuher",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/wuher.gif",
@@ -56253,7 +66746,12 @@
       "gempId": "206_12",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 6",
+      "set": "206",
+      "printings": [
+        {
+          "set": "206"
+        }
+      ],
       "front": {
         "title": "•Xizor's Bounty",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual6-Dark/large/xizorsbounty.gif",
@@ -56283,7 +66781,12 @@
       "gempId": "209_51",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Xizor's Palace: Sewer",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Dark/large/xizorspalacesewer.gif",
@@ -56306,7 +66809,12 @@
       "gempId": "203_34",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•Xizor's Palace: Uplink Station",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Dark/large/xizorspalaceuplinkstation.gif",
@@ -56336,7 +66844,12 @@
       "gempId": "12_125",
       "side": "Dark",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Yade M'rak",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/yademrak.gif",
@@ -56372,7 +66885,12 @@
       "gempId": "3_142",
       "side": "Dark",
       "rarity": "R2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Yaggle Gakkle",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Dark/large/yagglegakkle.gif",
@@ -56392,7 +66910,12 @@
       "gempId": "1_296",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Yavin 4",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/yavin4.gif",
@@ -56420,7 +66943,12 @@
       "gempId": "1_297",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Yavin 4: Docking Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/yavin4dockingbay.gif",
@@ -56452,7 +66980,12 @@
       "gempId": "1_298",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Yavin 4: Jungle",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/yavin4jungle.gif",
@@ -56476,7 +67009,12 @@
       "gempId": "12_126",
       "side": "Dark",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Yeb Yeb Adem'thorn",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/yebyebademthorn.gif",
@@ -56513,7 +67051,12 @@
       "gempId": "5_163",
       "side": "Dark",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•You Are Beaten",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Dark/large/youarebeaten.gif",
@@ -56545,7 +67088,12 @@
       "gempId": "9_133",
       "side": "Dark",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•You Cannot Hide Forever",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/youcannothideforever.gif",
@@ -56605,7 +67153,12 @@
       "gempId": "13_99",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•You Cannot Hide Forever",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/youcannothideforever.gif",
@@ -56626,7 +67179,12 @@
       "gempId": "12_144",
       "side": "Dark",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•You Cannot Hide Forever & •Mobilization Points",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Dark/large/youcannothideforever&mobilizationpoints.gif",
@@ -56693,7 +67251,12 @@
       "id": 6770,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•You Cannot Hide Forever (Death Star II) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Dark/large/youcannothideforeverv.gif",
@@ -56713,7 +67276,12 @@
       "gempId": "200_100",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 0",
+      "set": "200d",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•You Cannot Hide Forever (Death Star II) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/ResetDS-Dark/large/youcannothideforeverv.gif",
@@ -56732,7 +67300,12 @@
       "id": 6772,
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•You Cannot Hide Forever (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Dark/large/youcannothideforever.gif",
@@ -56752,7 +67325,12 @@
       "gempId": "200_100",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 0",
+      "set": "200d",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•You Cannot Hide Forever (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/ResetDS-Dark/large/youcannothideforever.gif",
@@ -56788,7 +67366,12 @@
       "gempId": "208_46",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•You Know What I've Come For",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/youknowwhativecomefor.gif",
@@ -56812,7 +67395,12 @@
       "gempId": "11_77",
       "side": "Dark",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•You May Start Your Landing",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/youmaystartyourlanding.gif",
@@ -56837,7 +67425,12 @@
       "id": 6773,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•You May Start Your Landing (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/youmaystartyourlanding.gif",
@@ -56853,7 +67446,12 @@
       "gempId": "1_279",
       "side": "Dark",
       "rarity": "C1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "You Overestimate Their Chances",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/youoverestimatetheirchances.gif",
@@ -56874,7 +67472,12 @@
       "id": 6774,
       "side": "Dark",
       "rarity": "C1",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "You Overestimate Their Chances (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Dark/large/youoverestimatetheirchances.gif",
@@ -56891,7 +67494,12 @@
       "gempId": "8_155",
       "side": "Dark",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•You Rebel Scum",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Dark/large/yourebelscum.gif",
@@ -56916,7 +67524,12 @@
       "gempId": "11_91",
       "side": "Dark",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•You Swindled Me!",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/youswindledme.gif",
@@ -56936,7 +67549,12 @@
       "id": 6775,
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•You Swindled Me! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/youswindledme.gif",
@@ -56956,7 +67574,12 @@
       "gempId": "208_47",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•You Swindled Me! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Dark/large/youswindledme.gif",
@@ -56977,7 +67600,12 @@
       "gempId": "11_78",
       "side": "Dark",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•You Want This, Don't You?",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Dark/large/youwantthisdontyou.gif",
@@ -56998,7 +67626,12 @@
       "id": 6776,
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•You Want This, Don't You? (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Dark/large/youwantthisdontyou.gif",
@@ -57018,7 +67651,12 @@
       "id": 6777,
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•You'll Be Dead!",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/youllbedead!.gif",
@@ -57034,7 +67672,12 @@
       "gempId": "200_114",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•You'll Be Dead!",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/youllbedead!.gif",
@@ -57056,7 +67699,12 @@
       "gempId": "9_141",
       "side": "Dark",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Young Fool",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/youngfool.gif",
@@ -57077,7 +67725,12 @@
       "gempId": "9_134",
       "side": "Dark",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Your Destiny",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Dark/large/yourdestiny.gif",
@@ -57100,7 +67753,12 @@
       "gempId": "1_233",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Your Eyes Can Deceive You",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/youreyescandeceiveyou.gif",
@@ -57121,7 +67779,12 @@
       "gempId": "1_280",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Your Powers Are Weak, Old Man",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/yourpowersareweakoldman.gif",
@@ -57143,7 +67806,12 @@
       "id": 6778,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Your Powers Are Weak, Old Man (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/yourpowersareweakoldman.gif",
@@ -57160,7 +67828,12 @@
       "gempId": "13_100",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•You've Never Won A Race?",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Dark/large/youveneverwonarace.gif",
@@ -57180,7 +67853,12 @@
       "id": 6779,
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Ysanne Isard",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Dark/large/ysanneisard.gif",
@@ -57207,7 +67885,12 @@
       "gempId": "200_92",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Ysanne Isard",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/ysanneisard.gif",
@@ -57244,7 +67927,12 @@
       "gempId": "6_137",
       "side": "Dark",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•••Yuzzum",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Dark/large/yuzzum.gif",
@@ -57279,7 +67967,12 @@
       "gempId": "204_46",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Zam Wesell",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Dark/large/zamwesell.gif",
@@ -57316,7 +68009,12 @@
       "gempId": "4_107",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Zuckuss",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/zuckuss.gif",
@@ -57362,7 +68060,12 @@
       "id": 6780,
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Zuckuss (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Dark/large/zuckuss.gif",
@@ -57391,7 +68094,12 @@
       "gempId": "110_12",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Enhanced Jabba's Palace",
+      "set": "110",
+      "printings": [
+        {
+          "set": "110"
+        }
+      ],
       "front": {
         "title": "•Zuckuss In Mist Hunter",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedJabbasPalace-Dark/large/zuckussinmisthunter.gif",
@@ -57427,7 +68135,12 @@
       "gempId": "4_180",
       "side": "Dark",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Zuckuss' Snare Rifle",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Dark/large/zuckusssnarerifle.gif",
@@ -57454,7 +68167,12 @@
       "gempId": "212_5",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 12",
+      "set": "212",
+      "printings": [
+        {
+          "set": "212"
+        }
+      ],
       "front": {
         "title": "•Admiral Trench",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual12-Dark/large/admiraltrench.gif",
@@ -57492,7 +68210,12 @@
       "gempId": "212_6",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 12",
+      "set": "212",
+      "printings": [
+        {
+          "set": "212"
+        }
+      ],
       "front": {
         "title": "•Allegiant General Pryde",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual12-Dark/large/allegiantgeneralpryde.gif",
@@ -57528,7 +68251,12 @@
       "gempId": "212_3",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 12",
+      "set": "212",
+      "printings": [
+        {
+          "set": "212"
+        }
+      ],
       "front": {
         "title": "•Aurra Sing With Blaster Rifle",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual12-Dark/large/aurrasingwithblasterrifle.gif",
@@ -57561,7 +68289,12 @@
       "gempId": "212_2",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Set 12",
+      "set": "212",
+      "printings": [
+        {
+          "set": "212"
+        }
+      ],
       "front": {
         "title": "•Moff Gideon",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual12-Dark/large/moffgideon.gif",
@@ -57596,7 +68329,12 @@
       "gempId": "212_1",
       "side": "Dark",
       "rarity": "PM",
-      "set": "Virtual Set 12",
+      "set": "212",
+      "printings": [
+        {
+          "set": "212"
+        }
+      ],
       "front": {
         "title": "•Evil Is Everywhere",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual12-Dark/large/eviliseverywhere.gif",
@@ -57616,7 +68354,12 @@
       "gempId": "212_4",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 12",
+      "set": "212",
+      "printings": [
+        {
+          "set": "212"
+        }
+      ],
       "front": {
         "title": "•Slip Sliding Away (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual12-Dark/large/slipslidingaway.gif",
@@ -57641,7 +68384,12 @@
       "gempId": "210_47",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•Insignificant Rebellion (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/cards/Virtual10-Dark/large/insignificantrebellion.gif",
@@ -57660,7 +68408,12 @@
       "gempId": "213_1",
       "side": "Dark",
       "rarity": "R1",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Admiral Ozzel (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/admiralozzel.gif",
@@ -57697,7 +68450,12 @@
       "gempId": "213_4",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Dryden Vos",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/drydenvos.gif",
@@ -57731,7 +68489,12 @@
       "gempId": "213_7",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "••Hylobon Enforcer",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/hylobonenforcer.gif",
@@ -57761,7 +68524,12 @@
       "gempId": "213_2",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Aemon Gremm With Percussive Cannon",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/aemongremmwithpercussivecannon.gif",
@@ -57792,7 +68560,12 @@
       "gempId": "213_5",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Eighth Brother",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/eighthbrother.gif",
@@ -57821,7 +68594,12 @@
       "gempId": "213_3",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Darth Tyranus",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/darthtyranus.gif",
@@ -57855,7 +68633,12 @@
       "gempId": "213_6",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Fifth Brother",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/fifthbrother.gif",
@@ -57887,7 +68670,12 @@
       "gempId": "213_8",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•••ID9 Probe Droid",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/id9probedroid.gif",
@@ -57915,7 +68703,12 @@
       "gempId": "213_11",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Ninth Sister",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/ninthsister.gif",
@@ -57948,7 +68741,12 @@
       "gempId": "213_9",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Margo",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/margo.gif",
@@ -57974,7 +68772,12 @@
       "gempId": "213_12",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Seventh Sister",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/seventhsister.gif",
@@ -58007,7 +68810,12 @@
       "gempId": "213_10",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Maul",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/maul.gif",
@@ -58040,7 +68848,12 @@
       "gempId": "213_13",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 13",
+      "set": "200d",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Failure At The Cave (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/failureatthecave.gif",
@@ -58060,7 +68873,12 @@
       "gempId": "213_14",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "<>Planetary Rings",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/planetaryrings.gif",
@@ -58077,7 +68895,12 @@
       "gempId": "213_15",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•There Are Many Hunting You Now",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/therearemanyhuntingyounow.gif",
@@ -58094,7 +68917,12 @@
       "gempId": "213_16",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Visage Of The Emperor (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/visageoftheemperor.gif",
@@ -58125,7 +68953,12 @@
       "gempId": "213_17",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•A Lawless Time",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/alawlesstime.gif",
@@ -58143,7 +68976,12 @@
       "gempId": "213_21",
       "side": "Dark",
       "rarity": "C2",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "Imperial Code Cylinder (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/imperialcodecylinder.gif",
@@ -58160,7 +68998,12 @@
       "gempId": "213_18",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Far More Frightening Than Death",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/farmorefrighteningthandeath.gif",
@@ -58178,7 +69021,12 @@
       "gempId": "213_19",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•I Never Ask For Anything Twice",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/ineveraskforanythingtwice.gif",
@@ -58196,7 +69044,12 @@
       "gempId": "213_20",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "I've Been Searching For You For Some Time",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/ivebeensearchingforyouforsometime.gif",
@@ -58213,7 +69066,12 @@
       "gempId": "213_22",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Working Much More Closely",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/workingmuchmoreclosely.gif",
@@ -58234,7 +69092,12 @@
       "gempId": "213_23",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Dathomir: Maul's Chambers",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/dathomirmaulschambers.gif",
@@ -58257,7 +69120,12 @@
       "gempId": "213_24",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Executor: Control Station",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/executorcontrolstation.gif",
@@ -58285,7 +69153,12 @@
       "gempId": "213_25",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•First Light: Bar",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/firstlightbar.gif",
@@ -58309,7 +69182,12 @@
       "gempId": "213_26",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•First Light: Dryden's Study",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/firstlightdrydensstudy.gif",
@@ -58333,7 +69211,12 @@
       "gempId": "213_27",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•First Light: Reception Area",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/firstlightreceptionarea.gif",
@@ -58357,7 +69240,12 @@
       "gempId": "213_28",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Malachor: Sith Temple Upper Chamber",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/malachorsithtempleupperchamber.gif",
@@ -58380,7 +69268,12 @@
       "gempId": "213_29",
       "side": "Dark",
       "rarity": "U2",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Malachor: Sith Temple Entrance",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/malachorsithtempleentrance.gif",
@@ -58404,7 +69297,12 @@
       "gempId": "213_30",
       "side": "Dark",
       "rarity": "U",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Wakeelmui (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/wakeelmui.gif",
@@ -58434,7 +69332,12 @@
       "gempId": "213_33",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "Black Sun Blaster",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/blacksunblaster.gif",
@@ -58454,7 +69357,12 @@
       "gempId": "213_34",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•••Crimson Dawn Blaster",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/crimsondawnblaster.gif",
@@ -58475,7 +69383,12 @@
       "gempId": "213_31",
       "side": "Dark",
       "rarity": "R",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "Hunt Down And Destroy The Jedi / Their Fire Has Gone Out Of The Universe (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/huntdownanddestroythejedi.gif",
@@ -58497,7 +69410,12 @@
       "gempId": "213_32",
       "side": "Dark",
       "rarity": "C",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "Shadow Collective / You Know Who I Answer To",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/shadowcollective.gif",
@@ -58519,7 +69437,12 @@
       "gempId": "301_6",
       "side": "Dark",
       "rarity": "U1",
-      "set": "Virtual Premium Set",
+      "set": "301",
+      "printings": [
+        {
+          "set": "301"
+        }
+      ],
       "front": {
         "title": "•Captain Khurgee (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/VirtualPremium-Dark/large/captainkhurgee.gif",

--- a/Light.json
+++ b/Light.json
@@ -5,7 +5,12 @@
       "gempId": "3_1",
       "side": "Light",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•2-1B (Too-Onebee)",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/21btooonebee.gif",
@@ -31,7 +36,12 @@
       "id": 5301,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•2-1B (Too-Onebee) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/21btooonebee.gif",
@@ -57,7 +67,12 @@
       "gempId": "1_1",
       "side": "Light",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "2X-3KPR (Tooex)",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/2x3kpr.gif",
@@ -87,7 +102,12 @@
       "gempId": "6_1",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•8D8",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/8d8.gif",
@@ -119,7 +139,12 @@
       "gempId": "209_16",
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•A Brave Resistance",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/abraveresistance.gif",
@@ -135,7 +160,12 @@
       "gempId": "13_1",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•A Close Race",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/acloserace.gif",
@@ -156,7 +186,12 @@
       "gempId": "1_70",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "A Few Maneuvers",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/afewmaneuvers.gif",
@@ -180,7 +215,12 @@
       "gempId": "6_52",
       "side": "Light",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•A Gift",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/agift.gif",
@@ -206,7 +246,12 @@
       "id": 5303,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•A Good Blaster At Your Side",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/agoodblasteratyourside.gif",
@@ -222,7 +267,12 @@
       "gempId": "200_34",
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•A Good Blaster At Your Side",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/agoodblasteratyourside.gif",
@@ -243,7 +293,12 @@
       "id": 5304,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•A Grand Army Of The Republic",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/agrandarmyoftherepublic.gif",
@@ -262,7 +317,12 @@
       "gempId": "11_26",
       "side": "Light",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•A Jedi's Concentration",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/ajedisconcentration.gif",
@@ -283,7 +343,12 @@
       "id": 5305,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•A Jedi's Cunning",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/ajediscunning.gif",
@@ -302,7 +367,12 @@
       "gempId": "11_27",
       "side": "Light",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•A Jedi's Focus",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/ajedisfocus.gif",
@@ -324,7 +394,12 @@
       "gempId": "11_28",
       "side": "Light",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•A Jedi's Patience",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/ajedispatience.gif",
@@ -344,7 +419,12 @@
       "id": 5306,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•A Jedi's Patience (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/ajedispatience.gif",
@@ -364,7 +444,12 @@
       "id": 5307,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•A Jedi's Plans",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/ajedisplans.gif",
@@ -383,7 +468,12 @@
       "gempId": "11_29",
       "side": "Light",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•A Jedi's Resilience",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/ajedisresilience.gif",
@@ -405,7 +495,12 @@
       "gempId": "4_75",
       "side": "Light",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "A Jedi's Strength",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/ajedisstrength.gif",
@@ -423,7 +518,12 @@
       "gempId": "111_1",
       "side": "Light",
       "rarity": "PM",
-      "set": "Third Anthology",
+      "set": "111",
+      "printings": [
+        {
+          "set": "111"
+        }
+      ],
       "front": {
         "title": "•A New Secret Base",
         "imageUrl": "https://res.starwarsccg.org/cards/ThirdAnthology-Light/large/anewsecretbase.gif",
@@ -484,7 +584,12 @@
       "gempId": "201_8",
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•A New Secret Base (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Light/large/anewsecretbase.gif",
@@ -537,7 +642,12 @@
       "gempId": "13_2",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•A Remote Planet",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/aremoteplanet.gif",
@@ -560,7 +670,12 @@
       "id": 5308,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•A Remote Planet (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/aremoteplanet.gif",
@@ -580,7 +695,12 @@
       "gempId": "11_30",
       "side": "Light",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•A Step Backward",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/astepbackward.gif",
@@ -611,7 +731,12 @@
       "gempId": "12_37",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•A Tragedy Has Occurred",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/atragedyhasoccurred.gif",
@@ -636,7 +761,12 @@
       "gempId": "13_3",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•A Tragedy Has Occurred",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/atragedyhasoccurred.gif",
@@ -659,7 +789,12 @@
       "gempId": "1_42",
       "side": "Light",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•A Tremor In The Force",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/atremorintheforce.gif",
@@ -687,7 +822,12 @@
       "id": 5309,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•A Tremor In The Force (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/atremorintheforce.gif",
@@ -703,7 +843,12 @@
       "gempId": "12_38",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•••A Vergence In The Force",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/avergenceintheforce.gif",
@@ -733,7 +878,12 @@
       "gempId": "9_62",
       "side": "Light",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "A-wing",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/awing.gif",
@@ -769,7 +919,12 @@
       "gempId": "9_86",
       "side": "Light",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "A-wing Cannon",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/awingcannon.gif",
@@ -794,7 +949,12 @@
       "gempId": "8_84",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "••A280 Sharpshooter Rifle",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/a280sharpshooterrifle.gif",
@@ -821,7 +981,12 @@
       "id": 5310,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "••A280 Sharpshooter Rifle (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/a280sharpshooterrifle.gif",
@@ -840,7 +1005,12 @@
       "id": 5311,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Aayla Secura",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/aaylasecura.gif",
@@ -868,7 +1038,12 @@
       "gempId": "200_1",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Aayla Secura",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/aaylasecura.gif",
@@ -904,7 +1079,12 @@
       "gempId": "200_1",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Aayla Secura (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/aaylasecurah.gif",
@@ -932,7 +1112,12 @@
       "gempId": "5_15",
       "side": "Light",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Access Denied",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/accessdenied.gif",
@@ -962,7 +1147,12 @@
       "id": 5313,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Access Denied (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/accessdenied.gif",
@@ -980,7 +1170,12 @@
       "id": 5314,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "Acclamator-Class Assault Ship",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/acclamatorclassassaultship.gif",
@@ -1009,7 +1204,12 @@
       "gempId": "200_59",
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "Acclamator-Class Assault Ship",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/acclamatorclassassaultship.gif",
@@ -1037,7 +1237,12 @@
       "gempId": "9_6",
       "side": "Light",
       "rarity": "XR",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Admiral Ackbar",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/admiralackbar.gif",
@@ -1095,7 +1300,12 @@
       "id": 5315,
       "side": "Light",
       "rarity": "XR",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Admiral Ackbar (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/admiralackbar.gif",
@@ -1123,7 +1333,12 @@
       "gempId": "203_1",
       "side": "Light",
       "rarity": "XR",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•Admiral Ackbar (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Light/large/admiralackbar.gif",
@@ -1169,7 +1384,12 @@
       "gempId": "209_1",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Admiral Raddus",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/admiralraddus.gif",
@@ -1200,7 +1420,12 @@
       "gempId": "208_1",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Admiral U.O. Statura",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/admiraluostatura.gif",
@@ -1233,7 +1458,12 @@
       "gempId": "2_43",
       "side": "Light",
       "rarity": "U1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Advance Preparation",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/advancepreparation.gif",
@@ -1252,7 +1482,12 @@
       "id": 5317,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Advance Preparation (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/advancepreparation.gif",
@@ -1272,7 +1507,12 @@
       "gempId": "5_16",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Advantage",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/advantage.gif",
@@ -1296,7 +1536,12 @@
       "id": 5318,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Advantage (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/advantage.gif",
@@ -1315,7 +1560,12 @@
       "gempId": "1_43",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Affect Mind",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/affectmind.gif",
@@ -1339,7 +1589,12 @@
       "id": 5319,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•Affect Mind (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Light/large/affectmind.gif",
@@ -1358,7 +1613,12 @@
       "gempId": "200_25",
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Set 0",
+      "set": "200d",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Affect Mind (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/ResetDS-Light/large/affectmind.gif",
@@ -1378,7 +1638,12 @@
       "gempId": "112_1",
       "side": "Light",
       "rarity": "PM",
-      "set": "Jabba's Palace Sealed Deck",
+      "set": "112",
+      "printings": [
+        {
+          "set": "112"
+        }
+      ],
       "front": {
         "title": "Agents In The Court / No Love For The Empire",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalaceSealedDeck-Light/large/agentsinthecourt.gif",
@@ -1400,7 +1665,12 @@
       "gempId": "211_48",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Ahch-To",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/ahchto.gif",
@@ -1423,7 +1693,12 @@
       "gempId": "211_47",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Ahch-To: Cliffs",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/ahchtocliffs.gif",
@@ -1446,7 +1721,12 @@
       "gempId": "211_46",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Ahch-To: Jedi Temple",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/ahchtojeditemple.gif",
@@ -1470,7 +1750,12 @@
       "gempId": "211_45",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Ahch-To: Jedi Village",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/ahchtojedivillage.gif",
@@ -1493,7 +1778,12 @@
       "gempId": "211_44",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Ahch-To: Luke's Hut",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/ahchtolukeshut.gif",
@@ -1516,7 +1806,12 @@
       "gempId": "210_1",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•Ahch-To: Saddle",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Light/large/ahchtosaddle.gif",
@@ -1539,7 +1834,12 @@
       "gempId": "211_59",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Ahsoka Tano",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/ahsokatano.gif",
@@ -1571,7 +1871,12 @@
       "gempId": "301_1",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Premium Set",
+      "set": "301",
+      "printings": [
+        {
+          "set": "301"
+        }
+      ],
       "front": {
         "title": "•Ahsoka Tano With Lightsabers",
         "imageUrl": "https://res.starwarsccg.org/cards/DemoDeck-Light/large/ahsokatanowithlightsabers.gif",
@@ -1610,7 +1915,12 @@
       "gempId": "8_34",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Aim High",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/aimhigh.gif",
@@ -1636,7 +1946,12 @@
       "gempId": "13_4",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Aim High",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/aimhigh.gif",
@@ -1657,7 +1972,12 @@
       "gempId": "7_151",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Air-2 Racing Swoop",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/air2racingswoop.gif",
@@ -1682,7 +2002,12 @@
       "gempId": "1_121",
       "side": "Light",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Alderaan",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/alderaan.gif",
@@ -1710,7 +2035,12 @@
       "id": 5328,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Alderaan (Blown Away)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/alderaanblownaway.gif",
@@ -1731,7 +2061,12 @@
       "id": 5329,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "Alderaan Consular Ship",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/alderaanconsularship.gif",
@@ -1759,7 +2094,12 @@
       "gempId": "7_1",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Alderaan Operative",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/alderaanoperative.gif",
@@ -1794,7 +2134,12 @@
       "gempId": "5_17",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•All My Urchins",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/allmyurchins.gif",
@@ -1819,7 +2164,12 @@
       "id": 5330,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•All My Urchins & •Cloud City Celebration",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/allmyurchinsandcloudcitycelebration.gif",
@@ -1836,7 +2186,12 @@
       "id": 5331,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•All My Urchins (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/allmyurchins.gif",
@@ -1855,7 +2210,12 @@
       "gempId": "7_82",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•All Wings Report In",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/allwingsreportin.gif",
@@ -1893,7 +2253,12 @@
       "gempId": "12_53",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•All Wings Report In & •Darklighter Spin",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/allwingsreportin&darklighterspin.gif",
@@ -1966,7 +2331,12 @@
       "gempId": "12_54",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Alter",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/alter.gif",
@@ -2010,7 +2380,12 @@
       "gempId": "1_71",
       "side": "Light",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Alter",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/alter.gif",
@@ -2046,7 +2421,12 @@
       "gempId": "10_1",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "Alter & Friendly Fire",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Light/large/alter&friendlyfire.gif",
@@ -2076,7 +2456,12 @@
       "id": 5332,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "Alter (Coruscant) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/altercoruscant.gif",
@@ -2097,7 +2482,12 @@
       "gempId": "200_143",
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "Alter (Coruscant) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/altercoruscant.gif",
@@ -2117,7 +2507,12 @@
       "id": 5334,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "Alter (Premiere) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/alterpremiere.gif",
@@ -2134,7 +2529,12 @@
       "gempId": "200_48",
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "Alter (Premiere) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/alterpremiere.gif",
@@ -2151,7 +2551,12 @@
       "gempId": "2_44",
       "side": "Light",
       "rarity": "U1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Alternatives To Fighting",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/alternativestofighting.gif",
@@ -2175,7 +2580,12 @@
       "gempId": "5_31",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Ambush",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/ambush.gif",
@@ -2192,7 +2602,12 @@
       "id": 5336,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Ambush (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/ambush.gif",
@@ -2213,7 +2628,12 @@
       "gempId": "210_2",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•Ambush (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Light/large/ambush.gif",
@@ -2234,7 +2654,12 @@
       "gempId": "14_62",
       "side": "Light",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Amidala's Blaster",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/amidalasblaster.gif",
@@ -2268,7 +2693,12 @@
       "gempId": "13_5",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•An Unusual Amount Of Fear",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/anunusualamountoffear.gif",
@@ -2293,7 +2723,12 @@
       "id": 5338,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•An Unusual Amount Of Fear (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/anunusualamountoffear.gif",
@@ -2313,7 +2748,12 @@
       "gempId": "9_48",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Anakin Skywalker",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/anakinskywalker.gif",
@@ -2333,7 +2773,12 @@
       "id": 5339,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Anakin Skywalker, Padawan Learner",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/anakinskywalkerpadawanlearner.gif",
@@ -2363,7 +2808,12 @@
       "gempId": "200_2",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Anakin Skywalker, Padawan Learner",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/anakinskywalkerpadawanlearner.gif",
@@ -2400,7 +2850,12 @@
       "gempId": "200_2",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Anakin Skywalker, Padawan Learner (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/OfficialAI-Light/large/anakinskywalkerpadawanlearner.gif",
@@ -2429,7 +2884,12 @@
       "id": 5341,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Anakin Solo",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/anakinsolo.gif",
@@ -2457,7 +2917,12 @@
       "gempId": "3_71",
       "side": "Light",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Anakin's Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/anakinslightsaber.gif",
@@ -2512,7 +2977,12 @@
       "id": 5342,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Anakin's Lightsaber (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/anakinslightsaber.gif",
@@ -2533,7 +3003,12 @@
       "gempId": "210_3",
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•Anakin's Lightsaber (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Light/large/anakinslightsaber.gif",
@@ -2555,7 +3030,12 @@
       "gempId": "11_47",
       "side": "Light",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Anakin's Podracer",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/anakinspodracer.gif",
@@ -2578,7 +3058,12 @@
       "gempId": "210_7",
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•Ancient Watering Hole",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Light/large/ancientwateringhole.gif",
@@ -2597,7 +3082,12 @@
       "gempId": "4_16",
       "side": "Light",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Anger, Fear, Aggression",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/angerfearaggression.gif",
@@ -2625,7 +3115,12 @@
       "id": 5345,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Anger, Fear, Aggression (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/angerfearaggression.gif",
@@ -2645,7 +3140,12 @@
       "gempId": "200_35",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Anger, Fear, Aggression (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/angerfearaggression.gif",
@@ -2667,7 +3167,12 @@
       "gempId": "4_80",
       "side": "Light",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Anoat",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/anoat.gif",
@@ -2701,7 +3206,12 @@
       "gempId": "201_16",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Anoat (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Light/large/anoat.gif",
@@ -2735,7 +3245,12 @@
       "gempId": "7_2",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Anoat Operative",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/anoatoperative.gif",
@@ -2771,7 +3286,12 @@
       "gempId": "12_39",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Another Pathetic Lifeform",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/anotherpatheticlifeform.gif",
@@ -2795,7 +3315,12 @@
       "gempId": "13_6",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Another Pathetic Lifeform",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/anotherpatheticlifeform.gif",
@@ -2817,7 +3342,12 @@
       "gempId": "7_83",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Antilles Maneuver",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/antillesmaneuver.gif",
@@ -2838,7 +3368,12 @@
       "id": 5346,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Antilles Maneuver & •Rebel Reinforcements",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/antillesmaneuver&rebelreinforcements.gif",
@@ -2856,7 +3391,12 @@
       "id": 5347,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Antilles Maneuver (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/antillesmaneuver.gif",
@@ -2876,7 +3416,12 @@
       "gempId": "200_49",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Antilles Maneuver (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/antillesmaneuver.gif",
@@ -2901,7 +3446,12 @@
       "gempId": "9_56",
       "side": "Light",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Aquaris",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/aquaris.gif",
@@ -2930,7 +3480,12 @@
       "gempId": "6_49",
       "side": "Light",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Arc Welder",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/arcwelder.gif",
@@ -2954,7 +3509,12 @@
       "gempId": "2_1",
       "side": "Light",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•••Arcona",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/arcona.gif",
@@ -2990,7 +3550,12 @@
       "gempId": "6_2",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Ardon 'Vapor' Crell",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/ardonvaporcrell.gif",
@@ -3015,7 +3580,12 @@
       "gempId": "12_55",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Are You Brain Dead?!",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/areyoubraindead.gif",
@@ -3036,7 +3606,12 @@
       "gempId": "204_17",
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Are You Okay?",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/areyouokay.gif",
@@ -3056,7 +3631,12 @@
       "gempId": "106_1",
       "side": "Light",
       "rarity": "PM",
-      "set": "Official Tournament Sealed Deck",
+      "set": "106",
+      "printings": [
+        {
+          "set": "106"
+        }
+      ],
       "front": {
         "title": "•Arleil Schous",
         "imageUrl": "https://res.starwarsccg.org/cards/OfficialTournamentSealedDeck-Light/large/arleilschous.gif",
@@ -3142,7 +3722,12 @@
       "gempId": "13_7",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Armament Dismantled",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/armamentdismantled.gif",
@@ -3166,7 +3751,12 @@
       "gempId": "5_32",
       "side": "Light",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Armed And Dangerous",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/armedanddangerous.gif",
@@ -3185,7 +3775,12 @@
       "id": 5348,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Armed And Dangerous & •Krayt Dragon Howl",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/armedanddangerous&kraytdragonhowl.gif",
@@ -3204,7 +3799,12 @@
       "gempId": "3_28",
       "side": "Light",
       "rarity": "R2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Artillery Remote",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/artilleryremote.gif",
@@ -3223,7 +3823,12 @@
       "id": 5349,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Artillery Remote (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/artilleryremote.gif",
@@ -3242,7 +3847,12 @@
       "gempId": "6_3",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Artoo",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/artoo.gif",
@@ -3289,7 +3899,12 @@
       "gempId": "10_2",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Artoo & •Threepio",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Light/large/artoo&threepio.gif",
@@ -3348,7 +3963,12 @@
       "id": 5350,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Artoo & •Threepio (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/artoo&threepio.gif",
@@ -3373,7 +3993,12 @@
       "id": 5351,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Artoo (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/artoo.gif",
@@ -3400,7 +4025,12 @@
       "gempId": "14_3",
       "side": "Light",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Artoo, Brave Little Droid",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/artoobravelittledroid.gif",
@@ -3444,7 +4074,12 @@
       "gempId": "14_4",
       "side": "Light",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Artoo, Brave Little Droid (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/artoobravelittledroidai.gif",
@@ -3470,7 +4105,12 @@
       "id": 5353,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Artoo, Brave Little Droid (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/artoobravelittledroid.gif",
@@ -3497,7 +4137,12 @@
       "id": 5354,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Artoo, Brave Little Droid (V) (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/artoobravelittledroidai.gif",
@@ -3525,7 +4170,12 @@
       "gempId": "5_33",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Artoo, Come Back At Once!",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/artoocomebackatonce.gif",
@@ -3558,7 +4208,12 @@
       "gempId": "6_60",
       "side": "Light",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Artoo, I Have A Bad Feeling About This",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/artooihaveabadfeelingaboutthis.gif",
@@ -3579,7 +4234,12 @@
       "gempId": "111_2",
       "side": "Light",
       "rarity": "PM",
-      "set": "Third Anthology",
+      "set": "111",
+      "printings": [
+        {
+          "set": "111"
+        }
+      ],
       "front": {
         "title": "•Artoo-Detoo In Red 5",
         "imageUrl": "https://res.starwarsccg.org/cards/ThirdAnthology-Light/large/artoodetooinred5.gif",
@@ -3629,7 +4289,12 @@
       "gempId": "5_34",
       "side": "Light",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "As Good As Gone",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/asgoodasgone.gif",
@@ -3649,7 +4314,12 @@
       "gempId": "14_40",
       "side": "Light",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Ascension Guns",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/ascensionguns.gif",
@@ -3672,7 +4342,12 @@
       "id": 5355,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Ascension Guns (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/ascensionguns.gif",
@@ -3694,7 +4369,12 @@
       "gempId": "201_11",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Ascension Guns (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Light/large/ascensionguns.gif",
@@ -3721,7 +4401,12 @@
       "gempId": "12_40",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Ascertaining The Truth",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/ascertainingthetruth.gif",
@@ -3750,7 +4435,12 @@
       "gempId": "7_3",
       "side": "Light",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "ASP-707 (Ayesspee)",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/asp707.gif",
@@ -3772,7 +4462,12 @@
       "id": 5356,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Assault on Muunilinst",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/assaultonmuunilinst.gif",
@@ -3790,7 +4485,12 @@
       "gempId": "4_81",
       "side": "Light",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "<><><>Asteroid Field",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/asteroidfield.gif",
@@ -3813,7 +4513,12 @@
       "gempId": "4_17",
       "side": "Light",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "<>Asteroid Sanctuary",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/asteroidsanctuary.gif",
@@ -3839,7 +4544,12 @@
       "gempId": "4_18",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Asteroids Do Not Concern Me",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/asteroidsdonotconcernme.gif",
@@ -3863,7 +4573,12 @@
       "id": 5357,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Asteroids Do Not Concern Me (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/asteroidsdonotconcernme.gif",
@@ -3882,7 +4597,12 @@
       "gempId": "4_8",
       "side": "Light",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Astromech Translator",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/astromechtranslator.gif",
@@ -3902,7 +4622,12 @@
       "gempId": "4_19",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•At Peace",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/atpeace.gif",
@@ -3927,7 +4652,12 @@
       "id": 5358,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•At Peace (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/atpeace.gif",
@@ -3945,7 +4675,12 @@
       "id": 5359,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "AT-RT",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/atrt.gif",
@@ -3971,7 +4706,12 @@
       "id": 5360,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•••AT-TE",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/atte.gif",
@@ -3997,7 +4737,12 @@
       "gempId": "3_72",
       "side": "Light",
       "rarity": "U2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Atgar Laser Cannon",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/atgarlasercannon.gif",
@@ -4024,7 +4769,12 @@
       "gempId": "3_40",
       "side": "Light",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Attack Pattern Delta",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/attackpatterndelta.gif",
@@ -4043,7 +4793,12 @@
       "id": 5361,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Attack Pattern Delta (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/attackpatterndelta.gif",
@@ -4063,7 +4818,12 @@
       "gempId": "2_42",
       "side": "Light",
       "rarity": "R2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Attack Run",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/attackrun.gif",
@@ -4085,7 +4845,12 @@
       "gempId": "6_4",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Attark",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/attark.gif",
@@ -4110,7 +4875,12 @@
       "id": 5362,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Attark (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/attark.gif",
@@ -4134,7 +4904,12 @@
       "gempId": "6_5",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Aved Luun",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/avedluun.gif",
@@ -4176,7 +4951,12 @@
       "id": 5363,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Aved Luun (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/avedluun.gif",
@@ -4203,7 +4983,12 @@
       "gempId": "4_45",
       "side": "Light",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Away Put Your Weapon",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/awayputyourweapon.gif",
@@ -4221,7 +5006,12 @@
       "id": 5364,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Away Put Your Weapon (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/awayputyourweapon.gif",
@@ -4240,7 +5030,12 @@
       "id": 5365,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Azure Angel",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/azureangel.gif",
@@ -4269,7 +5064,12 @@
       "gempId": "202_7",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 2",
+      "set": "202",
+      "printings": [
+        {
+          "set": "202"
+        }
+      ],
       "front": {
         "title": "•Azure Angel",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual2-Light/large/azureangel.gif",
@@ -4302,7 +5102,12 @@
       "gempId": "202_7",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 2",
+      "set": "202",
+      "printings": [
+        {
+          "set": "202"
+        }
+      ],
       "front": {
         "title": "•Azure Angel (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/OfficialAI-Light/large/azureangel.gif",
@@ -4331,7 +5136,12 @@
       "gempId": "7_140",
       "side": "Light",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "B-wing Attack Fighter",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/bwingattackfighter.gif",
@@ -4365,7 +5175,12 @@
       "gempId": "9_65",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "B-wing Attack Squadron",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/bwingattacksquadron.gif",
@@ -4396,7 +5211,12 @@
       "gempId": "9_66",
       "side": "Light",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "B-wing Bomber",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/bwingbomber.gif",
@@ -4429,7 +5249,12 @@
       "id": 5367,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Bacta Infirmary",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/bactainfirmary.gif",
@@ -4445,7 +5270,12 @@
       "gempId": "3_32",
       "side": "Light",
       "rarity": "R2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Bacta Tank",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/bactatank.gif",
@@ -4471,7 +5301,12 @@
       "id": 5368,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Bail Organa",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/bailorgana.gif",
@@ -4497,7 +5332,12 @@
       "gempId": "204_2",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Bail Organa",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/bailorgana.gif",
@@ -4528,7 +5368,12 @@
       "id": 5369,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Bail Organa, Father Of Rebellion",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/bailorganafatherofrebellion.gif",
@@ -4553,7 +5398,12 @@
       "gempId": "7_84",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Balanced Attack",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/balancedattack.gif",
@@ -4593,7 +5443,12 @@
       "id": 5370,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Balanced Attack (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/balancedattack.gif",
@@ -4613,7 +5468,12 @@
       "gempId": "6_6",
       "side": "Light",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•••Baragwin",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/baragwin.gif",
@@ -4645,7 +5505,12 @@
       "id": 5371,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•••Baragwin (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/baragwin.gif",
@@ -4670,7 +5535,12 @@
       "gempId": "6_53",
       "side": "Light",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Bargaining Table",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/bargainingtable.gif",
@@ -4691,7 +5561,12 @@
       "id": 5372,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Bargaining Table (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/bargainingtable.gif",
@@ -4710,7 +5585,12 @@
       "gempId": "12_56",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Baseless Accusations",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/baselessaccusations.gif",
@@ -4731,7 +5611,12 @@
       "gempId": "8_35",
       "side": "Light",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Battle Plan",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/battleplan.gif",
@@ -4755,7 +5640,12 @@
       "gempId": "13_8",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Battle Plan",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/battleplan.gif",
@@ -4776,7 +5666,12 @@
       "gempId": "12_41",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Battle Plan & •Draw Their Fire",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/battleplan&drawtheirfire.gif",
@@ -4800,7 +5695,12 @@
       "gempId": "207_1",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 7",
+      "set": "207",
+      "printings": [
+        {
+          "set": "207"
+        }
+      ],
       "front": {
         "title": "•Baze Malbus With Cannon",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual7-Light/large/bazemalbuswithcannon.gif",
@@ -4826,7 +5726,12 @@
       "gempId": "204_1",
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•BB-8 (Beebee-Ate)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/bb8.gif",
@@ -4854,7 +5759,12 @@
       "gempId": "211_28",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•BB-8 In Black Squadron 1",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/bb8inblacksquadron1.gif",
@@ -4880,7 +5790,12 @@
       "id": 5374,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•••Beast Rider",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/beastrider.gif",
@@ -4908,7 +5823,12 @@
       "gempId": "1_44",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Beggar",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/beggar.gif",
@@ -4935,7 +5855,12 @@
       "id": 5375,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Begun, The Clone War Has",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/beguntheclonewarhas.gif",
@@ -4954,7 +5879,12 @@
       "gempId": "5_18",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Beldon's Eye",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/beldonseye.gif",
@@ -4976,7 +5906,12 @@
       "gempId": "211_31",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Beldon's Eye & •All My Urchins",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/beldonseyeallmyurchins.gif",
@@ -4990,7 +5925,12 @@
       "id": 5377,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Beldon's Eye (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/beldonseye.gif",
@@ -5009,7 +5949,12 @@
       "gempId": "200_36",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Beldon's Eye (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/beldonseye.gif",
@@ -5057,7 +6002,12 @@
       "gempId": "7_4",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Ben Kenobi",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/benkenobi.gif",
@@ -5097,7 +6047,12 @@
       "gempId": "1_2",
       "side": "Light",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Beru Lars",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/berulars.gif",
@@ -5118,7 +6073,12 @@
       "id": 5378,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Beru Lars (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/berulars.gif",
@@ -5139,7 +6099,12 @@
       "gempId": "1_72",
       "side": "Light",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Beru Stew",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/berustew.gif",
@@ -5156,7 +6121,12 @@
       "id": 5379,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Beru Stew (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/berustew.gif",
@@ -5173,7 +6143,12 @@
       "gempId": "5_76",
       "side": "Light",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Bespin",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/bespin.gif",
@@ -5206,7 +6181,12 @@
       "gempId": "5_77",
       "side": "Light",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Bespin: Cloud City",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/bespincloudcity.gif",
@@ -5237,7 +6217,12 @@
       "gempId": "6_7",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•BG-J38",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/bgj38.gif",
@@ -5263,7 +6248,12 @@
       "id": 5380,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•BG-J38 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/bgj38.gif",
@@ -5289,7 +6279,12 @@
       "gempId": "14_41",
       "side": "Light",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Big Boomers!",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/bigboomers.gif",
@@ -5317,7 +6312,12 @@
       "gempId": "4_82",
       "side": "Light",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "<>Big One",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/bigone.gif",
@@ -5343,7 +6343,12 @@
       "gempId": "4_83",
       "side": "Light",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "<>Big One: Asteroid Cave Or Space Slug Belly",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/bigoneasteroidcaveorspaceslugbelly.gif",
@@ -5372,7 +6377,12 @@
       "gempId": "1_3",
       "side": "Light",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Biggs Darklighter",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/biggsdarklighter.gif",
@@ -5403,7 +6413,12 @@
       "id": 5381,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Biggs Darklighter (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/biggsdarklighter.gif",
@@ -5427,7 +6442,12 @@
       "id": 5382,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Biggs, Rogue Legend",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/biggsroguelegend.gif",
@@ -5452,7 +6472,12 @@
       "gempId": "5_12",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Bionic Hand",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/bionichand.gif",
@@ -5474,7 +6499,12 @@
       "id": 5383,
       "side": "Light",
       "rarity": "F",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Black Market Blaster",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/blackmarketblaster.gif",
@@ -5491,7 +6521,12 @@
       "gempId": "2_45",
       "side": "Light",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Blast The Door, Kid!",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/blastthedoorkid.gif",
@@ -5518,7 +6553,12 @@
       "gempId": "8_85",
       "side": "Light",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "BlasTech E-11B Blaster Rifle",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/blasteche11bblasterrifle.gif",
@@ -5542,7 +6582,12 @@
       "gempId": "4_46",
       "side": "Light",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Blasted Varmints",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/blastedvarmints.gif",
@@ -5560,7 +6605,12 @@
       "gempId": "1_152",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Blaster",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/blaster.gif",
@@ -5584,7 +6634,12 @@
       "gempId": "6_61",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Blaster Deflection",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/blasterdeflection.gif",
@@ -5606,7 +6661,12 @@
       "gempId": "5_35",
       "side": "Light",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Blaster Proficiency",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/blasterproficiency.gif",
@@ -5641,7 +6701,12 @@
       "gempId": "1_153",
       "side": "Light",
       "rarity": "C1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Blaster Rifle",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/blasterrifle.gif",
@@ -5665,7 +6730,12 @@
       "id": 5384,
       "side": "Light",
       "rarity": "C1",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "Blaster Rifle (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/blasterrifle.gif",
@@ -5685,7 +6755,12 @@
       "gempId": "200_69",
       "side": "Light",
       "rarity": "C1",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "Blaster Rifle (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/blasterrifle.gif",
@@ -5709,7 +6784,12 @@
       "gempId": "14_48",
       "side": "Light",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Blockade Flagship: Docking Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/blockadeflagshipdockingbay.gif",
@@ -5742,7 +6822,12 @@
       "id": 5385,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Blockade Flagship: Prison",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/blockadeflagshipprison.gif",
@@ -5766,7 +6851,12 @@
       "gempId": "209_32",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Blue 11",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/blue11.gif",
@@ -5792,7 +6882,12 @@
       "gempId": "2_46",
       "side": "Light",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Blue Milk",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/bluemilk.gif",
@@ -5814,7 +6909,12 @@
       "gempId": "210_5",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•Blue Squadron 1",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Light/large/bluesquadron1.gif",
@@ -5842,7 +6942,12 @@
       "gempId": "9_63",
       "side": "Light",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Blue Squadron 5",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/bluesquadron5.gif",
@@ -5880,7 +6985,12 @@
       "gempId": "9_64",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•••Blue Squadron B-wing",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/bluesquadronbwing.gif",
@@ -5915,7 +7025,12 @@
       "gempId": "6_54",
       "side": "Light",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Bo Shuda",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/boshuda.gif",
@@ -5945,7 +7060,12 @@
       "gempId": "206_1",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 6",
+      "set": "206",
+      "printings": [
+        {
+          "set": "206"
+        }
+      ],
       "front": {
         "title": "•Bodhi Rook",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual6-Light/large/bodhirook.gif",
@@ -5981,7 +7101,12 @@
       "gempId": "4_3",
       "side": "Light",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Bog-wing",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/bogwing.gif",
@@ -6012,7 +7137,12 @@
       "gempId": "6_8",
       "side": "Light",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•••B'omarr Monk",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/bomarrmonk.gif",
@@ -6048,7 +7178,12 @@
       "gempId": "14_63",
       "side": "Light",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "Booma",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/booma.gif",
@@ -6076,7 +7211,12 @@
       "gempId": "11_24",
       "side": "Light",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "Boonta Eve Podrace",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/boontaevepodrace.gif",
@@ -6100,7 +7240,12 @@
       "id": 5388,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Booster In Pulsar Skate",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/boosterinpulsarskate.gif",
@@ -6129,7 +7274,12 @@
       "gempId": "200_60",
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Booster In Pulsar Skate",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/boosterinpulsarskate.gif",
@@ -6164,7 +7314,12 @@
       "id": 5389,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Booster Terrik",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/boosterterrik.gif",
@@ -6192,7 +7347,12 @@
       "gempId": "1_4",
       "side": "Light",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•BoShek",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/boshek.gif",
@@ -6219,7 +7379,12 @@
       "id": 5390,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•BoShek (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/boshek.gif",
@@ -6246,7 +7411,12 @@
       "gempId": "210_6",
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•BoShek (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Light/large/boshek.gif",
@@ -6272,7 +7442,12 @@
       "id": 5392,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•BoShek, Brash Smuggler",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/boshekbrashsmuggler.gif",
@@ -6300,7 +7475,12 @@
       "gempId": "14_5",
       "side": "Light",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Boss Nass",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/bossnass.gif",
@@ -6347,7 +7527,12 @@
       "gempId": "14_6",
       "side": "Light",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Boss Nass (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/bossnassai.gif",
@@ -6374,7 +7559,12 @@
       "gempId": "7_5",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Bothan Spy",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/bothanspy.gif",
@@ -6407,7 +7597,12 @@
       "gempId": "7_110",
       "side": "Light",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Bothawui",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/bothawui.gif",
@@ -6437,7 +7632,12 @@
       "gempId": "7_6",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Bothawui Operative",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/bothawuioperative.gif",
@@ -6472,7 +7672,12 @@
       "gempId": "110_1",
       "side": "Light",
       "rarity": "PM",
-      "set": "Enhanced Jabba's Palace",
+      "set": "110",
+      "printings": [
+        {
+          "set": "110"
+        }
+      ],
       "front": {
         "title": "•Boushh",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedJabbasPalace-Light/large/boushh.gif",
@@ -6517,7 +7722,12 @@
       "id": 5394,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Boushh (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/boushh.gif",
@@ -6544,7 +7754,12 @@
       "gempId": "2_77",
       "side": "Light",
       "rarity": "R2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Bowcaster",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/bowcaster.gif",
@@ -6563,7 +7778,12 @@
       "id": 5395,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "Bowcaster (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/bowcaster.gif",
@@ -6584,7 +7804,12 @@
       "gempId": "2_2",
       "side": "Light",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Brainiac",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/brainiac.gif",
@@ -6611,7 +7836,12 @@
       "id": 5396,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Brainiac (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/brainiac.gif",
@@ -6635,7 +7865,12 @@
       "gempId": "14_53",
       "side": "Light",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Bravo 1",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/bravo1.gif",
@@ -6678,7 +7913,12 @@
       "gempId": "14_54",
       "side": "Light",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Bravo 2",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/bravo2.gif",
@@ -6716,7 +7956,12 @@
       "gempId": "14_55",
       "side": "Light",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Bravo 3",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/bravo3.gif",
@@ -6754,7 +7999,12 @@
       "gempId": "14_56",
       "side": "Light",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Bravo 4",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/bravo4.gif",
@@ -6792,7 +8042,12 @@
       "gempId": "14_57",
       "side": "Light",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Bravo 5",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/bravo5.gif",
@@ -6830,7 +8085,12 @@
       "gempId": "14_58",
       "side": "Light",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Bravo Fighter",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/bravofighter.gif",
@@ -6865,7 +8125,12 @@
       "id": 5397,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Bravo Fighter (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/bravofighter.gif",
@@ -6894,7 +8159,12 @@
       "gempId": "200_61",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Bravo Fighter (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/bravofighter.gif",
@@ -6923,7 +8193,12 @@
       "gempId": "7_7",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Bren Quersey",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/brenquersey.gif",
@@ -6951,7 +8226,12 @@
       "gempId": "5_86",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Bright Hope",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/brighthope.gif",
@@ -6982,7 +8262,12 @@
       "id": 5399,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Bright Hope (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/brighthope.gif",
@@ -7010,7 +8295,12 @@
       "gempId": "203_20",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•Bright Hope (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Light/large/brighthope.gif",
@@ -7043,7 +8333,12 @@
       "gempId": "11_16",
       "side": "Light",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Brisky Morning Munchen",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/briskymorningmunchen.gif",
@@ -7072,7 +8367,12 @@
       "gempId": "7_8",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Bron Burs",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/bronburs.gif",
@@ -7099,7 +8399,12 @@
       "id": 5400,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Bron Burs (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/bronburs.gif",
@@ -7127,7 +8432,12 @@
       "gempId": "1_5",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•C-3PO (See-Threepio)",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/c3po.gif",
@@ -7161,7 +8471,12 @@
       "id": 5401,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•C-3PO (See-Threepio) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/c3po.gif",
@@ -7184,7 +8499,12 @@
       "gempId": "208_2",
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•C1-10P (Chopper)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/c110pchopper.gif",
@@ -7216,7 +8536,12 @@
       "gempId": "3_2",
       "side": "Light",
       "rarity": "U2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Cal Alder",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/calalder.gif",
@@ -7247,7 +8572,12 @@
       "gempId": "206_2",
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Set 6",
+      "set": "206",
+      "printings": [
+        {
+          "set": "206"
+        }
+      ],
       "front": {
         "title": "•Cal Alder (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual6-Light/large/calalder.gif",
@@ -7279,7 +8609,12 @@
       "gempId": "11_1",
       "side": "Light",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Caldera Righim",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/calderarighim.gif",
@@ -7301,7 +8636,12 @@
       "gempId": "1_34",
       "side": "Light",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Caller",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/caller.gif",
@@ -7322,7 +8662,12 @@
       "gempId": "7_9",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Camie",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/camie.gif",
@@ -7355,7 +8700,12 @@
       "gempId": "1_73",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Cantina Brawl",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/cantinabrawl.gif",
@@ -7371,7 +8721,12 @@
       "id": 5402,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Cantina Brawl (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/cantinabrawl.gif",
@@ -7388,7 +8743,12 @@
       "gempId": "9_1",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Capital Support",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/capitalsupport.gif",
@@ -7410,7 +8770,12 @@
       "id": 5403,
       "side": "Light",
       "rarity": "C3",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Captain Antilles",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/captainantilles.gif",
@@ -7433,7 +8798,12 @@
       "gempId": "206_3",
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Set 6",
+      "set": "206",
+      "printings": [
+        {
+          "set": "206"
+        }
+      ],
       "front": {
         "title": "•Captain Cassian Andor",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual6-Light/large/captaincassianandor.gif",
@@ -7463,7 +8833,12 @@
       "gempId": "5_1",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Captain Han Solo",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/captainhansolo.gif",
@@ -7517,7 +8892,12 @@
       "gempId": "204_3",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Captain Hera Syndulla",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/captainherasyndulla.gif",
@@ -7559,7 +8939,12 @@
       "gempId": "12_1",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Captain Madakor",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/captainmadakor.gif",
@@ -7596,7 +8981,12 @@
       "gempId": "12_2",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Captain Panaka",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/captainpanaka.gif",
@@ -7639,7 +9029,12 @@
       "gempId": "203_3",
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•Captain Raymus Antilles",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Light/large/captainraymusantilles.gif",
@@ -7674,7 +9069,12 @@
       "id": 5404,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Captain Rex, 501st Legion",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/captainrex501stlegion.gif",
@@ -7702,7 +9102,12 @@
       "gempId": "200_3",
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Captain Rex, 501st Legion",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/captainrex501stlegion.gif",
@@ -7739,7 +9144,12 @@
       "gempId": "14_7",
       "side": "Light",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Captain Tarpals",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/captaintarpals.gif",
@@ -7781,7 +9191,12 @@
       "gempId": "14_64",
       "side": "Light",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Captain Tarpals' Electropole",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/captaintarpalselectropole.gif",
@@ -7808,7 +9223,12 @@
       "gempId": "9_7",
       "side": "Light",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Captain Verrack",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/captainverrack.gif",
@@ -7836,7 +9256,12 @@
       "id": 5405,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Captain Verrack (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/captainverrack.gif",
@@ -7860,7 +9285,12 @@
       "gempId": "8_1",
       "side": "Light",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Captain Yutani",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/captainyutani.gif",
@@ -7900,7 +9330,12 @@
       "id": 5406,
       "side": "Light",
       "rarity": "C1",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Captain Yutani With Blaster Cannon",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/captainyutaniwithblastercannon.gif",
@@ -7926,7 +9361,12 @@
       "gempId": "200_4",
       "side": "Light",
       "rarity": "C1",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Captain Yutani With Blaster Cannon",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/captainyutaniwithblastercannon.gif",
@@ -7959,7 +9399,12 @@
       "gempId": "5_36",
       "side": "Light",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Captive Fury",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/captivefury.gif",
@@ -7983,7 +9428,12 @@
       "gempId": "5_37",
       "side": "Light",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Captive Pursuit",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/captivepursuit.gif",
@@ -8014,7 +9464,12 @@
       "gempId": "8_44",
       "side": "Light",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Careful Planning",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/carefulplanning.gif",
@@ -8035,7 +9490,12 @@
       "id": 5407,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Careful Planning (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/carefulplanning.gif",
@@ -8056,7 +9516,12 @@
       "gempId": "200_50",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Careful Planning (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/carefulplanning.gif",
@@ -8079,7 +9544,12 @@
       "gempId": "208_3",
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•CC-2237 (Odd Ball)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/cc2237oddball.gif",
@@ -8113,7 +9583,12 @@
       "gempId": "2_30",
       "side": "Light",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Cell 2187",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/cell2187.gif",
@@ -8137,7 +9612,12 @@
       "id": 5408,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Cell 2187 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/cell2187.gif",
@@ -8155,7 +9635,12 @@
       "id": 5409,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "Center Of Tyranny / A Liberated World",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/centeroftyranny.gif",
@@ -8177,7 +9662,12 @@
       "gempId": "6_9",
       "side": "Light",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Chadra-Fan",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/chadrafan.gif",
@@ -8207,7 +9697,12 @@
       "gempId": "8_67",
       "side": "Light",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Chandrila",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/chandrila.gif",
@@ -8238,7 +9733,12 @@
       "gempId": "11_31",
       "side": "Light",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Changing The Odds",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/changingtheodds.gif",
@@ -8258,7 +9758,12 @@
       "id": 5410,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Changing The Odds (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/changingtheodds.gif",
@@ -8280,7 +9785,12 @@
       "gempId": "5_19",
       "side": "Light",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Chasm",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/chasm.gif",
@@ -8300,7 +9810,12 @@
       "id": 5411,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "Chasm (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Light/large/chasm.gif",
@@ -8319,7 +9834,12 @@
       "gempId": "2_3",
       "side": "Light",
       "rarity": "R2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Chewbacca",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/chewbacca.gif",
@@ -8367,7 +9887,12 @@
       "id": 5412,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Chewbacca (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/chewbacca.gif",
@@ -8393,7 +9918,12 @@
       "gempId": "8_2",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Chewbacca Of Kashyyyk",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/chewbaccaofkashyyyk.gif",
@@ -8439,7 +9969,12 @@
       "id": 5413,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Chewbacca Of Kashyyyk (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/chewbaccaofkashyyyk.gif",
@@ -8467,7 +10002,12 @@
       "gempId": "10_3",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Chewbacca, Protector",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Light/large/chewbaccaprotector.gif",
@@ -8514,7 +10054,12 @@
       "id": 5414,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Chewbacca, Protector (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/chewbaccaprotector.gif",
@@ -8540,7 +10085,12 @@
       "id": 5415,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Chewbacca, Walking Carpet",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/chewbaccawalkingcarpet.gif",
@@ -8566,7 +10116,12 @@
       "gempId": "8_86",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Chewbacca's Bowcaster",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/chewbaccasbowcaster.gif",
@@ -8601,7 +10156,12 @@
       "gempId": "104_1",
       "side": "Light",
       "rarity": "PM",
-      "set": "Empire Strikes Back Introductory Two Player Game",
+      "set": "104",
+      "printings": [
+        {
+          "set": "104"
+        }
+      ],
       "front": {
         "title": "•Chewie",
         "imageUrl": "https://res.starwarsccg.org/cards/EmpireStrikesBackIntroductoryTwoPlayerGame-Light/large/chewie.gif",
@@ -8624,7 +10184,12 @@
       "id": 5417,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Chewie (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/chewie.gif",
@@ -8650,7 +10215,12 @@
       "gempId": "200_5",
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Chewie (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/chewie.gif",
@@ -8698,7 +10268,12 @@
       "gempId": "109_1",
       "side": "Light",
       "rarity": "PM",
-      "set": "Enhanced Cloud City",
+      "set": "109",
+      "printings": [
+        {
+          "set": "109"
+        }
+      ],
       "front": {
         "title": "•Chewie With Blaster Rifle",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedCloudCity-Light/large/chewiewithblasterrifle.gif",
@@ -8740,7 +10315,12 @@
       "gempId": "204_4",
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Chewie With Bowcaster",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/chewiewithbowcaster.gif",
@@ -8787,7 +10367,12 @@
       "gempId": "13_9",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Chewie, Enraged",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/chewieenraged.gif",
@@ -8832,7 +10417,12 @@
       "id": 5418,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Chewie, Enraged (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/chewieenraged.gif",
@@ -8859,7 +10449,12 @@
       "gempId": "8_81",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Chewie's AT-ST",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/chewiesatst.gif",
@@ -8905,7 +10500,12 @@
       "id": 5419,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Chewie's AT-ST (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/chewiesatst.gif",
@@ -8931,7 +10531,12 @@
       "gempId": "8_3",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Chief Chirpa",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/chiefchirpa.gif",
@@ -8965,7 +10570,12 @@
       "id": 5420,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Chief Chirpa (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/chiefchirpa.gif",
@@ -8989,7 +10599,12 @@
       "gempId": "207_2",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 7",
+      "set": "207",
+      "printings": [
+        {
+          "set": "207"
+        }
+      ],
       "front": {
         "title": "•Chirrut Imwe",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual7-Light/large/chirrutimwe.gif",
@@ -9014,7 +10629,12 @@
       "gempId": "6_62",
       "side": "Light",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Choke",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/choke.gif",
@@ -9035,7 +10655,12 @@
       "gempId": "301_2",
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Premium Set",
+      "set": "301",
+      "printings": [
+        {
+          "set": "301"
+        }
+      ],
       "front": {
         "title": "City In The Clouds / You Truly Belong Here With Us",
         "imageUrl": "https://res.starwarsccg.org/cards/DemoDeck-Light/large/cityintheclouds.gif",
@@ -9057,7 +10682,12 @@
       "gempId": "5_20",
       "side": "Light",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Civil Disorder",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/civildisorder.gif",
@@ -9078,7 +10708,12 @@
       "id": 5422,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Civil Disorder (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/civildisorder.gif",
@@ -9097,7 +10732,12 @@
       "gempId": "2_60",
       "side": "Light",
       "rarity": "R2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Clak'dor VII",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/clakdorvii.gif",
@@ -9126,7 +10766,12 @@
       "gempId": "7_10",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Clak'dor VII Operative",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/clakdorviioperative.gif",
@@ -9161,7 +10806,12 @@
       "gempId": "5_38",
       "side": "Light",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Clash Of Sabers",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/clashofsabers.gif",
@@ -9191,7 +10841,12 @@
       "gempId": "13_10",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Clinging To The Edge",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/clingingtotheedge.gif",
@@ -9211,7 +10866,12 @@
       "id": 5423,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Clinging To The Edge (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/clingingtotheedge.gif",
@@ -9230,7 +10890,12 @@
       "id": 5424,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "••Clone Infantry Squad",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/cloneinfantrysquad.gif",
@@ -9256,7 +10921,12 @@
       "id": 5425,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "Clone Pilot",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/clonepilot.gif",
@@ -9280,7 +10950,12 @@
       "id": 5426,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•••Clone Sniper",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/clonesniper.gif",
@@ -9306,7 +10981,12 @@
       "id": 5427,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "Clone Specialist",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/clonespecialist.gif",
@@ -9334,7 +11014,12 @@
       "gempId": "210_8",
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•••Clone Squad Leader",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Light/large/clonesquadleader.gif",
@@ -9360,7 +11045,12 @@
       "id": 5429,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "Clone Trooper",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/clonetrooper.gif",
@@ -9386,7 +11076,12 @@
       "gempId": "210_9",
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "Clone Trooper",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Light/large/clonetrooper.gif",
@@ -9412,7 +11107,12 @@
       "id": 5431,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Cloning Cylinders",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/cloningcylinders.gif",
@@ -9431,7 +11131,12 @@
       "gempId": "211_53",
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Cloning Cylinders",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/cloningcylinders.gif",
@@ -9450,7 +11155,12 @@
       "gempId": "9_32",
       "side": "Light",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Close Air Support",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/closeairsupport.gif",
@@ -9474,7 +11184,12 @@
       "gempId": "4_47",
       "side": "Light",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Closer?!",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/closer.gif",
@@ -9501,7 +11216,12 @@
       "gempId": "5_88",
       "side": "Light",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Cloud Car",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/cloudcar.gif",
@@ -9538,7 +11258,12 @@
       "gempId": "5_89",
       "side": "Light",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Cloud City Blaster",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/cloudcityblaster.gif",
@@ -9561,7 +11286,12 @@
       "id": 5433,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "Cloud City Blaster (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/cloudcityblaster.gif",
@@ -9578,7 +11308,12 @@
       "gempId": "7_55",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Cloud City Celebration",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/cloudcitycelebration.gif",
@@ -9604,7 +11339,12 @@
       "gempId": "5_39",
       "side": "Light",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Cloud City Sabacc",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/cloudcitysabacc.gif",
@@ -9627,7 +11367,12 @@
       "gempId": "5_2",
       "side": "Light",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•••Cloud City Technician",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/cloudcitytechnician.gif",
@@ -9655,7 +11400,12 @@
       "gempId": "5_3",
       "side": "Light",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Cloud City Trooper",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/cloudcitytrooper.gif",
@@ -9693,7 +11443,12 @@
       "gempId": "5_78",
       "side": "Light",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Cloud City: Carbonite Chamber",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/cloudcitycarbonitechamber.gif",
@@ -9722,7 +11477,12 @@
       "gempId": "7_111",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Cloud City: Casino",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/cloudcitycasino.gif",
@@ -9751,7 +11511,12 @@
       "gempId": "5_79",
       "side": "Light",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Cloud City: Chasm Walkway",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/cloudcitychasmwalkway.gif",
@@ -9780,7 +11545,12 @@
       "gempId": "7_112",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Cloud City: Core Tunnel",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/cloudcitycoretunnel.gif",
@@ -9808,7 +11578,12 @@
       "gempId": "7_113",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Cloud City: Downtown Plaza",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/cloudcitydowntownplaza.gif",
@@ -9837,7 +11612,12 @@
       "gempId": "5_80",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Cloud City: Guest Quarters",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/cloudcityguestquarters.gif",
@@ -9865,7 +11645,12 @@
       "gempId": "5_81",
       "side": "Light",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Cloud City: Incinerator",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/cloudcityincinerator.gif",
@@ -9897,7 +11682,12 @@
       "gempId": "5_82",
       "side": "Light",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Cloud City: Lower Corridor",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/cloudcitylowercorridor.gif",
@@ -9926,7 +11716,12 @@
       "gempId": "7_114",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Cloud City: North Corridor",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/cloudcitynorthcorridor.gif",
@@ -9954,7 +11749,12 @@
       "gempId": "5_83",
       "side": "Light",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Cloud City: Platform 327 (Docking Bay)",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/cloudcityplatform327dockingbay.gif",
@@ -9988,7 +11788,12 @@
       "gempId": "5_84",
       "side": "Light",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Cloud City: Upper Plaza Corridor",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/cloudcityupperplazacorridor.gif",
@@ -10016,7 +11821,12 @@
       "gempId": "7_115",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Cloud City: West Gallery",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/cloudcitywestgallery.gif",
@@ -10045,7 +11855,12 @@
       "gempId": "5_85",
       "side": "Light",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "<><><>Clouds",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/clouds.gif",
@@ -10072,7 +11887,12 @@
       "gempId": "1_74",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Collision!",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/collision.gif",
@@ -10096,7 +11916,12 @@
       "gempId": "13_11",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Colo Claw Fish",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/coloclawfish.gif",
@@ -10129,7 +11954,12 @@
       "gempId": "9_8",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Colonel Cracken",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/colonelcracken.gif",
@@ -10168,7 +11998,12 @@
       "gempId": "7_11",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Colonel Feyn Gospic",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/colonelfeyngospic.gif",
@@ -10196,7 +12031,12 @@
       "id": 5434,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Colonel Feyn Gospic (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/colonelfeyngospic.gif",
@@ -10225,7 +12065,12 @@
       "gempId": "9_9",
       "side": "Light",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Colonel Salm",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/colonelsalm.gif",
@@ -10261,7 +12106,12 @@
       "gempId": "1_75",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Combined Attack",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/combinedattack.gif",
@@ -10282,7 +12132,12 @@
       "gempId": "9_2",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Combined Fleet Action",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/combinedfleetaction.gif",
@@ -10315,7 +12170,12 @@
       "id": 5435,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Combined Fleet Action (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/combinedfleetaction.gif",
@@ -10329,7 +12189,12 @@
       "id": 5436,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Commander Adar Tallon",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/commanderadartallon.gif",
@@ -10357,7 +12222,12 @@
       "id": 5437,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Commander Cody",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/commandercody.gif",
@@ -10384,7 +12254,12 @@
       "gempId": "200_6",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Commander Cody",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/commandercody.gif",
@@ -10421,7 +12296,12 @@
       "gempId": "2_4",
       "side": "Light",
       "rarity": "C1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Commander Evram Lajaie",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/commanderevramlajaie.gif",
@@ -10450,7 +12330,12 @@
       "id": 5438,
       "side": "Light",
       "rarity": "C1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Commander Evram Lajaie (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/commanderevramlajaie.gif",
@@ -10474,7 +12359,12 @@
       "gempId": "3_3",
       "side": "Light",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Commander Luke Skywalker",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/commanderlukeskywalker.gif",
@@ -10526,7 +12416,12 @@
       "id": 5439,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Commander Luke Skywalker (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/commanderlukeskywalker.gif",
@@ -10555,7 +12450,12 @@
       "gempId": "200_7",
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Commander Luke Skywalker (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/commanderlukeskywalker.gif",
@@ -10630,7 +12530,12 @@
       "id": 5440,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Commander Narra",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/commandernarra.gif",
@@ -10655,7 +12560,12 @@
       "gempId": "200_8",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Commander Narra",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/commandernarra.gif",
@@ -10689,7 +12599,12 @@
       "gempId": "209_2",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Commander Ruescott Melshi",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/commanderruescottmelshi.gif",
@@ -10713,7 +12628,12 @@
       "gempId": "2_5",
       "side": "Light",
       "rarity": "U2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Commander Vanden Willard",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/commandervandenwillard.gif",
@@ -10752,7 +12672,12 @@
       "id": 5442,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Commander Vanden Willard (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/commandervandenwillard.gif",
@@ -10777,7 +12702,12 @@
       "gempId": "211_58",
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Commander Vanden Willard (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/commandervandenwillard.gif",
@@ -10802,7 +12732,15 @@
       "gempId": "7_12",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "105"
+        },
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Commander Wedge Antilles",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/commanderwedgeantilles.gif",
@@ -10848,7 +12786,12 @@
       "id": 5444,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Commander Wedge Antilles (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/commanderwedgeantilles.gif",
@@ -10873,7 +12816,12 @@
       "gempId": "205_1",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 5",
+      "set": "205",
+      "printings": [
+        {
+          "set": "205"
+        }
+      ],
       "front": {
         "title": "•Commander Wedge Antilles (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual5-Light/large/commanderwedgeantilles.gif",
@@ -10918,7 +12866,12 @@
       "gempId": "8_36",
       "side": "Light",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Commando Training",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/commandotraining.gif",
@@ -10940,7 +12893,12 @@
       "id": 5445,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Commando Training & •K'lor'slug",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/commandotraining&klorslug.gif",
@@ -10957,7 +12915,12 @@
       "id": 5446,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Commando Training (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/commandotraining.gif",
@@ -10976,7 +12939,12 @@
       "gempId": "2_31",
       "side": "Light",
       "rarity": "R2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Commence Recharging",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/commencerecharging.gif",
@@ -11000,7 +12968,12 @@
       "id": 5447,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Communing",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/communing.gif",
@@ -11015,7 +12988,12 @@
       "gempId": "5_40",
       "side": "Light",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Computer Interface",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/computerinterface.gif",
@@ -11034,7 +13012,12 @@
       "id": 5448,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Computer Interface (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/computerinterface.gif",
@@ -11054,7 +13037,12 @@
       "gempId": "9_3",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Concentrate All Fire",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/concentrateallfire.gif",
@@ -11077,7 +13065,12 @@
       "gempId": "3_73",
       "side": "Light",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Concussion Grenade",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/concussiongrenade.gif",
@@ -11100,7 +13093,12 @@
       "gempId": "9_87",
       "side": "Light",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "Concussion Missiles",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/concussionmissiles.gif",
@@ -11126,7 +13124,12 @@
       "gempId": "12_57",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Control",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/control.gif",
@@ -11165,7 +13168,12 @@
       "gempId": "4_48",
       "side": "Light",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Control",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/control.gif",
@@ -11201,7 +13209,12 @@
       "gempId": "10_4",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "Control & Tunnel Vision",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Light/large/control&tunnelvision.gif",
@@ -11238,7 +13251,12 @@
       "gempId": "2_61",
       "side": "Light",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Corellia",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/corellia.gif",
@@ -11270,7 +13288,12 @@
       "id": 5449,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Corellia (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/corellia.gif",
@@ -11291,7 +13314,12 @@
       "gempId": "7_13",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Corellia Operative",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/corelliaoperative.gif",
@@ -11325,7 +13353,12 @@
       "gempId": "2_6",
       "side": "Light",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•••Corellian",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/corellian.gif",
@@ -11358,7 +13391,12 @@
       "gempId": "1_140",
       "side": "Light",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Corellian Corvette",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/corelliancorvette.gif",
@@ -11389,7 +13427,12 @@
       "gempId": "7_56",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Corellian Engineering Corporation",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/corellianengineeringcorporation.gif",
@@ -11410,7 +13453,12 @@
       "id": 5450,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Corellian Engineering Corporation (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/corellianengineeringcorporation.gif",
@@ -11429,7 +13477,12 @@
       "gempId": "6_63",
       "side": "Light",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Corellian Retort",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/corellianretort.gif",
@@ -11453,7 +13506,12 @@
       "id": 5451,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Corellian Retort (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/corellianretort.gif",
@@ -11473,7 +13531,12 @@
       "gempId": "2_47",
       "side": "Light",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Corellian Slip",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/corellianslip.gif",
@@ -11493,7 +13556,12 @@
       "id": 5452,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "Corellian Slip (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/corellianslip.gif",
@@ -11510,7 +13578,12 @@
       "gempId": "208_18",
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "Corellian Slip (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/corellianslip.gif",
@@ -11527,7 +13600,12 @@
       "gempId": "8_4",
       "side": "Light",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Corporal Beezer",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/corporalbeezer.gif",
@@ -11602,7 +13680,12 @@
       "id": 5453,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Corporal Beezer (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/corporalbeezer.gif",
@@ -11627,7 +13710,12 @@
       "gempId": "8_5",
       "side": "Light",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Corporal Delevar",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/corporaldelevar.gif",
@@ -11659,7 +13747,12 @@
       "gempId": "208_4",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Corporal Delevar (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/corporaldelevar.gif",
@@ -11693,7 +13786,12 @@
       "gempId": "8_6",
       "side": "Light",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Corporal Janse",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/corporaljanse.gif",
@@ -11728,7 +13826,12 @@
       "gempId": "8_7",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Corporal Kensaric",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/corporalkensaric.gif",
@@ -11762,7 +13865,12 @@
       "gempId": "9_10",
       "side": "Light",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Corporal Marmor",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/corporalmarmor.gif",
@@ -11796,7 +13904,12 @@
       "gempId": "9_11",
       "side": "Light",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Corporal Midge",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/corporalmidge.gif",
@@ -11827,7 +13940,12 @@
       "gempId": "14_8",
       "side": "Light",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Corporal Rushing",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/corporalrushing.gif",
@@ -11856,7 +13974,12 @@
       "gempId": "10_5",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Corran Horn",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Light/large/corranhorn.gif",
@@ -11894,7 +14017,12 @@
       "gempId": "202_8",
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Set 2",
+      "set": "202",
+      "printings": [
+        {
+          "set": "202"
+        }
+      ],
       "front": {
         "title": "•Corran Horn In Rogue 9",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual2-Light/large/corranhorninrogue9.gif",
@@ -11923,7 +14051,12 @@
       "gempId": "106_2",
       "side": "Light",
       "rarity": "PM",
-      "set": "Official Tournament Sealed Deck",
+      "set": "106",
+      "printings": [
+        {
+          "set": "106"
+        }
+      ],
       "front": {
         "title": "•Corulag",
         "imageUrl": "https://res.starwarsccg.org/cards/OfficialTournamentSealedDeck-Light/large/corulag.gif",
@@ -11954,7 +14087,12 @@
       "gempId": "12_73",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Coruscant",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/coruscant.gif",
@@ -11986,7 +14124,12 @@
       "gempId": "7_116",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Coruscant",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/coruscant.gif",
@@ -12015,7 +14158,12 @@
       "id": 5454,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Coruscant (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/coruscant.gif",
@@ -12035,7 +14183,12 @@
       "gempId": "7_57",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Coruscant Celebration",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/coruscantcelebration.gif",
@@ -12061,7 +14214,12 @@
       "gempId": "12_3",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Coruscant Guard",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/coruscantguard.gif",
@@ -12094,7 +14252,12 @@
       "gempId": "12_74",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Coruscant: Docking Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/coruscantdockingbay.gif",
@@ -12126,7 +14289,12 @@
       "gempId": "12_75",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Coruscant: Galactic Senate",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/coruscantgalacticsenate.gif",
@@ -12153,7 +14321,12 @@
       "id": 5455,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Coruscant: Jedi Archives",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/coruscantjediarchives.gif",
@@ -12175,7 +14348,12 @@
       "gempId": "12_76",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Coruscant: Jedi Council Chamber",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/coruscantjedicouncilchamber.gif",
@@ -12213,7 +14391,12 @@
       "id": 5456,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Coruscant: Jedi Council Chamber (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/coruscantjedicouncilchamber.gif",
@@ -12234,7 +14417,12 @@
       "id": 5457,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Coruscant: Lower Levels",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/coruscantlowerlevels.gif",
@@ -12254,7 +14442,12 @@
       "id": 5458,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Coruscant: Main Power Plant",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/coruscantmainpowerplant.gif",
@@ -12274,7 +14467,12 @@
       "id": 5459,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Coruscant: Night Club",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/coruscantnightclub.gif",
@@ -12295,7 +14493,12 @@
       "gempId": "200_57",
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Coruscant: Night Club",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/coruscantnightclub.gif",
@@ -12321,7 +14524,12 @@
       "id": 5460,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Coruscant: Senate Landing Platform",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/coruscantsenatelandingplatform.gif",
@@ -12343,7 +14551,12 @@
       "gempId": "8_37",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Count Me In",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/countmein.gif",
@@ -12367,7 +14580,12 @@
       "id": 5461,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Count Me In (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/countmein.gif",
@@ -12386,7 +14604,12 @@
       "gempId": "5_41",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Courage Of A Skywalker",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/courageofaskywalker.gif",
@@ -12406,7 +14629,12 @@
       "id": 5462,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Courage Of A Skywalker (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/courageofaskywalker.gif",
@@ -12426,7 +14654,12 @@
       "gempId": "8_45",
       "side": "Light",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Covert Landing",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/covertlanding.gif",
@@ -12446,7 +14679,12 @@
       "id": 5463,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Covert Landing (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/covertlanding.gif",
@@ -12466,7 +14704,12 @@
       "gempId": "5_21",
       "side": "Light",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Crack Shot",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/crackshot.gif",
@@ -12487,7 +14730,12 @@
       "gempId": "1_45",
       "side": "Light",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Crash Site Memorial",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/crashsitememorial.gif",
@@ -12510,7 +14758,12 @@
       "id": 5464,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Crash Site Memorial (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/crashsitememorial.gif",
@@ -12526,7 +14779,12 @@
       "gempId": "12_42",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Credits Will Do Fine",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/creditswilldofine.gif",
@@ -12554,7 +14812,12 @@
       "gempId": "9_49",
       "side": "Light",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Critical Error Revealed",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/criticalerrorrevealed.gif",
@@ -12578,7 +14841,12 @@
       "gempId": "204_5",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Crusher Roodown",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/crusherroodown.gif",
@@ -12607,7 +14875,12 @@
       "gempId": "209_3",
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•CT-5385 (Tup)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/ct5385tup.gif",
@@ -12635,7 +14908,12 @@
       "gempId": "203_2",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•CT-5555 (Fives)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Light/large/ct5555fives.gif",
@@ -12672,7 +14950,12 @@
       "gempId": "5_13",
       "side": "Light",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Cyborg Construct",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/cyborgconstruct.gif",
@@ -12694,7 +14977,12 @@
       "gempId": "211_54",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Cyborg Construct (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/cyborgconstruct.gif",
@@ -12713,7 +15001,12 @@
       "gempId": "1_6",
       "side": "Light",
       "rarity": "C1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "CZ-3 (Seezee-Three)",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/cz3.gif",
@@ -12742,7 +15035,12 @@
       "gempId": "3_4",
       "side": "Light",
       "rarity": "R2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Dack Ralter",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/dackralter.gif",
@@ -12769,7 +15067,12 @@
       "id": 5467,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Dack Ralter (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/dackralter.gif",
@@ -12794,7 +15097,12 @@
       "gempId": "4_84",
       "side": "Light",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Dagobah",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/dagobah.gif",
@@ -12830,7 +15138,12 @@
       "gempId": "4_85",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Dagobah: Bog Clearing",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/dagobahbogclearing.gif",
@@ -12856,7 +15169,12 @@
       "gempId": "4_86",
       "side": "Light",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Dagobah: Jungle",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/dagobahjungle.gif",
@@ -12882,7 +15200,12 @@
       "gempId": "4_87",
       "side": "Light",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Dagobah: Swamp",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/dagobahswamp.gif",
@@ -12908,7 +15231,12 @@
       "gempId": "4_88",
       "side": "Light",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Dagobah: Training Area",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/dagobahtrainingarea.gif",
@@ -12943,7 +15271,12 @@
       "gempId": "4_89",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Dagobah: Yoda's Hut",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/dagobahyodashut.gif",
@@ -12969,7 +15302,12 @@
       "gempId": "14_9",
       "side": "Light",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Dams Denna",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/damsdenna.gif",
@@ -13000,7 +15338,12 @@
       "gempId": "1_122",
       "side": "Light",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Dantooine",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/dantooine.gif",
@@ -13028,7 +15371,12 @@
       "gempId": "7_135",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Dantooine Base Operations / More Dangerous Than You Realize",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/dantooinebaseoperations.gif",
@@ -13049,7 +15397,12 @@
       "id": 5469,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Dantooine Engineering Corps",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/dantooineengineeringcorps.gif",
@@ -13067,7 +15420,12 @@
       "id": 5470,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Dantooine: Base - Docking Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/dantooinebasedockingbay.gif",
@@ -13088,7 +15446,12 @@
       "id": 5471,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Dantooine: Base - Operations Center",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/dantooinebaseoperationscenter.gif",
@@ -13110,7 +15473,12 @@
       "gempId": "5_42",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Dark Approach",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/darkapproach.gif",
@@ -13127,7 +15495,12 @@
       "id": 5472,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Dark Approach (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/darkapproach.gif",
@@ -13147,7 +15520,12 @@
       "gempId": "3_41",
       "side": "Light",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Dark Dissension",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/darkdissension.gif",
@@ -13168,7 +15546,12 @@
       "id": 5473,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Dark Dissension (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/darkdissension.gif",
@@ -13188,7 +15571,12 @@
       "gempId": "7_85",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Darklighter Spin",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/darklighterspin.gif",
@@ -13209,7 +15597,12 @@
       "id": 5474,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Darklighter Spin (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/darklighterspin.gif",
@@ -13229,7 +15622,12 @@
       "gempId": "13_12",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Darth Maul's Demise",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/darthmaulsdemise.gif",
@@ -13250,7 +15648,12 @@
       "gempId": "5_43",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Dash",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/dash.gif",
@@ -13267,7 +15670,12 @@
       "id": 5475,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Dash in Rogue 10",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/dashinrogue12.gif",
@@ -13293,7 +15701,12 @@
       "gempId": "201_20",
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Dash in Rogue 10",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Light/large/dashinrogue12.gif",
@@ -13332,7 +15745,12 @@
       "gempId": "10_6",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Dash Rendar",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Light/large/dashrendar.gif",
@@ -13375,7 +15793,12 @@
       "id": 5476,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Dash Rendar (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/dashrendar.gif",
@@ -13404,7 +15827,12 @@
       "gempId": "210_12",
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•Dash Rendar (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Light/large/dashrendar.gif",
@@ -13432,7 +15860,12 @@
       "gempId": "8_8",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Daughter Of Skywalker",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/daughterofskywalker.gif",
@@ -13485,7 +15918,12 @@
       "id": 5478,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Daughter Of Skywalker (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/daughterofskywalker.gif",
@@ -13514,7 +15952,12 @@
       "gempId": "200_9",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Daughter Of Skywalker (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/daughterofskywalker.gif",
@@ -13564,7 +16007,12 @@
       "gempId": "8_43",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "Deactivate The Shield Generator",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/deactivatetheshieldgenerator.gif",
@@ -13587,7 +16035,12 @@
       "gempId": "7_117",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Death Star",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/deathstar.gif",
@@ -13610,7 +16063,12 @@
       "gempId": "1_46",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Death Star Plans",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/deathstarplans.gif",
@@ -13635,7 +16093,12 @@
       "gempId": "1_123",
       "side": "Light",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Death Star: Detention Block Control Room",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/deathstardetentionblockcontrolroom.gif",
@@ -13660,7 +16123,12 @@
       "gempId": "7_118",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Death Star: Detention Block Corridor",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/deathstardetentionblockcorridor.gif",
@@ -13691,7 +16159,12 @@
       "gempId": "1_124",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Death Star: Docking Bay 327",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/deathstardockingbay327.gif",
@@ -13724,7 +16197,12 @@
       "gempId": "101_1",
       "side": "Light",
       "rarity": "PM",
-      "set": "Premiere Introductory Two Player Game",
+      "set": "101",
+      "printings": [
+        {
+          "set": "101"
+        }
+      ],
       "front": {
         "title": "•Death Star: Level 6 Core Shaft Corridor",
         "imageUrl": "https://res.starwarsccg.org/cards/PremiereIntroductoryTwoPlayerGame-Light/large/deathstarlevel6coreshaftcorridor.gif",
@@ -13750,7 +16228,12 @@
       "gempId": "1_125",
       "side": "Light",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Death Star: Trash Compactor",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/deathstartrashcompactor.gif",
@@ -13773,7 +16256,12 @@
       "gempId": "2_62",
       "side": "Light",
       "rarity": "R2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Death Star: Trench",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/deathstartrench.gif",
@@ -13802,7 +16290,12 @@
       "gempId": "7_14",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Debnoli",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/debnoli.gif",
@@ -13827,7 +16320,12 @@
       "id": 5479,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Debnoli (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/debnoli.gif",
@@ -13852,7 +16350,12 @@
       "id": 5480,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Declaration Of Rebellion",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/declarationofrebellion.gif",
@@ -13871,7 +16374,12 @@
       "gempId": "9_67",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Defiance",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/defiance.gif",
@@ -13903,7 +16411,12 @@
       "gempId": "2_63",
       "side": "Light",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Dejarik Hologameboard",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/dejarikhologameboard.gif",
@@ -13926,7 +16439,12 @@
       "gempId": "1_47",
       "side": "Light",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Demotion",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/demotion.gif",
@@ -13949,7 +16467,12 @@
       "id": 5481,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Demotion (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/demotion.gif",
@@ -13965,7 +16488,12 @@
       "gempId": "11_2",
       "side": "Light",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Deneb Both",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/denebboth.gif",
@@ -13993,7 +16521,12 @@
       "gempId": "12_4",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Depa Billaba",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/depabillaba.gif",
@@ -14035,7 +16568,12 @@
       "gempId": "207_3",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 7",
+      "set": "207",
+      "printings": [
+        {
+          "set": "207"
+        }
+      ],
       "front": {
         "title": "•Depa Billaba (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual7-Light/large/depabillaba.gif",
@@ -14068,7 +16606,12 @@
       "gempId": "3_5",
       "side": "Light",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Derek 'Hobbie' Klivian",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/derekhobbieklivian.gif",
@@ -14103,7 +16646,12 @@
       "id": 5482,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Derek 'Hobbie' Klivian (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/derekhobbieklivian.gif",
@@ -14129,7 +16677,12 @@
       "gempId": "200_10",
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Derek 'Hobbie' Klivian (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/derekhobbieklivian.gif",
@@ -14166,7 +16719,12 @@
       "gempId": "4_20",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Descent Into The Dark",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/descentintothedark.gif",
@@ -14191,7 +16749,12 @@
       "id": 5483,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Descent Into The Dark (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/descentintothedark.gif",
@@ -14210,7 +16773,12 @@
       "gempId": "7_119",
       "side": "Light",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "<>Desert",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/desert.gif",
@@ -14237,7 +16805,12 @@
       "gempId": "5_44",
       "side": "Light",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Desperate Reach",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/desperatereach.gif",
@@ -14257,7 +16830,12 @@
       "id": 5484,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "Desperate Reach (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/desperatereach.gif",
@@ -14277,7 +16855,12 @@
       "gempId": "7_86",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Desperate Tactics",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/desperatetactics.gif",
@@ -14297,7 +16880,12 @@
       "id": 5485,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Desperate Tactics(V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/desperatetactics.gif",
@@ -14318,7 +16906,12 @@
       "gempId": "13_13",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Desperate Times",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/desperatetimes.gif",
@@ -14336,7 +16929,12 @@
       "gempId": "6_10",
       "side": "Light",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Devaronian",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/devaronian.gif",
@@ -14367,7 +16965,12 @@
       "id": 5486,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Dexter Jettster",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/dexterjettster.gif",
@@ -14394,7 +16997,12 @@
       "gempId": "1_7",
       "side": "Light",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Dice Ibegon",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/diceibegon.gif",
@@ -14422,7 +17030,12 @@
       "gempId": "207_4",
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Set 7",
+      "set": "207",
+      "printings": [
+        {
+          "set": "207"
+        }
+      ],
       "front": {
         "title": "•Dice Ibegon (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual7-Light/large/diceibegon.gif",
@@ -14450,7 +17063,12 @@
       "gempId": "203_19",
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "Diplomatic Mission To Alderaan / A Weakness Can Be Found",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Light/large/diplomaticmissiontoalderaan.gif",
@@ -14472,7 +17090,12 @@
       "gempId": "7_87",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Direct Assault",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/directassault.gif",
@@ -14494,7 +17117,12 @@
       "gempId": "1_48",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Disarmed",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/disarmed.gif",
@@ -14519,7 +17147,12 @@
       "gempId": "3_33",
       "side": "Light",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Disarming Creature",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/disarmingcreature.gif",
@@ -14543,7 +17176,12 @@
       "id": 5488,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "Disarming Creature (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/disarmingcreature.gif",
@@ -14562,7 +17200,12 @@
       "gempId": "5_22",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Dismantle On Sight",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/dismantleonsight.gif",
@@ -14582,7 +17225,12 @@
       "id": 5489,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Dismantle On Sight (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/dismantleonsight.gif",
@@ -14601,7 +17249,12 @@
       "gempId": "7_157",
       "side": "Light",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Disruptor Pistol",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/disruptorpistol.gif",
@@ -14622,7 +17275,12 @@
       "gempId": "13_14",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Diversionary Tactics",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/diversionarytactics.gif",
@@ -14639,7 +17297,12 @@
       "id": 5490,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Diversionary Tactics (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/diversionarytactics.gif",
@@ -14660,7 +17323,12 @@
       "gempId": "4_21",
       "side": "Light",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Do, Or Do Not",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/doordonot.gif",
@@ -14681,7 +17349,12 @@
       "gempId": "13_15",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Do, Or Do Not",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/doordonot.gif",
@@ -14702,7 +17375,12 @@
       "gempId": "10_7",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Do, Or Do Not & •Wise Advice",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Light/large/doordonot&wiseadvice.gif",
@@ -14722,7 +17400,12 @@
       "gempId": "7_58",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Docking And Repair Facilities",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/dockingandrepairfacilities.gif",
@@ -14746,7 +17429,12 @@
       "gempId": "5_45",
       "side": "Light",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Dodge",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/dodge.gif",
@@ -14767,7 +17455,12 @@
       "gempId": "2_7",
       "side": "Light",
       "rarity": "U2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Doikk Na'ts",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/doikknats.gif",
@@ -14793,7 +17486,12 @@
       "gempId": "4_76",
       "side": "Light",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Domain Of Evil",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/domainofevil.gif",
@@ -14811,7 +17509,12 @@
       "gempId": "13_16",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Don't Do That Again",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/dontdothatagain.gif",
@@ -14852,7 +17555,12 @@
       "gempId": "11_17",
       "side": "Light",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Don't Do That Again",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/dontdothatagain.gif",
@@ -14894,7 +17602,12 @@
       "id": 5491,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•Don't Do That Again (Tatooine) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Light/large/dontdothatagaintatooine.gif",
@@ -14914,7 +17627,12 @@
       "gempId": "200_26",
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Set 0",
+      "set": "200d",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Don't Do That Again (Tatooine) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/ResetDS-Light/large/dontdothatagaintatooine.gif",
@@ -14933,7 +17651,12 @@
       "id": 5493,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•Don't Do That Again (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Light/large/dontdothatagain.gif",
@@ -14953,7 +17676,12 @@
       "gempId": "200_26",
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Set 0",
+      "set": "200d",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Don't Do That Again (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/ResetDS-Light/large/dontdothatagain.gif",
@@ -14994,7 +17722,12 @@
       "gempId": "6_64",
       "side": "Light",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Don't Forget The Droids",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/dontforgetthedroids.gif",
@@ -15019,7 +17752,12 @@
       "id": 5494,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Don't Forget The Droids (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/dontforgetthedroids.gif",
@@ -15039,7 +17777,12 @@
       "gempId": "1_76",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Don't Get Cocky",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/dontgetcocky.gif",
@@ -15061,7 +17804,12 @@
       "gempId": "7_88",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Don't Tread On Me",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/donttreadonme.gif",
@@ -15079,7 +17827,12 @@
       "id": 5495,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Don't Tread On Me (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/donttreadonme.gif",
@@ -15100,7 +17853,12 @@
       "gempId": "200_51",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "Don't Tread On Me (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/donttreadonme.gif",
@@ -15125,7 +17883,12 @@
       "gempId": "1_77",
       "side": "Light",
       "rarity": "C1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Don't Underestimate Our Chances",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/dontunderestimateourchances.gif",
@@ -15147,7 +17910,12 @@
       "id": 5496,
       "side": "Light",
       "rarity": "C1",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "Don't Underestimate Our Chances (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/dontunderestimateourchances.gif",
@@ -15163,7 +17931,12 @@
       "id": 5497,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Dorme'",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/dorme.gif",
@@ -15187,7 +17960,12 @@
       "gempId": "200_11",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Dorme'",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/dorme.gif",
@@ -15220,7 +17998,12 @@
       "gempId": "2_48",
       "side": "Light",
       "rarity": "R2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Double Agent",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/doubleagent.gif",
@@ -15244,7 +18027,12 @@
       "gempId": "7_59",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Down With The Emperor!",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/downwiththeemperor.gif",
@@ -15266,7 +18054,12 @@
       "id": 5498,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Down With The Emperor! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/downwiththeemperor.gif",
@@ -15285,7 +18078,12 @@
       "gempId": "200_38",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Down With The Emperor! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/downwiththeemperor.gif",
@@ -15311,7 +18109,12 @@
       "gempId": "7_60",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Draw Their Fire",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/drawtheirfire.gif",
@@ -15339,7 +18142,12 @@
       "id": 5499,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Dressel",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/dressel.gif",
@@ -15359,7 +18167,12 @@
       "gempId": "8_9",
       "side": "Light",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "Dresselian Commando",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/dresseliancommando.gif",
@@ -15394,7 +18207,12 @@
       "gempId": "7_15",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•••Droid Merchant",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/droidmerchant.gif",
@@ -15424,7 +18242,12 @@
       "gempId": "4_9",
       "side": "Light",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Droid Sensorscope",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/droidsensorscope.gif",
@@ -15445,7 +18268,12 @@
       "gempId": "1_78",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Droid Shutdown",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/droidshutdown.gif",
@@ -15465,7 +18293,12 @@
       "gempId": "6_11",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Droopy McCool",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/droopymccool.gif",
@@ -15493,7 +18326,12 @@
       "gempId": "3_74",
       "side": "Light",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Dual Laser Cannon",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/duallasercannon.gif",
@@ -15518,7 +18356,12 @@
       "id": 5500,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Dual Laser Cannon (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/duallasercannon.gif",
@@ -15538,7 +18381,12 @@
       "gempId": "6_65",
       "side": "Light",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Dune Sea Sabacc",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/duneseasabacc.gif",
@@ -15561,7 +18409,12 @@
       "gempId": "1_8",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Dutch",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/dutch.gif",
@@ -15602,7 +18455,12 @@
       "gempId": "210_13",
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•Dutch (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Light/large/dutch.gif",
@@ -15627,7 +18485,12 @@
       "gempId": "111_3",
       "side": "Light",
       "rarity": "PM",
-      "set": "Third Anthology",
+      "set": "111",
+      "printings": [
+        {
+          "set": "111"
+        }
+      ],
       "front": {
         "title": "•Echo Base Garrison",
         "imageUrl": "https://res.starwarsccg.org/cards/ThirdAnthology-Light/large/echobasegarrison.gif",
@@ -15665,7 +18528,12 @@
       "gempId": "3_34",
       "side": "Light",
       "rarity": "R2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Echo Base Operations",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/echobaseoperations.gif",
@@ -15692,7 +18560,12 @@
       "gempId": "13_17",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Echo Base Sensors",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/echobasesensors.gif",
@@ -15715,7 +18588,12 @@
       "gempId": "3_6",
       "side": "Light",
       "rarity": "C3",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Echo Base Trooper",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/echobasetrooper.gif",
@@ -15751,7 +18629,12 @@
       "gempId": "3_7",
       "side": "Light",
       "rarity": "C1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•••Echo Base Trooper Officer",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/echobasetrooperofficer.gif",
@@ -15783,7 +18666,12 @@
       "id": 5502,
       "side": "Light",
       "rarity": "C1",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•••Echo Base Trooper Officer (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/echobasetrooperofficer.gif",
@@ -15808,7 +18696,12 @@
       "gempId": "7_158",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Echo Base Trooper Rifle",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/echobasetrooperrifle.gif",
@@ -15832,7 +18725,12 @@
       "gempId": "3_29",
       "side": "Light",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Echo Trooper Backpack",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/echotrooperbackpack.gif",
@@ -15853,7 +18751,12 @@
       "gempId": "4_49",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Effective Repairs",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/effectiverepairs.gif",
@@ -15878,7 +18781,12 @@
       "gempId": "209_19",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "Effective Repairs & Starship Levitation",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/effectiverepairsstarshiplevitation.gif",
@@ -15894,7 +18802,12 @@
       "gempId": "3_8",
       "side": "Light",
       "rarity": "C1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "EG-4 (Eegee-Four)",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/eg4eegeefour.gif",
@@ -15921,7 +18834,12 @@
       "gempId": "4_50",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Egregious Pilot Error",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/egregiouspiloterror.gif",
@@ -15949,7 +18867,12 @@
       "gempId": "11_32",
       "side": "Light",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Either Way, You Win",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/eitherwayyouwin.gif",
@@ -15969,7 +18892,12 @@
       "id": 5504,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Either Way, You Win (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/eitherwayyouwin.gif",
@@ -15989,7 +18917,12 @@
       "gempId": "2_32",
       "side": "Light",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Eject! Eject!",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/ejecteject.gif",
@@ -16009,7 +18942,12 @@
       "id": 5505,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "Eject! Eject! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/ejecteject.gif",
@@ -16028,7 +18966,12 @@
       "gempId": "1_35",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Electrobinoculars",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/electrobinoculars.gif",
@@ -16048,7 +18991,12 @@
       "gempId": "14_65",
       "side": "Light",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "Electropole",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/electropole.gif",
@@ -16070,7 +19018,12 @@
       "id": 5506,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "Elegant Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/elegantlightsaber.gif",
@@ -16091,7 +19044,12 @@
       "gempId": "208_5",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Ello Asty",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/elloasty.gif",
@@ -16127,7 +19085,12 @@
       "gempId": "1_49",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Ellorrs Madak",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/ellorrsmadak.gif",
@@ -16149,7 +19112,12 @@
       "id": 5507,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "Ellorrs Madak (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/ellorrsmadak.gif",
@@ -16165,7 +19133,12 @@
       "gempId": "203_4",
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•Ellorrs Madak, Pilot Instructor",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Light/large/ellorrsmadakpilotinstructor.gif",
@@ -16190,7 +19163,12 @@
       "gempId": "6_12",
       "side": "Light",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Elom",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/elom.gif",
@@ -16216,7 +19194,12 @@
       "gempId": "7_16",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Elyhek Rue",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/elyhekrue.gif",
@@ -16243,7 +19226,12 @@
       "id": 5509,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Emperor's Sinister Plans",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/emperorssinisterplans.gif",
@@ -16263,7 +19251,12 @@
       "gempId": "4_22",
       "side": "Light",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "<>Encampment",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/encampment.gif",
@@ -16283,7 +19276,12 @@
       "id": 5510,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "<>Encampment (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/encampment.gif",
@@ -16303,7 +19301,12 @@
       "gempId": "11_33",
       "side": "Light",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•End Of A Reign",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/endofareign.gif",
@@ -16326,7 +19329,12 @@
       "gempId": "8_68",
       "side": "Light",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Endor",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/endor.gif",
@@ -16360,7 +19368,12 @@
       "gempId": "204_24",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Endor (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/endor.gif",
@@ -16395,7 +19408,12 @@
       "gempId": "8_46",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Endor Celebration",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/endorcelebration.gif",
@@ -16423,7 +19441,12 @@
       "id": 5511,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Endor Celebration (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/endorcelebration.gif",
@@ -16443,7 +19466,12 @@
       "gempId": "203_5",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•Endor Commando Team",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Light/large/endorcommandoteam.gif",
@@ -16479,7 +19507,12 @@
       "gempId": "8_10",
       "side": "Light",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "Endor Scout Trooper",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/endorscouttrooper.gif",
@@ -16513,7 +19546,12 @@
       "gempId": "8_69",
       "side": "Light",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Endor: Back Door",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/endorbackdoor.gif",
@@ -16548,7 +19586,12 @@
       "gempId": "8_70",
       "side": "Light",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Endor: Bunker",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/endorbunker.gif",
@@ -16577,7 +19620,12 @@
       "gempId": "204_25",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Endor: Bunker (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/endorbunker.gif",
@@ -16607,7 +19655,12 @@
       "gempId": "8_71",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Endor: Chief Chirpa's Hut",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/endorchiefchirpashut.gif",
@@ -16636,7 +19689,12 @@
       "gempId": "8_72",
       "side": "Light",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Endor: Dense Forest",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/endordenseforest.gif",
@@ -16665,7 +19723,12 @@
       "gempId": "8_73",
       "side": "Light",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Endor: Ewok Village",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/endorewokvillage.gif",
@@ -16698,7 +19761,12 @@
       "id": 5512,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Endor: Ewok Village (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/endorewokvillage.gif",
@@ -16720,7 +19788,12 @@
       "gempId": "208_23",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Endor: Ewok Village (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/endorewokvillage.gif",
@@ -16749,7 +19822,12 @@
       "gempId": "8_74",
       "side": "Light",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•••Endor: Great Forest",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/endorgreatforest.gif",
@@ -16777,7 +19855,12 @@
       "gempId": "8_75",
       "side": "Light",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Endor: Hidden Forest Trail",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/endorhiddenforesttrail.gif",
@@ -16805,7 +19888,12 @@
       "gempId": "8_76",
       "side": "Light",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Endor: Landing Platform (Docking Bay)",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/endorlandingplatformdockingbay.gif",
@@ -16840,7 +19928,12 @@
       "gempId": "8_77",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Endor: Rebel Landing Site (Forest)",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/endorrebellandingsiteforest.gif",
@@ -16868,7 +19961,12 @@
       "gempId": "13_18",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Energy Walls",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/energywalls.gif",
@@ -16898,7 +19996,12 @@
       "gempId": "9_88",
       "side": "Light",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "Enhanced Proton Torpedoes",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/enhancedprotontorpedoes.gif",
@@ -16922,7 +20025,12 @@
       "id": 5513,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "Enhanced Proton Torpedoes (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/enhancedprotontorpedoes.gif",
@@ -16942,7 +20050,12 @@
       "gempId": "205_2",
       "side": "Light",
       "rarity": "C3",
-      "set": "Virtual Set 5",
+      "set": "205",
+      "printings": [
+        {
+          "set": "205"
+        }
+      ],
       "front": {
         "title": "Ensign Chad Hilse",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual5-Light/large/ensignchadhilse.gif",
@@ -16972,7 +20085,12 @@
       "gempId": "11_34",
       "side": "Light",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Entering The Arena",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/enteringthearena.gif",
@@ -16999,7 +20117,12 @@
       "gempId": "7_61",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Entrenchment",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/entrenchment.gif",
@@ -17020,7 +20143,12 @@
       "id": 5514,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Entrenchment (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/entrenchment.gif",
@@ -17039,7 +20167,12 @@
       "gempId": "11_48",
       "side": "Light",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "Eopie",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/eopie.gif",
@@ -17066,7 +20199,12 @@
       "id": 5515,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Errant Venture",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/errantventure.gif",
@@ -17093,7 +20231,12 @@
       "id": 5516,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Errant Venture (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/errantventureai.gif",
@@ -17121,7 +20264,12 @@
       "gempId": "1_79",
       "side": "Light",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Escape Pod",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/escapepod.gif",
@@ -17138,7 +20286,12 @@
       "gempId": "204_18",
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "Escape Pod & We're Doomed",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/escapepodweredoomed.gif",
@@ -17164,7 +20317,12 @@
       "id": 5517,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Escape Pod (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/escapepod.gif",
@@ -17181,7 +20339,12 @@
       "gempId": "201_12",
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "Escape Pod (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Light/large/escapepod.gif",
@@ -17210,7 +20373,12 @@
       "gempId": "3_35",
       "side": "Light",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Evacuation Control",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/evacuationcontrol.gif",
@@ -17230,7 +20398,12 @@
       "id": 5518,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Evacuation Control (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/evacuationcontrol.gif",
@@ -17249,7 +20422,12 @@
       "gempId": "200_39",
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "Evacuation Control (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/evacuationcontrol.gif",
@@ -17274,7 +20452,12 @@
       "gempId": "11_35",
       "side": "Light",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Eventually You'll Lose",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/eventuallyyoulllose.gif",
@@ -17298,7 +20481,12 @@
       "gempId": "8_47",
       "side": "Light",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Ewok And Roll",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/ewokandroll.gif",
@@ -17319,7 +20507,12 @@
       "gempId": "8_87",
       "side": "Light",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "Ewok Bow",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/ewokbow.gif",
@@ -17340,7 +20533,12 @@
       "gempId": "8_88",
       "side": "Light",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "Ewok Catapult",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/ewokcatapult.gif",
@@ -17364,7 +20562,12 @@
       "gempId": "13_19",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Ewok Celebration",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/ewokcelebration.gif",
@@ -17385,7 +20588,12 @@
       "gempId": "8_82",
       "side": "Light",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "Ewok Glider",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/ewokglider.gif",
@@ -17413,7 +20621,12 @@
       "gempId": "8_48",
       "side": "Light",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Ewok Log Jam",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/ewoklogjam.gif",
@@ -17434,7 +20647,12 @@
       "gempId": "8_49",
       "side": "Light",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "Ewok Rescue",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/ewokrescue.gif",
@@ -17457,7 +20675,12 @@
       "gempId": "8_11",
       "side": "Light",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "Ewok Sentry",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/ewoksentry.gif",
@@ -17491,7 +20714,12 @@
       "gempId": "8_89",
       "side": "Light",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "Ewok Spear",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/ewokspear.gif",
@@ -17515,7 +20743,12 @@
       "gempId": "8_12",
       "side": "Light",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "Ewok Spearman",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/ewokspearman.gif",
@@ -17546,7 +20779,12 @@
       "gempId": "8_13",
       "side": "Light",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "Ewok Tribesman",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/ewoktribesman.gif",
@@ -17580,7 +20818,12 @@
       "gempId": "8_90",
       "side": "Light",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "Explosive Charge",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/explosivecharge.gif",
@@ -17601,7 +20844,12 @@
       "gempId": "1_50",
       "side": "Light",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Eyes In The Dark",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/eyesinthedark.gif",
@@ -17621,7 +20869,12 @@
       "id": 5519,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Eyes In The Dark (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/eyesinthedark.gif",
@@ -17637,7 +20890,12 @@
       "gempId": "210_14",
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•Ezra Bridger",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Light/large/ezrabridger.gif",
@@ -17665,7 +20923,12 @@
       "gempId": "106_3",
       "side": "Light",
       "rarity": "PM",
-      "set": "Official Tournament Sealed Deck",
+      "set": "106",
+      "printings": [
+        {
+          "set": "106"
+        }
+      ],
       "front": {
         "title": "•Faithful Service",
         "imageUrl": "https://res.starwarsccg.org/cards/OfficialTournamentSealedDeck-Light/large/faithfulservice.gif",
@@ -17687,7 +20950,12 @@
       "id": 5521,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Faithful Service (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/faithfulservice.gif",
@@ -17706,7 +20974,12 @@
       "gempId": "3_42",
       "side": "Light",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Fall Back!",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/fallback.gif",
@@ -17723,7 +20996,12 @@
       "gempId": "13_20",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Fall Of A Jedi",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/fallofajedi.gif",
@@ -17752,7 +21030,12 @@
       "gempId": "5_46",
       "side": "Light",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Fall Of The Empire",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/falloftheempire.gif",
@@ -17770,7 +21053,12 @@
       "gempId": "5_47",
       "side": "Light",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Fall Of The Legend",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/fallofthelegend.gif",
@@ -17791,7 +21079,12 @@
       "gempId": "6_66",
       "side": "Light",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Fallen Portal",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/fallenportal.gif",
@@ -17816,7 +21109,12 @@
       "gempId": "14_59",
       "side": "Light",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•••Fambaa",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/fambaa.gif",
@@ -17850,7 +21148,12 @@
       "gempId": "7_120",
       "side": "Light",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "<>Farm",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/farm.gif",
@@ -17879,7 +21182,12 @@
       "id": 5522,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "••Field Dressing",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/fielddressing.gif",
@@ -17899,7 +21207,12 @@
       "gempId": "1_9",
       "side": "Light",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Figrin D'an",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/figrindan.gif",
@@ -17926,7 +21239,12 @@
       "gempId": "204_6",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Finn",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/finn.gif",
@@ -17967,7 +21285,12 @@
       "gempId": "2_25",
       "side": "Light",
       "rarity": "U2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Fire Extinguisher",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/fireextinguisher.gif",
@@ -17994,7 +21317,12 @@
       "gempId": "8_50",
       "side": "Light",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "Firefight",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/firefight.gif",
@@ -18014,7 +21342,12 @@
       "id": 5523,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "Firefight (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/firefight.gif",
@@ -18034,7 +21367,12 @@
       "gempId": "7_17",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Firin Morett",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/firinmorett.gif",
@@ -18076,7 +21414,12 @@
       "gempId": "7_89",
       "side": "Light",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•First Aid",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/firstaid.gif",
@@ -18095,7 +21438,12 @@
       "gempId": "9_12",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•First Officer Thaneespi",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/firstofficerthaneespi.gif",
@@ -18134,7 +21482,12 @@
       "id": 5524,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Fixer",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/fixer.gif",
@@ -18159,7 +21512,12 @@
       "gempId": "4_23",
       "side": "Light",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Flash Of Insight",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/flashofinsight.gif",
@@ -18182,7 +21540,12 @@
       "id": 5525,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Flash Of Insight (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/flashofinsight.gif",
@@ -18201,7 +21564,12 @@
       "gempId": "6_13",
       "side": "Light",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•••Florn Lamproid",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/flornlamproid.gif",
@@ -18228,7 +21596,12 @@
       "gempId": "8_51",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Fly Casual",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/flycasual.gif",
@@ -18255,7 +21628,12 @@
       "gempId": "102_1",
       "side": "Light",
       "rarity": "PM",
-      "set": "Jedi Pack",
+      "set": "102",
+      "printings": [
+        {
+          "set": "102"
+        }
+      ],
       "front": {
         "title": "•For Luck",
         "imageUrl": "https://res.starwarsccg.org/cards/JediPack-Light/large/forluck.gif",
@@ -18276,7 +21654,12 @@
       "id": 5526,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•For Luck (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/forluck.gif",
@@ -18295,7 +21678,12 @@
       "gempId": "200_40",
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•For Luck (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/forluck.gif",
@@ -18323,7 +21711,12 @@
       "gempId": "202_6",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 2",
+      "set": "202",
+      "printings": [
+        {
+          "set": "202"
+        }
+      ],
       "front": {
         "title": "•Force Levitation",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual2-Light/large/forcelevitation.gif",
@@ -18342,7 +21735,12 @@
       "gempId": "211_51",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Force Projection",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/forceprojection.gif",
@@ -18362,7 +21760,12 @@
       "gempId": "7_121",
       "side": "Light",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "<>Forest",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/forest.gif",
@@ -18386,7 +21789,12 @@
       "id": 5528,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Foul Moudama",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/foulmoudama.gif",
@@ -18415,7 +21823,12 @@
       "gempId": "4_51",
       "side": "Light",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Found Someone You Have",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/foundsomeoneyouhave.gif",
@@ -18431,7 +21844,12 @@
       "id": 5529,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Found Someone You Have & Higher Ground",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/foundsomeoneyouhave&higherground.gif",
@@ -18447,7 +21865,12 @@
       "id": 5530,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Found Someone You Have (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/foundsomeoneyouhave.gif",
@@ -18467,7 +21890,12 @@
       "gempId": "200_52",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "Found Someone You Have (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/foundsomeoneyouhave.gif",
@@ -18487,7 +21915,12 @@
       "gempId": "8_52",
       "side": "Light",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Free Ride",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/freeride.gif",
@@ -18509,7 +21942,12 @@
       "gempId": "12_58",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Free Ride & •Endor Celebration",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/freeride&endorcelebration.gif",
@@ -18535,7 +21973,12 @@
       "gempId": "12_5",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Freon Drevan",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/freondrevan.gif",
@@ -18566,7 +22009,12 @@
       "gempId": "1_80",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Friendly Fire",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/friendlyfire.gif",
@@ -18584,7 +22032,12 @@
       "gempId": "3_36",
       "side": "Light",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Frostbite",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/frostbite.gif",
@@ -18606,7 +22059,12 @@
       "id": 5531,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Frostbite (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/frostbite.gif",
@@ -18625,7 +22083,12 @@
       "gempId": "5_23",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Frozen Assets",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/frozenassets.gif",
@@ -18657,7 +22120,12 @@
       "gempId": "1_81",
       "side": "Light",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Full Throttle",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/fullthrottle.gif",
@@ -18676,7 +22144,12 @@
       "gempId": "1_36",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Fusion Generator Supply Tanks",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/fusiongeneratorsupplytanks.gif",
@@ -18696,7 +22169,12 @@
       "id": 5532,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Fusion Generator Supply Tanks (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/fusiongeneratorsupplytanks.gif",
@@ -18712,7 +22190,12 @@
       "gempId": "3_9",
       "side": "Light",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "FX-7 (Effex-Seven)",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/fx7effexseven.gif",
@@ -18739,7 +22222,12 @@
       "gempId": "209_4",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Galen Erso",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/galenerso.gif",
@@ -18760,7 +22248,12 @@
       "gempId": "5_48",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Gambler's Luck",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/gamblersluck.gif",
@@ -18777,7 +22270,12 @@
       "id": 5534,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Gambler's Luck (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/gamblersluck.gif",
@@ -18797,7 +22295,12 @@
       "gempId": "6_14",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Garon Nas Tal",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/garonnastal.gif",
@@ -18822,7 +22325,12 @@
       "gempId": "2_8",
       "side": "Light",
       "rarity": "U2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Garouf Lafoe",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/garouflafoe.gif",
@@ -18847,7 +22355,12 @@
       "gempId": "6_15",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Geezum",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/geezum.gif",
@@ -18878,7 +22391,12 @@
       "id": 5535,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•General Airen Cracken",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/generalairencracken.gif",
@@ -18903,7 +22421,12 @@
       "gempId": "200_12",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•General Airen Cracken",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/generalairencracken.gif",
@@ -18944,7 +22467,12 @@
       "id": 5536,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•General Bel Iblis",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/generalbeliblis.gif",
@@ -18970,7 +22498,12 @@
       "id": 5537,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•General Bob Hudsol",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/generalbobhudsol.gif",
@@ -18995,7 +22528,12 @@
       "gempId": "9_13",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•General Calrissian",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/generalcalrissian.gif",
@@ -19046,7 +22584,12 @@
       "gempId": "3_10",
       "side": "Light",
       "rarity": "R2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•General Carlist Rieekan",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/generalcarlistrieekan.gif",
@@ -19085,7 +22628,12 @@
       "id": 5538,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•General Carlist Rieekan (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/generalcarlistrieekan.gif",
@@ -19110,7 +22658,12 @@
       "gempId": "208_6",
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•General Carlist Rieekan (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/generalcarlistrieekan.gif",
@@ -19147,7 +22700,12 @@
       "gempId": "8_14",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•General Crix Madine",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/generalcrixmadine.gif",
@@ -19230,7 +22788,12 @@
       "gempId": "1_10",
       "side": "Light",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•General Dodonna",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/generaldodonna.gif",
@@ -19268,7 +22831,12 @@
       "id": 5539,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•General Dodonna (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/generaldodonna.gif",
@@ -19292,7 +22860,12 @@
       "gempId": "209_5",
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•General Dodonna (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/generaldodonna.gif",
@@ -19317,7 +22890,12 @@
       "gempId": "14_10",
       "side": "Light",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•General Jar Jar",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/generaljarjar.gif",
@@ -19367,7 +22945,12 @@
       "gempId": "14_11",
       "side": "Light",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•General Jar Jar (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/generaljarjarai.gif",
@@ -19395,7 +22978,12 @@
       "gempId": "209_6",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•General Kenobi",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/generalkenobi.gif",
@@ -19430,7 +23018,12 @@
       "gempId": "207_5",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 7",
+      "set": "207",
+      "printings": [
+        {
+          "set": "207"
+        }
+      ],
       "front": {
         "title": "•General Leia Organa",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual7-Light/large/generalleiaorgana.gif",
@@ -19473,7 +23066,12 @@
       "gempId": "7_18",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•General McQuarrie",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/generalmcquarrie.gif",
@@ -19510,7 +23108,12 @@
       "gempId": "8_15",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•General Solo",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/generalsolo.gif",
@@ -19568,7 +23171,12 @@
       "id": 5543,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•General Solo (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/generalsolo.gif",
@@ -19597,7 +23205,12 @@
       "gempId": "200_13",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•General Solo (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/generalsolo.gif",
@@ -19655,7 +23268,12 @@
       "id": 5544,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•General Solomahal",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/generalsolomahal.gif",
@@ -19682,7 +23300,12 @@
       "gempId": "9_14",
       "side": "Light",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•General Walex Blissex",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/generalwalexblissex.gif",
@@ -19717,7 +23340,12 @@
       "id": 5545,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•General Walex Blissex (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/generalwalexblissex.gif",
@@ -19742,7 +23370,12 @@
       "gempId": "209_7",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•General Walex Blissex (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/generalwalexblissex.gif",
@@ -19765,7 +23398,12 @@
       "id": 5547,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Geonosis: Docking Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/geonosisdockingbay.gif",
@@ -19786,7 +23424,12 @@
       "id": 5548,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Geonosis: Forward Command Center",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/geonosisforwardcommandcenter.gif",
@@ -19807,7 +23450,12 @@
       "id": 5549,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Geonosis: Petranaki Arena",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/geonosispetranakiarena.gif",
@@ -19827,7 +23475,12 @@
       "id": 5550,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Geonosis: Rocky Plains",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/geonosisrockyplains.gif",
@@ -19848,7 +23501,12 @@
       "gempId": "8_53",
       "side": "Light",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Get Alongside That One",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/getalongsidethatone.gif",
@@ -19867,7 +23525,12 @@
       "gempId": "14_31",
       "side": "Light",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Get To Your Ships!",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/gettoyourships.gif",
@@ -19894,7 +23557,12 @@
       "gempId": "6_16",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Ghoel",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/ghoel.gif",
@@ -19922,7 +23590,12 @@
       "gempId": "207_17",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 7",
+      "set": "207",
+      "printings": [
+        {
+          "set": "207"
+        }
+      ],
       "front": {
         "title": "•Ghost",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual7-Light/large/ghost.gif",
@@ -19962,7 +23635,12 @@
       "gempId": "14_60",
       "side": "Light",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "Gian Speeder",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/gianspeeder.gif",
@@ -19987,7 +23665,12 @@
       "gempId": "1_82",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Gift Of The Mentor",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/giftofthementor.gif",
@@ -20020,7 +23703,12 @@
       "gempId": "14_42",
       "side": "Light",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Gimme A Lift!",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/gimmealift.gif",
@@ -20041,7 +23729,12 @@
       "gempId": "5_49",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Glancing Blow",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/glancingblow.gif",
@@ -20062,7 +23755,12 @@
       "gempId": "3_75",
       "side": "Light",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Golan Laser Battery",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/golanlaserbattery.gif",
@@ -20089,7 +23787,12 @@
       "gempId": "1_141",
       "side": "Light",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Gold 1",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/gold1.gif",
@@ -20124,7 +23827,12 @@
       "id": 5551,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Gold 1 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/gold1.gif",
@@ -20150,7 +23858,12 @@
       "gempId": "2_69",
       "side": "Light",
       "rarity": "U1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Gold 2",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/gold2.gif",
@@ -20186,7 +23899,12 @@
       "gempId": "7_141",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Gold 3",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/gold3.gif",
@@ -20222,7 +23940,12 @@
       "gempId": "7_142",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Gold 4",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/gold4.gif",
@@ -20258,7 +23981,12 @@
       "gempId": "1_142",
       "side": "Light",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Gold 5",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/gold5.gif",
@@ -20294,7 +24022,12 @@
       "gempId": "7_143",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Gold 6",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/gold6.gif",
@@ -20330,7 +24063,12 @@
       "gempId": "103_1",
       "side": "Light",
       "rarity": "PM",
-      "set": "Rebel Leader Pack",
+      "set": "103",
+      "printings": [
+        {
+          "set": "103"
+        }
+      ],
       "front": {
         "title": "•Gold Leader In Gold 1",
         "imageUrl": "https://res.starwarsccg.org/cards/RebelLeader-Light/large/goldleaderingold1.gif",
@@ -20355,7 +24093,12 @@
       "id": 5553,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Gold Leader In Gold 1 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/goldleaderingold1.gif",
@@ -20383,7 +24126,12 @@
       "gempId": "200_62",
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Gold Leader In Gold 1 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/goldleaderingold1.gif",
@@ -20418,7 +24166,12 @@
       "gempId": "9_68",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Gold Squadron 1",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/goldsquadron1.gif",
@@ -20473,7 +24226,12 @@
       "gempId": "106_4",
       "side": "Light",
       "rarity": "PM",
-      "set": "Official Tournament Sealed Deck",
+      "set": "106",
+      "printings": [
+        {
+          "set": "106"
+        }
+      ],
       "front": {
         "title": "•••Gold Squadron Y-wing",
         "imageUrl": "https://res.starwarsccg.org/cards/OfficialTournamentSealedDeck-Light/large/goldsquadronywing.gif",
@@ -20508,7 +24266,12 @@
       "gempId": "200_27",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200d",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Goldenrod",
         "imageUrl": "https://res.starwarsccg.org/cards/ResetDS-Light/large/goldenrod.gif",
@@ -20528,7 +24291,12 @@
       "gempId": "7_62",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Goo Nee Tay",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/gooneetay.gif",
@@ -20555,7 +24323,12 @@
       "gempId": "8_16",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Graak",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/graak.gif",
@@ -20580,7 +24353,12 @@
       "gempId": "6_17",
       "side": "Light",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•••Gran",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/gran.gif",
@@ -20607,7 +24385,12 @@
       "gempId": "2_33",
       "side": "Light",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Grappling Hook",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/grapplinghook.gif",
@@ -20641,7 +24424,12 @@
       "id": 5554,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Grappling Hook (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/grapplinghook.gif",
@@ -20662,7 +24450,12 @@
       "gempId": "204_14",
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Graveyard Of Giants",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/graveyardofgiants.gif",
@@ -20686,7 +24479,12 @@
       "gempId": "12_6",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Graxol Kelvyyn",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/graxolkelvyyn.gif",
@@ -20711,7 +24509,12 @@
       "gempId": "9_69",
       "side": "Light",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Gray Squadron 1",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/graysquadron1.gif",
@@ -20748,7 +24551,12 @@
       "gempId": "9_70",
       "side": "Light",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Gray Squadron 2",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/graysquadron2.gif",
@@ -20785,7 +24593,12 @@
       "gempId": "9_15",
       "side": "Light",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•••Gray Squadron Y-wing Pilot",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/graysquadronywingpilot.gif",
@@ -20814,7 +24627,12 @@
       "gempId": "11_18",
       "side": "Light",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Great Shot, Kid!",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/greatshotkid.gif",
@@ -20842,7 +24660,12 @@
       "gempId": "4_77",
       "side": "Light",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Great Warrior",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/greatwarrior.gif",
@@ -20860,7 +24683,12 @@
       "gempId": "9_16",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Green Leader",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/greenleader.gif",
@@ -20896,7 +24724,12 @@
       "gempId": "201_18",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Green Leader In Green Squadron 1",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Light/large/greenleaderingreensquadron1.gif",
@@ -20927,7 +24760,12 @@
       "gempId": "9_71",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Green Squadron 1",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/greensquadron1.gif",
@@ -20965,7 +24803,12 @@
       "id": 5555,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Green Squadron 1 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/greensquadron1.gif",
@@ -20992,7 +24835,12 @@
       "gempId": "9_72",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Green Squadron 3",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/greensquadron3.gif",
@@ -21031,7 +24879,12 @@
       "gempId": "9_73",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•••Green Squadron A-wing",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/greensquadronawing.gif",
@@ -21068,7 +24921,12 @@
       "gempId": "9_17",
       "side": "Light",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•••Green Squadron Pilot",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/greensquadronpilot.gif",
@@ -21097,7 +24955,12 @@
       "gempId": "2_49",
       "side": "Light",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Grimtaash",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/grimtaash.gif",
@@ -21129,7 +24992,12 @@
       "gempId": "7_19",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Grondorn Muse",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/grondornmuse.gif",
@@ -21166,7 +25034,12 @@
       "gempId": "4_24",
       "side": "Light",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Grounded Starfighter",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/groundedstarfighter.gif",
@@ -21186,7 +25059,12 @@
       "id": 5556,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Grrrghrrrgh!",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/grrrghrrrgh.gif",
@@ -21206,7 +25084,12 @@
       "gempId": "11_3",
       "side": "Light",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Grugnak",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/grugnak.gif",
@@ -21233,7 +25116,12 @@
       "id": 5557,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Guardian's Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/guardianslightsaber.gif",
@@ -21249,7 +25137,12 @@
       "id": 5558,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "Gundark",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/gundark.gif",
@@ -21271,7 +25164,12 @@
       "gempId": "14_32",
       "side": "Light",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•••Gungan Energy Shield",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/gunganenergyshield.gif",
@@ -21300,7 +25198,12 @@
       "gempId": "14_12",
       "side": "Light",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•••Gungan General",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/gungangeneral.gif",
@@ -21344,7 +25247,12 @@
       "gempId": "14_13",
       "side": "Light",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "Gungan Guard",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/gunganguard.gif",
@@ -21381,7 +25289,12 @@
       "gempId": "12_7",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Gungan Warrior",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/gunganwarrior.gif",
@@ -21419,7 +25332,12 @@
       "gempId": "102_2",
       "side": "Light",
       "rarity": "PM",
-      "set": "Jedi Pack",
+      "set": "102",
+      "printings": [
+        {
+          "set": "102"
+        }
+      ],
       "front": {
         "title": "•Han",
         "imageUrl": "https://res.starwarsccg.org/cards/JediPack-Light/large/han.gif",
@@ -21460,7 +25378,12 @@
       "id": 5559,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Han (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/han.gif",
@@ -21489,7 +25412,12 @@
       "gempId": "200_14",
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Han (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/han.gif",
@@ -21537,7 +25465,12 @@
       "gempId": "1_11",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Han Solo",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/hansolo.gif",
@@ -21588,7 +25521,12 @@
       "id": 5560,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Han Solo (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/hansolo.gif",
@@ -21615,7 +25553,12 @@
       "id": 5561,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Han Solo, Courageous Smuggler",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/hansolocourageoussmuggler.gif",
@@ -21640,7 +25583,12 @@
       "id": 5562,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Han Solo, Innocent Scoundrel",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/hansoloinnocentscoundrel.gif",
@@ -21665,7 +25613,12 @@
       "gempId": "108_1",
       "side": "Light",
       "rarity": "PM",
-      "set": "Enhanced Premiere",
+      "set": "108",
+      "printings": [
+        {
+          "set": "108"
+        }
+      ],
       "front": {
         "title": "•Han With Heavy Blaster Pistol",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedPremiere-Light/large/hanwithheavyblasterpistol.gif",
@@ -21715,7 +25668,12 @@
       "gempId": "13_21",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Han, Chewie, And The Falcon",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/hanchewieandthefalcon.gif",
@@ -21754,7 +25712,12 @@
       "id": 5563,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Han, Chewie, And The Falcon (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/hanchewieandthefalcon.gif",
@@ -21782,7 +25745,12 @@
       "gempId": "205_7",
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Set 5",
+      "set": "205",
+      "printings": [
+        {
+          "set": "205"
+        }
+      ],
       "front": {
         "title": "•Han, Chewie, And The Falcon (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual5-Light/large/hanchewieandthefalcon.gif",
@@ -21822,7 +25790,12 @@
       "gempId": "1_83",
       "side": "Light",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Han's Back",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/hansback.gif",
@@ -21855,7 +25828,12 @@
       "id": 5564,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Han's Back (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/hansback.gif",
@@ -21871,7 +25849,12 @@
       "id": 5565,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Han's Blaster, So Uncivilized",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/hansblastersouncivilized.gif",
@@ -21888,7 +25871,12 @@
       "gempId": "1_84",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Han's Dice",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/hansdice.gif",
@@ -21904,7 +25892,12 @@
       "id": 5566,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Han's Dice (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/hansdice.gif",
@@ -21921,7 +25914,12 @@
       "gempId": "1_154",
       "side": "Light",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Han's Heavy Blaster Pistol",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/hansheavyblasterpistol.gif",
@@ -21953,7 +25951,12 @@
       "id": 5567,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Han's Heavy Blaster Pistol (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/hansheavyblasterpistol.gif",
@@ -21970,7 +25973,12 @@
       "gempId": "200_70",
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Han's Heavy Blaster Pistol (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/hansheavyblasterpistol.gif",
@@ -22003,7 +26011,12 @@
       "gempId": "4_10",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Han's Toolkit",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/hanstoolkit.gif",
@@ -22030,7 +26043,12 @@
       "id": 5568,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Han's Toolkit (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/hanstoolkit.gif",
@@ -22049,7 +26067,12 @@
       "gempId": "7_20",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Harc Seff",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/harcseff.gif",
@@ -22083,7 +26106,12 @@
       "id": 5569,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Harc Seff (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/harcseff.gif",
@@ -22109,7 +26137,12 @@
       "gempId": "200_15",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Harc Seff (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/harcseff.gif",
@@ -22145,7 +26178,12 @@
       "gempId": "7_90",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Harvest",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/harvest.gif",
@@ -22165,7 +26203,12 @@
       "id": 5570,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Harvest (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/harvest.gif",
@@ -22186,7 +26229,12 @@
       "gempId": "5_24",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Haven",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/haven.gif",
@@ -22214,7 +26262,12 @@
       "gempId": "13_22",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•He Can Go About His Business",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/hecangoabouthisbusiness.gif",
@@ -22237,7 +26290,12 @@
       "id": 5571,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•He Can Go About His Business (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Light/large/hecangoabouthisbusiness.gif",
@@ -22257,7 +26315,12 @@
       "gempId": "208_25",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "He Is The Chosen One / He Will Bring Balance",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/heisthechosenone.gif",
@@ -22279,7 +26342,12 @@
       "gempId": "9_50",
       "side": "Light",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Head Back To The Surface",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/headbacktothesurface.gif",
@@ -22297,7 +26365,12 @@
       "gempId": "9_51",
       "side": "Light",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Heading For The Medical Frigate",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/headingforthemedicalfrigate.gif",
@@ -22315,7 +26388,12 @@
       "id": 5573,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Heading For The Medical Frigate (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/headingforthemedicalfrigate.gif",
@@ -22335,7 +26413,12 @@
       "gempId": "1_85",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Hear Me Baby, Hold Together",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/hearmebabyholdtogether.gif",
@@ -22351,7 +26434,12 @@
       "id": 5574,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "Hear Me Baby, Hold Together (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/hearmebabyholdtogether.gif",
@@ -22368,7 +26456,12 @@
       "gempId": "201_13",
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "Hear Me Baby, Hold Together (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Light/large/hearmebabyholdtogether.gif",
@@ -22393,7 +26486,12 @@
       "gempId": "9_89",
       "side": "Light",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "Heavy Turbolaser Battery",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/heavyturbolaserbattery.gif",
@@ -22416,7 +26514,12 @@
       "gempId": "1_86",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Help Me Obi-Wan Kenobi",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/helpmeobiwankenobi.gif",
@@ -22439,7 +26542,12 @@
       "gempId": "207_12",
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Set 7",
+      "set": "207",
+      "printings": [
+        {
+          "set": "207"
+        }
+      ],
       "front": {
         "title": "Help Me Obi-Wan Kenobi (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual7-Light/large/helpmeobiwankenobi.gif",
@@ -22463,7 +26571,12 @@
       "gempId": "8_54",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Here We Go Again",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/herewegoagain.gif",
@@ -22482,7 +26595,12 @@
       "gempId": "5_25",
       "side": "Light",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Hero Of A Thousand Devices",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/heroofathousanddevices.gif",
@@ -22519,7 +26637,12 @@
       "gempId": "7_91",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Heroes Of Yavin",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/heroesofyavin.gif",
@@ -22537,7 +26660,12 @@
       "gempId": "7_63",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Heroic Sacrifice",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/heroicsacrifice.gif",
@@ -22562,7 +26690,12 @@
       "gempId": "2_9",
       "side": "Light",
       "rarity": "U2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Het Nkik",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/hetnkik.gif",
@@ -22594,7 +26727,12 @@
       "id": 5575,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Het Nkik (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/hetnkik.gif",
@@ -22615,7 +26753,12 @@
       "gempId": "7_136",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Hidden Base / Systems Will Slip Through Your Fingers",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/hiddenbase.gif",
@@ -22636,7 +26779,12 @@
       "id": 5577,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "Hidden Base / Systems Will Slip Through Your Fingers (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/hiddenbase.gif",
@@ -22664,7 +26812,12 @@
       "gempId": "6_50",
       "side": "Light",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Hidden Compartment",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/hiddencompartment.gif",
@@ -22687,7 +26840,12 @@
       "id": 5578,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Hidden Fortress",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/hiddenfortress.gif",
@@ -22702,7 +26860,12 @@
       "gempId": "4_25",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Hiding In The Garbage",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/hidinginthegarbage.gif",
@@ -22722,7 +26885,12 @@
       "id": 5579,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Hiding In The Garbage (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/hidinginthegarbage.gif",
@@ -22741,7 +26909,12 @@
       "gempId": "5_50",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Higher Ground",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/higherground.gif",
@@ -22763,7 +26936,12 @@
       "gempId": "5_26",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Hindsight",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/hindsight.gif",
@@ -22784,7 +26962,12 @@
       "id": 5580,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Hindsight (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/hindsight.gif",
@@ -22804,7 +26987,15 @@
       "gempId": "7_92",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "105"
+        },
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Hit And Run",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/hitandrun.gif",
@@ -22822,7 +27013,12 @@
       "gempId": "6_18",
       "side": "Light",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "H'nemthe",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/hnemthe.gif",
@@ -22854,7 +27050,12 @@
       "gempId": "7_21",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Hol Okand",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/holokand.gif",
@@ -22882,7 +27083,12 @@
       "gempId": "6_51",
       "side": "Light",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Holoprojector",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/holoprojector.gif",
@@ -22914,7 +27120,12 @@
       "gempId": "9_74",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Home One",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/homeone.gif",
@@ -22958,7 +27169,12 @@
       "gempId": "9_57",
       "side": "Light",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Home One: Docking Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/homeonedockingbay.gif",
@@ -22990,7 +27206,12 @@
       "gempId": "9_58",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Home One: War Room",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/homeonewarroom.gif",
@@ -23015,7 +27236,12 @@
       "gempId": "9_33",
       "side": "Light",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Honor Of The Jedi",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/honorofthejedi.gif",
@@ -23041,7 +27267,12 @@
       "gempId": "5_27",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Hopping Mad",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/hoppingmad.gif",
@@ -23071,7 +27302,12 @@
       "id": 5581,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Hopping Mad (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/hoppingmad.gif",
@@ -23090,7 +27326,12 @@
       "gempId": "13_23",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Horace Vancil",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/horacevancil.gif",
@@ -23121,7 +27362,12 @@
       "gempId": "12_8",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Horox Ryyder",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/horoxryyder.gif",
@@ -23153,7 +27399,12 @@
       "gempId": "3_55",
       "side": "Light",
       "rarity": "U2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Hoth",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/hoth.gif",
@@ -23184,7 +27435,12 @@
       "gempId": "7_64",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Hoth Sentry",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/hothsentry.gif",
@@ -23208,7 +27464,12 @@
       "gempId": "3_30",
       "side": "Light",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Hoth Survival Gear",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/hothsurvivalgear.gif",
@@ -23228,7 +27489,12 @@
       "gempId": "3_56",
       "side": "Light",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Hoth: Defensive Perimeter (3rd Marker)",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/hothdefensiveperimeter.gif",
@@ -23250,7 +27516,12 @@
       "gempId": "3_57",
       "side": "Light",
       "rarity": "U2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Hoth: Echo Command Center (War Room)",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/hothechocommandcenterwarroom.gif",
@@ -23278,7 +27549,12 @@
       "id": 5583,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Hoth: Echo Command Center (War Room) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/hothechocommandcenterwarroom.gif",
@@ -23301,7 +27577,12 @@
       "gempId": "3_58",
       "side": "Light",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Hoth: Echo Corridor",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/hothechocorridor.gif",
@@ -23329,7 +27610,12 @@
       "id": 5584,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Hoth: Echo Corridor (v)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/hothechocorridor.gif",
@@ -23351,7 +27637,12 @@
       "gempId": "3_59",
       "side": "Light",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Hoth: Echo Docking Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/hothechodockingbay.gif",
@@ -23384,7 +27675,12 @@
       "gempId": "3_60",
       "side": "Light",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Hoth: Echo Med Lab",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/hothechomedlab.gif",
@@ -23411,7 +27707,12 @@
       "id": 5585,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Hoth: Echo Med Lab (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/hothechomedlab.gif",
@@ -23434,7 +27735,12 @@
       "gempId": "3_61",
       "side": "Light",
       "rarity": "U2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Hoth: Main Power Generators (1st Marker)",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/hothmainpowergenerators.gif",
@@ -23455,7 +27761,12 @@
       "id": 5587,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Hoth: Main Power Generators (1st Marker) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/hothmainpowergenerators.gif",
@@ -23475,7 +27786,12 @@
       "id": 5588,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Hoth: Main Power Generators (1st Marker) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Dark/large/hothmainpowergenerators.gif",
@@ -23496,7 +27812,12 @@
       "gempId": "210_15",
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•Hoth: Main Power Generators (1st Marker) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Light/large/hothmainpowergenerators.gif",
@@ -23519,7 +27840,12 @@
       "gempId": "3_62",
       "side": "Light",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Hoth: North Ridge (4th Marker)",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/hothnorthridge.gif",
@@ -23541,7 +27867,12 @@
       "gempId": "3_63",
       "side": "Light",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Hoth: Snow Trench (2nd Marker)",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/hothsnowtrench.gif",
@@ -23563,7 +27894,12 @@
       "gempId": "2_50",
       "side": "Light",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Houjix",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/houjix.gif",
@@ -23595,7 +27931,12 @@
       "gempId": "10_8",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "Houjix & Out Of Nowhere",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Light/large/houjix&outofnowhere.gif",
@@ -23615,7 +27956,12 @@
       "gempId": "1_87",
       "side": "Light",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "How Did We Get Into This Mess?",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/howdidwegetintothismess.gif",
@@ -23635,7 +27981,12 @@
       "gempId": "2_10",
       "side": "Light",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Hunchback",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/hunchback.gif",
@@ -23656,7 +28007,12 @@
       "id": 5592,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Hunt Down The Dark Acolyte",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/huntdownthedarkacolyte.gif",
@@ -23674,7 +28030,12 @@
       "gempId": "1_37",
       "side": "Light",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Hydroponics Station",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/hydroponicsstation.gif",
@@ -23696,7 +28057,12 @@
       "gempId": "1_88",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Hyper Escape",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/hyperescape.gif",
@@ -23720,7 +28086,12 @@
       "gempId": "11_19",
       "side": "Light",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•I Can't Believe He's Gone",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/icantbelievehesgone.gif",
@@ -23748,7 +28119,12 @@
       "id": 5593,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•I Can't Believe He's Gone (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/icantbelievehesgone.gif",
@@ -23769,7 +28145,12 @@
       "gempId": "11_25",
       "side": "Light",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•I Did It!",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/ididit.gif",
@@ -23794,7 +28175,12 @@
       "gempId": "5_51",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•I Don't Need Their Scum, Either",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/idontneedtheirscumeither.gif",
@@ -23814,7 +28200,12 @@
       "id": 5594,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•I Don't Need Their Scum, Either (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/idontneedtheirscumeither.gif",
@@ -23834,7 +28225,12 @@
       "gempId": "9_34",
       "side": "Light",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•I Feel The Conflict",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/ifeeltheconflict.gif",
@@ -23856,7 +28252,12 @@
       "gempId": "4_52",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "I Have A Bad Feeling About This",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/ihaveabadfeelingaboutthis.gif",
@@ -23877,7 +28278,12 @@
       "gempId": "8_55",
       "side": "Light",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•I Have A Really Bad Feeling About This",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/ihaveareallybadfeelingaboutthis.gif",
@@ -23898,7 +28304,12 @@
       "gempId": "2_51",
       "side": "Light",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "I Have A Very Bad Feeling About This",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/ihaveaverybadfeelingaboutthis.gif",
@@ -23922,7 +28333,12 @@
       "gempId": "8_38",
       "side": "Light",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•I Hope She's All Right",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/ihopeshesallright.gif",
@@ -23945,7 +28361,12 @@
       "id": 5595,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•I Hope She's All Right (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/ihopeshesallright.gif",
@@ -23961,7 +28382,12 @@
       "gempId": "8_56",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•I Know",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/iknow.gif",
@@ -24000,7 +28426,12 @@
       "id": 5596,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•I Know That Laugh",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/iknowthatlaugh.gif",
@@ -24016,7 +28447,12 @@
       "gempId": "6_55",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•I Must Be Allowed To Speak",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/imustbeallowedtospeak.gif",
@@ -24037,7 +28473,12 @@
       "id": 5597,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•I Must Be Allowed To Speak (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/imustbeallowedtospeak.gif",
@@ -24056,7 +28497,12 @@
       "gempId": "200_41",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•I Must Be Allowed To Speak (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/imustbeallowedtospeak.gif",
@@ -24085,7 +28531,12 @@
       "gempId": "207_13",
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Set 7",
+      "set": "207",
+      "printings": [
+        {
+          "set": "207"
+        }
+      ],
       "front": {
         "title": "•I Think I Can Handle Myself",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual7-Light/large/ithinkicanhandlemyself.gif",
@@ -24101,7 +28552,12 @@
       "gempId": "3_43",
       "side": "Light",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "I Thought They Smelled Bad On The Outside",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/ithoughttheysmelledbadontheoutside.gif",
@@ -24118,7 +28574,12 @@
       "gempId": "12_43",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•I Will Not Defer",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/iwillnotdefer.gif",
@@ -24147,7 +28608,12 @@
       "gempId": "8_39",
       "side": "Light",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•I Wonder Who They Found",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/iwonderwhotheyfound.gif",
@@ -24175,7 +28641,12 @@
       "id": 5599,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•I Wonder Who They Found (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/iwonderwhotheyfound.gif",
@@ -24194,7 +28665,12 @@
       "gempId": "3_37",
       "side": "Light",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Ice Storm",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/icestorm.gif",
@@ -24220,7 +28696,12 @@
       "gempId": "2_11",
       "side": "Light",
       "rarity": "U2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Ickabel G'ont",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/ickabelgont.gif",
@@ -24245,7 +28726,12 @@
       "id": 5600,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•IL-19",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/il19.gif",
@@ -24272,7 +28758,12 @@
       "gempId": "208_7",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Ilco Munica",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/ilcomunica.gif",
@@ -24305,7 +28796,12 @@
       "gempId": "9_4",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•I'll Take The Leader",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/illtaketheleader.gif",
@@ -24325,7 +28821,12 @@
       "gempId": "14_1",
       "side": "Light",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•I'll Try Spinning",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/illtryspinning.gif",
@@ -24348,7 +28849,12 @@
       "gempId": "204_19",
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•I'm Getting Pretty Good At This",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/imgettingprettygoodatthis.gif",
@@ -24368,7 +28874,12 @@
       "gempId": "2_52",
       "side": "Light",
       "rarity": "U1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "I'm Here To Rescue You",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/imheretorescueyou.gif",
@@ -24390,7 +28901,12 @@
       "id": 5602,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "I'm Here to Rescue You (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/imheretorescueyou.gif",
@@ -24411,7 +28927,12 @@
       "gempId": "9_35",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•I'm With You Too",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/imwithyoutoo.gif",
@@ -24435,7 +28956,12 @@
       "id": 5603,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•I'm With You Too (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/imwithyoutoo.gif",
@@ -24454,7 +28980,12 @@
       "gempId": "7_65",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Imperial Atrocity",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/imperialatrocity.gif",
@@ -24479,7 +29010,12 @@
       "id": 5604,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "Imperial Atrocity (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/imperialatrocity.gif",
@@ -24498,7 +29034,12 @@
       "id": 5605,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Imperial Navigation Charts",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/imperialnavigationcharts.gif",
@@ -24514,7 +29055,12 @@
       "gempId": "5_52",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Impressive, Most Impressive",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/impressivemostimpressive.gif",
@@ -24531,7 +29077,12 @@
       "id": 5606,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Impressive, Most Impressive (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/impressivemostimpressive.gif",
@@ -24551,7 +29102,12 @@
       "gempId": "200_53",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Impressive, Most Impressive (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/impressivemostimpressive.gif",
@@ -24581,7 +29137,12 @@
       "gempId": "7_66",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Incom Corporation",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/incomcorporation.gif",
@@ -24603,7 +29164,12 @@
       "id": 5607,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Incom Corporation & •Koensayr Manufacturing",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/incomcorporation&koensayrmanufacturing.gif",
@@ -24621,7 +29187,12 @@
       "gempId": "7_22",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Incom Engineer",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/incomengineer.gif",
@@ -24647,7 +29218,12 @@
       "gempId": "2_75",
       "side": "Light",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Incom T-16 Skyhopper",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/incomt16skyhopper.gif",
@@ -24675,7 +29251,12 @@
       "gempId": "12_59",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Inconsequential Barriers",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/inconsequentialbarriers.gif",
@@ -24704,7 +29285,12 @@
       "gempId": "9_75",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Independence",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/independence.gif",
@@ -24736,7 +29322,12 @@
       "gempId": "4_26",
       "side": "Light",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Ineffective Maneuver",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/ineffectivemaneuver.gif",
@@ -24757,7 +29348,12 @@
       "id": 5608,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Ineffective Maneuver (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/ineffectivemaneuver.gif",
@@ -24777,7 +29373,12 @@
       "gempId": "3_76",
       "side": "Light",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Infantry Mine",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/infantrymine.gif",
@@ -24798,7 +29399,12 @@
       "id": 5609,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "Infiltration / Unlikely Allies",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/infiltration.gif",
@@ -24825,7 +29431,12 @@
       "id": 5610,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Infinity",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/infinity.gif",
@@ -24853,7 +29464,12 @@
       "gempId": "13_24",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Inner Strength",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/innerstrength.gif",
@@ -24872,7 +29488,12 @@
       "gempId": "5_53",
       "side": "Light",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Innocent Scoundrel",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/innocentscoundrel.gif",
@@ -24896,7 +29517,12 @@
       "gempId": "9_52",
       "side": "Light",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Insertion Planning",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/insertionplanning.gif",
@@ -24917,7 +29543,12 @@
       "gempId": "8_40",
       "side": "Light",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Insurrection",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/insurrection.gif",
@@ -24956,7 +29587,12 @@
       "gempId": "12_44",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Insurrection & •Aim High",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/insurrection&aimhigh.gif",
@@ -24990,7 +29626,12 @@
       "id": 5611,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Insurrection (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/insurrection.gif",
@@ -25009,7 +29650,12 @@
       "gempId": "1_89",
       "side": "Light",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Into The Garbage Chute, Flyboy",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/intothegarbagechuteflyboy.gif",
@@ -25029,7 +29675,12 @@
       "id": 5612,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Into The Garbage Chute, Flyboy (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/intothegarbagechuteflyboy.gif",
@@ -25046,7 +29697,12 @@
       "gempId": "5_54",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Into The Ventilation Shaft, Lefty",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/intotheventilationshaftlefty.gif",
@@ -25063,7 +29719,12 @@
       "gempId": "7_159",
       "side": "Light",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Intruder Missile",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/intrudermissile.gif",
@@ -25089,7 +29750,12 @@
       "gempId": "6_19",
       "side": "Light",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•••Ishi Tib",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/ishitib.gif",
@@ -25116,7 +29782,12 @@
       "gempId": "3_44",
       "side": "Light",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•It Can Wait",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/itcanwait.gif",
@@ -25138,7 +29809,12 @@
       "gempId": "1_90",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "It Could Be Worse",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/itcouldbeworse.gif",
@@ -25160,7 +29836,12 @@
       "gempId": "4_78",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "It Is The Future You See",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/itisthefutureyousee.gif",
@@ -25177,7 +29858,12 @@
       "id": 5613,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "It Is The Future You See (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/itisthefutureyousee.gif",
@@ -25196,7 +29882,12 @@
       "gempId": "6_20",
       "side": "Light",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•••Ithorian",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/ithorian.gif",
@@ -25223,7 +29914,12 @@
       "gempId": "106_5",
       "side": "Light",
       "rarity": "PM",
-      "set": "Official Tournament Sealed Deck",
+      "set": "106",
+      "printings": [
+        {
+          "set": "106"
+        }
+      ],
       "front": {
         "title": "•It's A Hit!",
         "imageUrl": "https://res.starwarsccg.org/cards/OfficialTournamentSealedDeck-Light/large/itsahit.gif",
@@ -25256,7 +29952,12 @@
       "gempId": "5_55",
       "side": "Light",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•It's A Trap!",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/itsatrap.gif",
@@ -25286,7 +29987,12 @@
       "gempId": "7_93",
       "side": "Light",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•It's Not My Fault!",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/itsnotmyfault.gif",
@@ -25302,7 +30008,12 @@
       "id": 5615,
       "side": "Light",
       "rarity": "F",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•It's Not My Fault! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/itsnotmyfault.gif",
@@ -25321,7 +30032,12 @@
       "gempId": "14_33",
       "side": "Light",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•It's On Automatic Pilot!",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/itsonautomaticpilot.gif",
@@ -25346,7 +30062,12 @@
       "gempId": "210_16",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•It's True, All Of It",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Light/large/itstrueallofit.gif",
@@ -25367,7 +30088,12 @@
       "gempId": "12_60",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•I've Decided To Go Back",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/ivedecidedtogoback.gif",
@@ -25391,7 +30117,12 @@
       "id": 5617,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•I've Decided To Go Back (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/ivedecidedtogoback.gif",
@@ -25412,7 +30143,12 @@
       "gempId": "208_19",
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•I've Got A Bad Feeling About ...",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/ivegotabadfeelingabout.gif",
@@ -25429,7 +30165,12 @@
       "gempId": "1_91",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "I've Got A Bad Feeling About This",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/ivegotabadfeelingaboutthis.gif",
@@ -25448,7 +30189,12 @@
       "id": 5619,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Jabba, This Is Your Last Chance!",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/jabbathisisyourlastchance.gif",
@@ -25468,7 +30214,12 @@
       "gempId": "6_67",
       "side": "Light",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Jabba's Palace Sabacc",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/jabbaspalacesabacc.gif",
@@ -25487,7 +30238,12 @@
       "gempId": "112_2",
       "side": "Light",
       "rarity": "PM",
-      "set": "Jabba's Palace Sealed Deck",
+      "set": "112",
+      "printings": [
+        {
+          "set": "112"
+        }
+      ],
       "front": {
         "title": "•Jabba's Palace: Antechamber",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalaceSealedDeck-Light/large/jabbaspalaceantechamber.gif",
@@ -25513,7 +30269,12 @@
       "gempId": "6_81",
       "side": "Light",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Jabba's Palace: Audience Chamber",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/jabbaspalaceaudiencechamber.gif",
@@ -25546,7 +30307,12 @@
       "gempId": "6_82",
       "side": "Light",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Jabba's Palace: Entrance Cavern",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/jabbaspalaceentrancecavern.gif",
@@ -25573,7 +30339,12 @@
       "id": 5620,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Jabba's Prize/Jabba's Prize",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/jabbasprizefront.gif",
@@ -25605,7 +30376,12 @@
       "gempId": "200_16",
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Jabba's Prize/Jabba's Prize",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/jabbasprizefront.gif",
@@ -25643,7 +30419,12 @@
       "id": 5622,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Jaina Solo",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/jainasolo.gif",
@@ -25671,7 +30452,12 @@
       "gempId": "204_26",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Jakku",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/jakku.gif",
@@ -25703,7 +30489,12 @@
       "gempId": "207_16",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 7",
+      "set": "207",
+      "printings": [
+        {
+          "set": "207"
+        }
+      ],
       "front": {
         "title": "•Jakku: Docking Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual7-Light/large/jakkudockingbay.gif",
@@ -25736,7 +30527,12 @@
       "gempId": "204_27",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Jakku: Niima Outpost Shipyard",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/jakkuniimaoutpostshipyard.gif",
@@ -25763,7 +30559,12 @@
       "gempId": "204_28",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Jakku: Ravager Crash Site",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/jakkuravagercrashsite.gif",
@@ -25791,7 +30592,12 @@
       "gempId": "204_29",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Jakku: Rey's Encampment",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/jakkureysencampment.gif",
@@ -25821,7 +30627,12 @@
       "gempId": "204_30",
       "side": "Light",
       "rarity": "C1",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Jakku: Starship Graveyard",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/jakkustarshipgraveyard.gif",
@@ -25849,7 +30660,12 @@
       "gempId": "204_31",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Jakku: Tuanul Village",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/jakkutuanulvillage.gif",
@@ -25877,7 +30693,12 @@
       "id": 5623,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Jan Ors With Blaster Pistol",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/janorswithblasterpistol.gif",
@@ -25903,7 +30724,12 @@
       "gempId": "11_4",
       "side": "Light",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Jar Jar Binks",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/jarjarbinks.gif",
@@ -25942,7 +30768,12 @@
       "gempId": "13_25",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Jar Jar's Electropole",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/jarjarselectropole.gif",
@@ -25970,7 +30801,12 @@
       "gempId": "12_9",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Jawa",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/jawa.gif",
@@ -26004,7 +30840,12 @@
       "gempId": "1_12",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Jawa",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/jawa.gif",
@@ -26036,7 +30877,12 @@
       "gempId": "2_78",
       "side": "Light",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Jawa Ion Gun",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/jawaiongun.gif",
@@ -26060,7 +30906,12 @@
       "id": 5624,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "Jawa Ion Gun (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/jawaiongun.gif",
@@ -26077,7 +30928,12 @@
       "gempId": "1_51",
       "side": "Light",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Jawa Siesta",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/jawasiesta.gif",
@@ -26105,7 +30961,12 @@
       "id": 5625,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Jawa Siesta (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/jawasiesta.gif",
@@ -26120,7 +30981,12 @@
       "id": 5626,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•••Jedi Advisor",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/jediadvisor.gif",
@@ -26148,7 +31014,12 @@
       "gempId": "210_17",
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•Jedi Business",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Light/large/jedibusiness.gif",
@@ -26167,7 +31038,12 @@
       "gempId": "11_36",
       "side": "Light",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Jedi Escape",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/jediescape.gif",
@@ -26190,7 +31066,12 @@
       "id": 5628,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•••Jedi Guardian",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/jediguardian.gif",
@@ -26219,7 +31100,12 @@
       "gempId": "13_26",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Jedi Leap",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/jedileap.gif",
@@ -26240,7 +31126,12 @@
       "gempId": "4_53",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Jedi Levitation",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/jedilevitation.gif",
@@ -26262,7 +31153,12 @@
       "id": 5629,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Jedi Levitation (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/jedilevitation.gif",
@@ -26282,7 +31178,12 @@
       "gempId": "200_54",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "Jedi Levitation (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/jedilevitation.gif",
@@ -26306,7 +31207,12 @@
       "gempId": "1_155",
       "side": "Light",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Jedi Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/jedilightsaber.gif",
@@ -26336,7 +31242,12 @@
       "id": 5630,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "Jedi Lightsaber (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/jedilightsaber.gif",
@@ -26354,7 +31265,12 @@
       "gempId": "211_33",
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "Jedi Lightsaber (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/jedilightsaber.gif",
@@ -26374,7 +31290,12 @@
       "gempId": "6_68",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Jedi Mind Trick",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/jedimindtrick.gif",
@@ -26395,7 +31316,12 @@
       "gempId": "210_18",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•Jedi Mind Trick (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Light/large/jedimindtrick.gif",
@@ -26414,7 +31340,12 @@
       "id": 5633,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•••Jedi Pilot",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/jedipilot.gif",
@@ -26443,7 +31374,12 @@
       "gempId": "1_92",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Jedi Presence",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/jedipresence.gif",
@@ -26467,7 +31403,12 @@
       "id": 5634,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "••Jedi Starfighter",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/jedistarfighter.gif",
@@ -26494,7 +31435,12 @@
       "id": 5635,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•••Jedi Survivor",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/jedisurvivor.gif",
@@ -26523,7 +31469,12 @@
       "gempId": "1_13",
       "side": "Light",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Jek Porkins",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/jekporkins.gif",
@@ -26551,7 +31502,12 @@
       "id": 5636,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Jek Porkins (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/jekporkins.gif",
@@ -26576,7 +31532,12 @@
       "gempId": "3_11",
       "side": "Light",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Jeroen Webb",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/jeroenwebb.gif",
@@ -26607,7 +31568,12 @@
       "id": 5637,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Jeroen Webb (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/jeroenwebb.gif",
@@ -26633,7 +31599,12 @@
       "gempId": "14_14",
       "side": "Light",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Jerus Jannick",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/jerusjannick.gif",
@@ -26666,7 +31637,12 @@
       "gempId": "6_21",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Jess",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/jess.gif",
@@ -26695,7 +31671,12 @@
       "gempId": "7_23",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Joh Yowza",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/johyowza.gif",
@@ -26724,7 +31705,12 @@
       "gempId": "7_122",
       "side": "Light",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "<>Jungle",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/jungle.gif",
@@ -26749,7 +31735,12 @@
       "gempId": "206_4",
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Set 6",
+      "set": "206",
+      "printings": [
+        {
+          "set": "206"
+        }
+      ],
       "front": {
         "title": "•Jyn Erso",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual6-Light/large/jynerso.gif",
@@ -26781,7 +31772,12 @@
       "gempId": "206_5",
       "side": "Light",
       "rarity": "F",
-      "set": "Virtual Set 6",
+      "set": "206",
+      "printings": [
+        {
+          "set": "206"
+        }
+      ],
       "front": {
         "title": "•K-2SO (Kay-Tuesso)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual6-Light/large/k2so.gif",
@@ -26817,7 +31813,12 @@
       "gempId": "3_12",
       "side": "Light",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•K-3PO (Kay-Threepio)",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/k3pokaythreepio.gif",
@@ -26844,7 +31845,12 @@
       "gempId": "14_61",
       "side": "Light",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "Kaadu",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/kaadu.gif",
@@ -26871,7 +31877,12 @@
       "id": 5638,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "Kaadu (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/kaadu.gif",
@@ -26897,7 +31908,12 @@
       "gempId": "1_14",
       "side": "Light",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Kabe",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/kabe.gif",
@@ -26926,7 +31942,12 @@
       "gempId": "1_15",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Kal'Falnl C'ndros",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/kalfalnlcndros.gif",
@@ -26957,7 +31978,12 @@
       "gempId": "6_22",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Kalit",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/kalit.gif",
@@ -26989,7 +32015,12 @@
       "id": 5639,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Kalit (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/kalit.gif",
@@ -27013,7 +32044,12 @@
       "gempId": "7_152",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Kalit's Sandcrawler",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/kalitssandcrawler.gif",
@@ -27040,7 +32076,12 @@
       "gempId": "211_43",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Kamino",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/kamino.gif",
@@ -27063,7 +32104,12 @@
       "gempId": "211_42",
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Kamino: Clone Birthing Center",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/kaminoclonebirthingcenter.gif",
@@ -27087,7 +32133,12 @@
       "gempId": "211_41",
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Kamino: Clone Training Center",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/kaminoclonetrainingcenter.gif",
@@ -27111,7 +32162,12 @@
       "gempId": "203_6",
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•Kanan Jarrus",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Light/large/kananjarrus.gif",
@@ -27144,7 +32200,12 @@
       "gempId": "9_18",
       "side": "Light",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Karie Neth",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/karieneth.gif",
@@ -27181,7 +32242,12 @@
       "gempId": "2_64",
       "side": "Light",
       "rarity": "C1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Kashyyyk",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/kashyyyk.gif",
@@ -27211,7 +32277,12 @@
       "id": 5643,
       "side": "Light",
       "rarity": "C1",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Kashyyyk (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/kashyyyk.gif",
@@ -27233,7 +32304,12 @@
       "gempId": "7_24",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Kashyyyk Operative",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/kashyyykoperative.gif",
@@ -27268,7 +32344,12 @@
       "id": 5644,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Kashyyyk: Forest Depths",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/kashyyykforestdepths.gif",
@@ -27289,7 +32370,12 @@
       "id": 5645,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Kashyyyk: Sacred Forest",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/kashyyyksacredforest.gif",
@@ -27310,7 +32396,12 @@
       "id": 5646,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Kashyyyk: Wookiee Haven (Forest)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/kashyyykwookieehavenforest.gif",
@@ -27332,7 +32423,12 @@
       "gempId": "8_17",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Kazak",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/kazak.gif",
@@ -27361,7 +32457,12 @@
       "gempId": "6_69",
       "side": "Light",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Ke Chu Ke Kukuta?",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/kechukekukuta.gif",
@@ -27377,7 +32478,12 @@
       "id": 5647,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "Ke Chu Ke Kukuta? (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/kechukekukuta.gif",
@@ -27397,7 +32503,12 @@
       "gempId": "5_4",
       "side": "Light",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Kebyc",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/kebyc.gif",
@@ -27425,7 +32536,12 @@
       "id": 5648,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Kebyc (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/kebyc.gif",
@@ -27449,7 +32565,12 @@
       "gempId": "5_56",
       "side": "Light",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Keep Your Eyes Open",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/keepyoureyesopen.gif",
@@ -27468,7 +32589,12 @@
       "id": 5649,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Keep Your Eyes Open (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/keepyoureyesopen.gif",
@@ -27488,7 +32614,12 @@
       "gempId": "204_20",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "Keep Your Eyes Open (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/keepyoureyesopen.gif",
@@ -27512,7 +32643,12 @@
       "gempId": "11_20",
       "side": "Light",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Keeping The Empire Out Forever",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/keepingtheempireoutforever.gif",
@@ -27533,7 +32669,12 @@
       "gempId": "9_19",
       "side": "Light",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Keir Santage",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/keirsantage.gif",
@@ -27564,7 +32705,12 @@
       "gempId": "1_126",
       "side": "Light",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Kessel",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/kessel.gif",
@@ -27598,7 +32744,12 @@
       "gempId": "1_52",
       "side": "Light",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Kessel Run",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/kesselrun.gif",
@@ -27626,7 +32777,12 @@
       "id": 5650,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Kessel Run (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/kesselrun.gif",
@@ -27644,7 +32800,12 @@
       "gempId": "7_25",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Ketwol",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/ketwol.gif",
@@ -27676,7 +32837,12 @@
       "gempId": "12_10",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Ki-Adi-Mundi",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/kiadimundi.gif",
@@ -27717,7 +32883,12 @@
       "id": 5651,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Ki-Adi-Mundi (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/kiadimundi.gif",
@@ -27746,7 +32917,12 @@
       "gempId": "6_83",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Kiffex",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/kiffex.gif",
@@ -27780,7 +32956,12 @@
       "gempId": "7_26",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Kiffex Operative",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/kiffexoperative.gif",
@@ -27816,7 +32997,12 @@
       "gempId": "9_20",
       "side": "Light",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Kin Kian",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/kinkian.gif",
@@ -27849,7 +33035,12 @@
       "gempId": "207_6",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 7",
+      "set": "207",
+      "printings": [
+        {
+          "set": "207"
+        }
+      ],
       "front": {
         "title": "•Kin Kian (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual7-Light/large/kinkian.gif",
@@ -27909,7 +33100,12 @@
       "gempId": "6_84",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Kirdo III",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/kirdoiii.gif",
@@ -27943,7 +33139,12 @@
       "gempId": "7_27",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Kirdo III Operative",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/kirdoiiioperative.gif",
@@ -27978,7 +33179,12 @@
       "gempId": "210_19",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•Kit Fisto",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Light/large/kitfisto.gif",
@@ -28010,7 +33216,12 @@
       "gempId": "6_23",
       "side": "Light",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•••Kitonak",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/kitonak.gif",
@@ -28041,7 +33252,12 @@
       "gempId": "6_24",
       "side": "Light",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Klatooinian Revolutionary",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/klatooinianrevolutionary.gif",
@@ -28070,7 +33286,12 @@
       "gempId": "1_53",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•K'lor'slug",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/klorslug.gif",
@@ -28101,7 +33322,12 @@
       "id": 5653,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•K'lor'slug (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/klorslug.gif",
@@ -28117,7 +33343,12 @@
       "gempId": "200_42",
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•K'lor'slug (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/klorslug.gif",
@@ -28145,7 +33376,12 @@
       "gempId": "209_20",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Knights Of The Old Republic",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/knightsoftheoldrepublic.gif",
@@ -28165,7 +33401,12 @@
       "gempId": "7_67",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Koensayr Manufacturing",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/koensayrmanufacturing.gif",
@@ -28187,7 +33428,12 @@
       "gempId": "1_93",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Krayt Dragon Howl",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/kraytdragonhowl.gif",
@@ -28207,7 +33453,12 @@
       "id": 5655,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Krayt Dragon Howl (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/kraytdragonhowl.gif",
@@ -28224,7 +33475,12 @@
       "id": 5656,
       "side": "Light",
       "rarity": "F",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Kyle Katarn",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/kylekatarn.gif",
@@ -28247,7 +33503,12 @@
       "id": 5657,
       "side": "Light",
       "rarity": "F",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Kyle Katarn (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/kylekatarnai.gif",
@@ -28270,7 +33531,12 @@
       "id": 5658,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Kyle Katarn's Blaster Rifle",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/kylekatarnsblasterrifle.gif",
@@ -28286,7 +33552,12 @@
       "id": 5659,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Lady Luck",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/ladyluck.gif",
@@ -28312,7 +33583,12 @@
       "gempId": "209_8",
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Lak Sivrak",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/laksivrak.gif",
@@ -28337,7 +33613,12 @@
       "gempId": "4_11",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "••Landing Claw",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/landingclaw.gif",
@@ -28364,7 +33645,12 @@
       "gempId": "5_5",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Lando Calrissian",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/landocalrissian.gif",
@@ -28411,7 +33697,12 @@
       "id": 5661,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Lando Calrissian (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/landocalrissian.gif",
@@ -28441,7 +33732,12 @@
       "gempId": "201_1",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Lando Calrissian (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Light/large/landocalrissian.gif",
@@ -28504,7 +33800,12 @@
       "gempId": "13_27",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Lando Calrissian, Scoundrel",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/landocalrissianscoundrel.gif",
@@ -28546,7 +33847,12 @@
       "id": 5662,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Lando Calrissian, Scoundrel (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/landocalrissianscoundrel.gif",
@@ -28574,7 +33880,12 @@
       "id": 5663,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Lando Calrissian, Unlikely Hero",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/landocalrissianunlikelyhero.gif",
@@ -28602,7 +33913,12 @@
       "gempId": "109_2",
       "side": "Light",
       "rarity": "PM",
-      "set": "Enhanced Cloud City",
+      "set": "109",
+      "printings": [
+        {
+          "set": "109"
+        }
+      ],
       "front": {
         "title": "•Lando In Millennium Falcon",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedCloudCity-Light/large/landoinmillenniumfalcon.gif",
@@ -28648,7 +33964,12 @@
       "gempId": "109_3",
       "side": "Light",
       "rarity": "PM",
-      "set": "Enhanced Cloud City",
+      "set": "109",
+      "printings": [
+        {
+          "set": "109"
+        }
+      ],
       "front": {
         "title": "•Lando With Blaster Pistol",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedCloudCity-Light/large/landowithblasterpistol.gif",
@@ -28696,7 +34017,12 @@
       "gempId": "112_3",
       "side": "Light",
       "rarity": "PM",
-      "set": "Jabba's Palace Sealed Deck",
+      "set": "112",
+      "printings": [
+        {
+          "set": "112"
+        }
+      ],
       "front": {
         "title": "•Lando With Vibro-Ax",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalaceSealedDeck-Light/large/landowithvibroax.gif",
@@ -28742,7 +34068,12 @@
       "gempId": "7_160",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Lando's Blaster Rifle",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/landosblasterrifle.gif",
@@ -28775,7 +34106,12 @@
       "gempId": "13_28",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Lando's Not A System, He's A Man",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/landosnotasystemhesaman.gif",
@@ -28796,7 +34132,12 @@
       "gempId": "5_14",
       "side": "Light",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Lando's Wrist Comlink",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/landoswristcomlink.gif",
@@ -28817,7 +34158,12 @@
       "id": 5664,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Lars' Hydroponics Station",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/larshydroponicsstation.gif",
@@ -28832,7 +34178,12 @@
       "id": 5665,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Lars' Protocol Droid",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/larsprotocoldroid.gif",
@@ -28857,7 +34208,12 @@
       "id": 5666,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Lars' Vaporator",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/larsvaporator.gif",
@@ -28873,7 +34229,12 @@
       "gempId": "6_25",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Laudica",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/laudica.gif",
@@ -28901,7 +34262,12 @@
       "id": 5667,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Laudica (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/laudica.gif",
@@ -28926,7 +34292,12 @@
       "gempId": "9_36",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Launching The Assault",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/launchingtheassault.gif",
@@ -28957,7 +34328,12 @@
       "gempId": "10_9",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•LE-BO2D9 (Leebo)",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Light/large/lebo2d9leebo.gif",
@@ -28983,7 +34359,12 @@
       "id": 5669,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•LE-BO2D9 (Leebo) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/lebo2d9leebo.gif",
@@ -29010,7 +34391,12 @@
       "id": 5670,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Learn About The Force, Luke",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/learnabouttheforceluke.gif",
@@ -29025,7 +34411,12 @@
       "id": 5671,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Leebo",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/leebo.gif",
@@ -29053,7 +34444,12 @@
       "gempId": "1_16",
       "side": "Light",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Leesub Sirln",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/leesubsirln.gif",
@@ -29080,7 +34476,12 @@
       "id": 5672,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Leesub Sirln (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/leesubsirln.gif",
@@ -29104,7 +34505,12 @@
       "gempId": "200_17",
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Leesub Sirln (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/leesubsirln.gif",
@@ -29135,7 +34541,12 @@
       "gempId": "7_68",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Legendary Starfighter",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/legendarystarfighter.gif",
@@ -29162,7 +34573,12 @@
       "gempId": "102_3",
       "side": "Light",
       "rarity": "PM",
-      "set": "Jedi Pack",
+      "set": "102",
+      "printings": [
+        {
+          "set": "102"
+        }
+      ],
       "front": {
         "title": "•Leia",
         "imageUrl": "https://res.starwarsccg.org/cards/JediPack-Light/large/leia.gif",
@@ -29197,7 +34613,12 @@
       "id": 5673,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Leia (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/leia.gif",
@@ -29225,7 +34646,12 @@
       "gempId": "200_18",
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Leia (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/leia.gif",
@@ -29271,7 +34697,12 @@
       "gempId": "5_28",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Leia Of Alderaan",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/leiaofalderaan.gif",
@@ -29294,7 +34725,12 @@
       "id": 5674,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Leia Of Alderaan (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/leiaofalderaan.gif",
@@ -29313,7 +34749,12 @@
       "gempId": "205_5",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 5",
+      "set": "205",
+      "printings": [
+        {
+          "set": "205"
+        }
+      ],
       "front": {
         "title": "•Leia Of Alderaan (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual5-Light/large/leiaofalderaan.gif",
@@ -29337,7 +34778,12 @@
       "gempId": "1_17",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Leia Organa",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/leiaorgana.gif",
@@ -29390,7 +34836,12 @@
       "gempId": "202_1",
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Set 2",
+      "set": "202",
+      "printings": [
+        {
+          "set": "202"
+        }
+      ],
       "front": {
         "title": "•Leia Organa (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual2-Light/large/leiaorgana.gif",
@@ -29425,7 +34876,12 @@
       "gempId": "108_2",
       "side": "Light",
       "rarity": "PM",
-      "set": "Enhanced Premiere",
+      "set": "108",
+      "printings": [
+        {
+          "set": "108"
+        }
+      ],
       "front": {
         "title": "•Leia With Blaster Rifle",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedPremiere-Light/large/leiawithblasterrifle.gif",
@@ -29476,7 +34932,12 @@
       "id": 5675,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Leia, Optimistic Leader",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/leiaoptimisticleader.gif",
@@ -29504,7 +34965,12 @@
       "gempId": "13_29",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Leia, Rebel Princess",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/leiarebelprincess.gif",
@@ -29554,7 +35020,12 @@
       "gempId": "1_94",
       "side": "Light",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Leia's Back",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/leiasback.gif",
@@ -29588,7 +35059,12 @@
       "id": 5676,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Leia's Back (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/leiasback.gif",
@@ -29605,7 +35081,12 @@
       "gempId": "7_161",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Leia's Blaster Rifle",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/leiasblasterrifle.gif",
@@ -29644,7 +35125,12 @@
       "gempId": "1_156",
       "side": "Light",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Leia's Sporting Blaster",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/leiassportingblaster.gif",
@@ -29682,7 +35168,12 @@
       "id": 5677,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Leia's Sporting Blaster (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/leiassportingblaster.gif",
@@ -29699,7 +35190,12 @@
       "gempId": "6_26",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Leslomy Tacema",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/leslomytacema.gif",
@@ -29726,7 +35222,12 @@
       "id": 5678,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Leslomy Tacema (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/leslomytacema.gif",
@@ -29752,7 +35253,12 @@
       "gempId": "203_7",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•Leslomy Tacema (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Light/large/leslomytacema.gif",
@@ -29788,7 +35294,12 @@
       "gempId": "2_53",
       "side": "Light",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Let The Wookiee Win",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/letthewookieewin.gif",
@@ -29805,7 +35316,12 @@
       "id": 5679,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Let The Wookiee Win (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/letthewookieewin.gif",
@@ -29826,7 +35342,12 @@
       "gempId": "14_2",
       "side": "Light",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Let's Go Left",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/letsgoleft.gif",
@@ -29848,7 +35369,12 @@
       "id": 5680,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Let's Go Left (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/letsgoleft.gif",
@@ -29867,7 +35393,12 @@
       "gempId": "9_37",
       "side": "Light",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Let's Keep A Little Optimism Here",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/letskeepalittleoptimismhere.gif",
@@ -29891,7 +35422,12 @@
       "gempId": "13_30",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Let's Keep A Little Optimism Here",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/letskeepalittleoptimismhere.gif",
@@ -29911,7 +35447,12 @@
       "id": 5681,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•Let's Keep A Little Optimism Here (Death Star II) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Light/large/letskeepalittleoptimismherev.gif",
@@ -29930,7 +35471,12 @@
       "id": 5682,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Let's Keep A Little Optimism Here (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/letskeepalittleoptimismhere.gif",
@@ -29949,7 +35495,12 @@
       "id": 5683,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•Let's Keep A Little Optimism Here (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Light/large/letskeepalittleoptimismhere.gif",
@@ -29969,7 +35520,12 @@
       "gempId": "4_54",
       "side": "Light",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Levitation",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/levitation.gif",
@@ -29997,7 +35553,12 @@
       "id": 5684,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Levitation (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/levitation.gif",
@@ -30017,7 +35578,12 @@
       "gempId": "12_11",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Liana Merian",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/lianamerian.gif",
@@ -30051,7 +35617,12 @@
       "gempId": "211_34",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Libertine",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/libertine.gif",
@@ -30079,7 +35650,12 @@
       "gempId": "9_76",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Liberty",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/liberty.gif",
@@ -30111,7 +35687,12 @@
       "gempId": "14_15",
       "side": "Light",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Arven Wendik",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/lieutenantarvenwendik.gif",
@@ -30140,7 +35721,12 @@
       "gempId": "9_21",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Blount",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/lieutenantblount.gif",
@@ -30178,7 +35764,12 @@
       "id": 5686,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Blount (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/lieutenantblount.gif",
@@ -30204,7 +35795,12 @@
       "gempId": "14_16",
       "side": "Light",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Chamberlyn",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/lieutenantchamberlyn.gif",
@@ -30237,7 +35833,12 @@
       "gempId": "8_18",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Greeve",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/lieutenantgreeve.gif",
@@ -30272,7 +35873,12 @@
       "gempId": "209_9",
       "side": "Light",
       "rarity": "C1",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Kaydel Connix",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/lieutenantkaydelconnix.gif",
@@ -30297,7 +35903,12 @@
       "gempId": "7_28",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Lepira",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/lieutenantlepira.gif",
@@ -30325,7 +35936,12 @@
       "gempId": "7_29",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Naytaan",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/lieutenantnaytaan.gif",
@@ -30353,7 +35969,12 @@
       "gempId": "8_19",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Page",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/lieutenantpage.gif",
@@ -30384,7 +36005,12 @@
       "gempId": "14_17",
       "side": "Light",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Rya Kirsch",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/lieutenantryakirsch.gif",
@@ -30413,7 +36039,12 @@
       "gempId": "9_22",
       "side": "Light",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Lieutenant s'Too Vees",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/lieutenantstoovees.gif",
@@ -30458,7 +36089,12 @@
       "gempId": "7_30",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Tarn Mison",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/lieutenanttarnmison.gif",
@@ -30483,7 +36119,12 @@
       "gempId": "9_23",
       "side": "Light",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Telsij",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/lieutenanttelsij.gif",
@@ -30511,7 +36152,12 @@
       "gempId": "12_12",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Williams",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/lieutenantwilliams.gif",
@@ -30544,7 +36190,12 @@
       "id": 5688,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Lieutenant Williams (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/lieutenantwilliams.gif",
@@ -30571,7 +36222,12 @@
       "gempId": "6_70",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Life Debt",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/lifedebt.gif",
@@ -30614,7 +36270,12 @@
       "gempId": "1_148",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Lift Tube",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/lifttube.gif",
@@ -30646,7 +36307,12 @@
       "gempId": "5_57",
       "side": "Light",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Lift Tube Escape",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/lifttubeescape.gif",
@@ -30670,7 +36336,12 @@
       "gempId": "4_55",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Light Maneuvers",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/lightmaneuvers.gif",
@@ -30698,7 +36369,12 @@
       "gempId": "209_30",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Lightmaker",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/lightmaker.gif",
@@ -30725,7 +36401,12 @@
       "gempId": "1_54",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Lightsaber Proficiency",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/lightsaberproficiency.gif",
@@ -30750,7 +36431,12 @@
       "gempId": "202_5",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 2",
+      "set": "202",
+      "printings": [
+        {
+          "set": "202"
+        }
+      ],
       "front": {
         "title": "•Like My Father Before Me",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual2-Light/large/likemyfatherbeforeme.gif",
@@ -30774,7 +36460,12 @@
       "gempId": "1_18",
       "side": "Light",
       "rarity": "C1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "LIN-V8K (Elleyein-Veeatekay)",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/linv8k.gif",
@@ -30801,7 +36492,12 @@
       "gempId": "5_6",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Lobot",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/lobot.gif",
@@ -30830,7 +36526,12 @@
       "id": 5690,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Lobot (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/lobot.gif",
@@ -30854,7 +36555,12 @@
       "gempId": "200_19",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Lobot (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/lobot.gif",
@@ -30887,7 +36593,12 @@
       "gempId": "7_94",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Local Defense",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/localdefense.gif",
@@ -30919,7 +36630,12 @@
       "gempId": "7_137",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Local Uprising / Liberation",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/localuprising.gif",
@@ -30940,7 +36656,12 @@
       "id": 5692,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Local Uprising / Liberation (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/localuprising.gif",
@@ -30968,7 +36689,12 @@
       "gempId": "11_5",
       "side": "Light",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Loci Rosen",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/locirosen.gif",
@@ -30996,7 +36722,12 @@
       "gempId": "2_34",
       "side": "Light",
       "rarity": "U2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Logistical Delay",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/logisticaldelay.gif",
@@ -31019,7 +36750,12 @@
       "id": 5693,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Logistical Delay (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/logisticaldelay.gif",
@@ -31038,7 +36774,12 @@
       "gempId": "8_20",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Logray",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/logray.gif",
@@ -31065,7 +36806,12 @@
       "gempId": "6_27",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Loje Nella",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/lojenella.gif",
@@ -31092,7 +36838,12 @@
       "id": 5694,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Loje Nella (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/lojenella.gif",
@@ -31113,7 +36864,12 @@
       "gempId": "104_2",
       "side": "Light",
       "rarity": "PM",
-      "set": "Empire Strikes Back Introductory Two Player Game",
+      "set": "104",
+      "printings": [
+        {
+          "set": "104"
+        }
+      ],
       "front": {
         "title": "Lone Rogue",
         "imageUrl": "https://res.starwarsccg.org/cards/EmpireStrikesBackIntroductoryTwoPlayerGame-Light/large/lonerogue.gif",
@@ -31130,7 +36886,12 @@
       "gempId": "204_7",
       "side": "Light",
       "rarity": "C1",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Lor San Tekka",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/lorsantekka.gif",
@@ -31162,7 +36923,12 @@
       "gempId": "11_37",
       "side": "Light",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Losing Track",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/losingtrack.gif",
@@ -31186,7 +36952,12 @@
       "gempId": "8_57",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Lost In The Wilderness",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/lostinthewilderness.gif",
@@ -31208,7 +36979,12 @@
       "gempId": "4_56",
       "side": "Light",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Lost Relay",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/lostrelay.gif",
@@ -31224,7 +37000,12 @@
       "id": 5696,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "Low-Altitude Assault Transport",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/lowaltitudeassaulttransport.gif",
@@ -31251,7 +37032,12 @@
       "gempId": "3_45",
       "side": "Light",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Lucky Shot",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/luckyshot.gif",
@@ -31268,7 +37054,12 @@
       "id": 5697,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Lucky Shot (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/luckyshot.gif",
@@ -31285,7 +37076,12 @@
       "gempId": "101_2",
       "side": "Light",
       "rarity": "PM",
-      "set": "Premiere Introductory Two Player Game",
+      "set": "101",
+      "printings": [
+        {
+          "set": "101"
+        }
+      ],
       "front": {
         "title": "•Luke",
         "imageUrl": "https://res.starwarsccg.org/cards/PremiereIntroductoryTwoPlayerGame-Light/large/luke.gif",
@@ -31323,7 +37119,12 @@
       "id": 5698,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Luke (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/luke.gif",
@@ -31351,7 +37152,12 @@
       "gempId": "1_19",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Luke Skywalker",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/lukeskywalker.gif",
@@ -31397,7 +37203,12 @@
       "id": 5699,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Luke Skywalker (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/lukeskywalker.gif",
@@ -31425,7 +37236,12 @@
       "gempId": "200_20",
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Luke Skywalker (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/lukeskywalker.gif",
@@ -31476,7 +37292,12 @@
       "gempId": "9_24",
       "side": "Light",
       "rarity": "UR",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Luke Skywalker, Jedi Knight",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/lukeskywalkerjediknight.gif",
@@ -31527,7 +37348,12 @@
       "id": 5700,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Luke Skywalker, Rebel Hero",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/lukeskywalkerrebelhero.gif",
@@ -31555,7 +37381,12 @@
       "gempId": "10_10",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Luke Skywalker, Rebel Scout",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Light/large/lukeskywalkerrebelscout.gif",
@@ -31606,7 +37437,12 @@
       "id": 5701,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Luke Skywalker, Rebel Scout (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/lukeskywalkerrebelscout.gif",
@@ -31636,7 +37472,12 @@
       "gempId": "200_21",
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Luke Skywalker, Rebel Scout (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/lukeskywalkerrebelscout.gif",
@@ -31686,7 +37527,12 @@
       "id": 5702,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Luke Skywalker, Strong In The Force",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/lukeskywalkerstrongintheforce.gif",
@@ -31715,7 +37561,12 @@
       "gempId": "210_20",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•Luke Skywalker, The Last Jedi",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Light/large/lukeskywalkerthelastjedi.gif",
@@ -31744,7 +37595,12 @@
       "gempId": "208_8",
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Luke Skywalker, The Rebellion's Hope",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/lukeskywalkertherebellionshope.gif",
@@ -31791,7 +37647,12 @@
       "gempId": "108_3",
       "side": "Light",
       "rarity": "PM",
-      "set": "Enhanced Premiere",
+      "set": "108",
+      "printings": [
+        {
+          "set": "108"
+        }
+      ],
       "front": {
         "title": "•Luke With Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedPremiere-Light/large/lukewithlightsaber.gif",
@@ -31843,7 +37704,12 @@
       "id": 5704,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Luke, Trust Me",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/luketrustme.gif",
@@ -31859,7 +37725,12 @@
       "gempId": "1_95",
       "side": "Light",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Luke's Back",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/lukesback.gif",
@@ -31896,7 +37767,12 @@
       "id": 5705,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Luke's Back (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/lukesback.gif",
@@ -31913,7 +37789,12 @@
       "gempId": "4_12",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Luke's Backpack",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/lukesbackpack.gif",
@@ -31934,7 +37815,12 @@
       "id": 5706,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Luke's Bionic Hand",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/lukesbionichand.gif",
@@ -31953,7 +37839,12 @@
       "gempId": "200_33",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Luke's Bionic Hand",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/lukesbionichand.gif",
@@ -31980,7 +37871,12 @@
       "gempId": "5_90",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Luke's Blaster Pistol",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/lukesblasterpistol.gif",
@@ -32021,7 +37917,12 @@
       "id": 5707,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Luke's Blaster Pistol (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/lukesblasterpistol.gif",
@@ -32041,7 +37942,12 @@
       "gempId": "208_29",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Luke's Blaster Pistol (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/lukesblasterpistol.gif",
@@ -32077,7 +37983,12 @@
       "gempId": "2_35",
       "side": "Light",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Luke's Cape",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/lukescape.gif",
@@ -32098,7 +38009,12 @@
       "gempId": "2_79",
       "side": "Light",
       "rarity": "U1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Luke's Hunting Rifle",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/lukeshuntingrifle.gif",
@@ -32141,7 +38057,12 @@
       "id": 5708,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Luke's Hunting Rifle (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/lukeshuntingrifle.gif",
@@ -32161,7 +38082,12 @@
       "gempId": "207_19",
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Set 7",
+      "set": "207",
+      "printings": [
+        {
+          "set": "207"
+        }
+      ],
       "front": {
         "title": "•Luke's Hunting Rifle (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual7-Light/large/lukeshuntingrifle.gif",
@@ -32202,7 +38128,12 @@
       "gempId": "9_90",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Luke's Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/lukeslightsaber.gif",
@@ -32246,7 +38177,12 @@
       "gempId": "102_4",
       "side": "Light",
       "rarity": "PM",
-      "set": "Jedi Pack",
+      "set": "102",
+      "printings": [
+        {
+          "set": "102"
+        }
+      ],
       "front": {
         "title": "•Luke's T-16 Skyhopper",
         "imageUrl": "https://res.starwarsccg.org/cards/JediPack-Light/large/lukest16skyhopper.gif",
@@ -32286,7 +38222,12 @@
       "id": 5709,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Luke's Ultimatum",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/lukesultimatum.gif",
@@ -32305,7 +38246,12 @@
       "gempId": "1_149",
       "side": "Light",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Luke's X-34 Landspeeder",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/lukesx34landspeeder.gif",
@@ -32328,7 +38274,12 @@
       "gempId": "8_21",
       "side": "Light",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Lumat",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/lumat.gif",
@@ -32356,7 +38307,12 @@
       "gempId": "9_77",
       "side": "Light",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Luminous",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/luminous.gif",
@@ -32391,7 +38347,12 @@
       "gempId": "2_12",
       "side": "Light",
       "rarity": "U1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "M-HYD 'Binary' Droid",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/mhydbinarydroid.gif",
@@ -32414,7 +38375,12 @@
       "gempId": "12_13",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Mace Windu",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/macewindu.gif",
@@ -32456,7 +38422,12 @@
       "gempId": "12_14",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Mace Windu (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/macewinduai.gif",
@@ -32483,7 +38454,12 @@
       "id": 5711,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Mace Windu (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/macewindu.gif",
@@ -32513,7 +38489,12 @@
       "gempId": "201_2",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Mace Windu (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Light/large/macewindu.gif",
@@ -32555,7 +38536,12 @@
       "id": 5712,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Mace Windu (V) (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/macewinduai.gif",
@@ -32585,7 +38571,12 @@
       "gempId": "201_42",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Mace Windu (V) (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Light/large/macewinduai.gif",
@@ -32614,7 +38605,12 @@
       "gempId": "14_18",
       "side": "Light",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Mace Windu, Jedi Master",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/macewindujedimaster.gif",
@@ -32659,7 +38655,12 @@
       "gempId": "14_19",
       "side": "Light",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Mace Windu, Jedi Master (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/macewindujedimasterai.gif",
@@ -32686,7 +38687,12 @@
       "id": 5715,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Mace Windu, Master of the Order",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/macewindumasteroftheorder.gif",
@@ -32714,7 +38720,12 @@
       "id": 5716,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Mace Windu, Master of the Order (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/macewindumasteroftheorderai.gif",
@@ -32743,7 +38754,12 @@
       "gempId": "201_21",
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Mace Windu's Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Light/large/macewinduslightsaber.gif",
@@ -32770,7 +38786,12 @@
       "gempId": "2_26",
       "side": "Light",
       "rarity": "R2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Magnetic Suction Tube",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/magneticsuctiontube.gif",
@@ -32791,7 +38812,12 @@
       "gempId": "3_13",
       "side": "Light",
       "rarity": "R2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Major Bren Derlin",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/majorbrenderlin.gif",
@@ -32821,7 +38847,12 @@
       "gempId": "203_8",
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•Major Bren Derlin (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Light/large/majorbrenderlin.gif",
@@ -32857,7 +38888,12 @@
       "gempId": "207_7",
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Set 7",
+      "set": "207",
+      "printings": [
+        {
+          "set": "207"
+        }
+      ],
       "front": {
         "title": "•Major Caluan Ematt",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual7-Light/large/majorcaluanematt.gif",
@@ -32883,7 +38919,12 @@
       "gempId": "9_25",
       "side": "Light",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Major Haash'n",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/majorhaashn.gif",
@@ -32916,7 +38957,12 @@
       "id": 5717,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Major Haash'n (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/majorhaashn.gif",
@@ -32941,7 +38987,12 @@
       "gempId": "208_9",
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Major Harter Kalonia",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/majorharterkalonia.gif",
@@ -32969,7 +39020,12 @@
       "gempId": "9_26",
       "side": "Light",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Major Olander Brit",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/majorolanderbrit.gif",
@@ -32997,7 +39053,12 @@
       "gempId": "7_31",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Major Palo Torshan",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/majorpalotorshan.gif",
@@ -33030,7 +39091,12 @@
       "gempId": "9_27",
       "side": "Light",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Major Panno",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/majorpanno.gif",
@@ -33064,7 +39130,12 @@
       "gempId": "207_8",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 7",
+      "set": "207",
+      "printings": [
+        {
+          "set": "207"
+        }
+      ],
       "front": {
         "title": "•Major Taslin Brance",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual7-Light/large/majortaslinbrance.gif",
@@ -33090,7 +39161,12 @@
       "gempId": "211_29",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Make Ten Men Feel Like A Hundred",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/maketenmenfeellikeahundred.gif",
@@ -33106,7 +39182,12 @@
       "gempId": "12_77",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Malastare",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/malastare.gif",
@@ -33138,7 +39219,12 @@
       "gempId": "6_71",
       "side": "Light",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Mandalorian Mishap",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/mandalorianmishap.gif",
@@ -33165,7 +39251,12 @@
       "id": 5719,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Mandalorian Mishap & •Jedi Mind Trick",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/mandalorianmishapjedimindtrick.gif",
@@ -33181,7 +39272,12 @@
       "id": 5720,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Mandalorian Mishap (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/mandalorianmishap.gif",
@@ -33201,7 +39297,12 @@
       "gempId": "208_20",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Mandalorian Mishap (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/mandalorianmishap.gif",
@@ -33245,7 +39346,12 @@
       "gempId": "7_69",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Maneuvering Flaps",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/maneuveringflaps.gif",
@@ -33264,7 +39370,12 @@
       "id": 5721,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Maneuvering Flaps & •Nick Of Time",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/maneuveringflaps&nickoftime.gif",
@@ -33281,7 +39392,12 @@
       "id": 5722,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Maneuvering Flaps (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/maneuveringflaps.gif",
@@ -33300,7 +39416,12 @@
       "gempId": "200_43",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "Maneuvering Flaps (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/maneuveringflaps.gif",
@@ -33324,7 +39445,12 @@
       "gempId": "1_55",
       "side": "Light",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Mantellian Savrip",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/mantelliansavrip.gif",
@@ -33358,7 +39484,12 @@
       "id": 5723,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Maris Brood, Fallen Jedi",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/marisbroodfallenjedi.gif",
@@ -33385,7 +39516,12 @@
       "id": 5724,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Maris Brood, Fallen Jedi (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/marisbroodfallenjediai.gif",
@@ -33413,7 +39549,12 @@
       "gempId": "12_15",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Mas Amedda",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/masamedda.gif",
@@ -33445,7 +39586,12 @@
       "gempId": "9_78",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Masanya",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/masanya.gif",
@@ -33477,7 +39623,12 @@
       "gempId": "204_33",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Masanya (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/masanya.gif",
@@ -33510,7 +39661,12 @@
       "gempId": "111_4",
       "side": "Light",
       "rarity": "PM",
-      "set": "Third Anthology",
+      "set": "111",
+      "printings": [
+        {
+          "set": "111"
+        }
+      ],
       "front": {
         "title": "Massassi Base Operations / One In A Million",
         "imageUrl": "https://res.starwarsccg.org/cards/ThirdAnthology-Light/large/massassibaseoperations.gif",
@@ -33531,7 +39687,12 @@
       "id": 5726,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Massassi Base Sentry",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/massassibasesentry.gif",
@@ -33549,7 +39710,12 @@
       "id": 5727,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Master Kenobi",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/masterkenobi.gif",
@@ -33573,7 +39739,12 @@
       "gempId": "110_2",
       "side": "Light",
       "rarity": "PM",
-      "set": "Enhanced Jabba's Palace",
+      "set": "110",
+      "printings": [
+        {
+          "set": "110"
+        }
+      ],
       "front": {
         "title": "•Master Luke",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedJabbasPalace-Light/large/masterluke.gif",
@@ -33621,7 +39792,12 @@
       "id": 5728,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Master Luke (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/masterluke.gif",
@@ -33650,7 +39826,12 @@
       "gempId": "12_16",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Master Qui-Gon",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/masterquigon.gif",
@@ -33687,7 +39868,12 @@
       "gempId": "12_17",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Master Qui-Gon (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/masterquigonai.gif",
@@ -33714,7 +39900,12 @@
       "id": 5730,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Master Qui-Gon (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/masterquigon.gif",
@@ -33744,7 +39935,12 @@
       "gempId": "200_22",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Master Qui-Gon (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/masterquigon.gif",
@@ -33786,7 +39982,12 @@
       "id": 5731,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Master Qui-Gon (V) (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/masterquigonai.gif",
@@ -33816,7 +40017,12 @@
       "gempId": "200_146",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Master Qui-Gon (V) (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/masterquigonai.gif",
@@ -33846,7 +40052,12 @@
       "gempId": "6_28",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Max Rebo",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/maxrebo.gif",
@@ -33874,7 +40085,12 @@
       "id": 5733,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Max Rebo (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/maxrebo.gif",
@@ -33895,7 +40111,12 @@
       "gempId": "211_57",
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Maz Kanata",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/mazkanata.gif",
@@ -33924,7 +40145,12 @@
       "gempId": "211_40",
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Maz's Castle: Antechamber",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/mazscastleantechamber.gif",
@@ -33947,7 +40173,12 @@
       "gempId": "211_39",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Maz's Castle: Hidden Recess",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/mazscastlehiddenrecess.gif",
@@ -33971,7 +40202,12 @@
       "gempId": "7_70",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Mechanical Failure",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/mechanicalfailure.gif",
@@ -33994,7 +40230,12 @@
       "gempId": "7_71",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Meditation",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/meditation.gif",
@@ -34016,7 +40257,12 @@
       "gempId": "7_144",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Medium Bulk Freighter",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/mediumbulkfreighter.gif",
@@ -34051,7 +40297,12 @@
       "gempId": "3_77",
       "side": "Light",
       "rarity": "C1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Medium Repeating Blaster Cannon",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/mediumrepeatingblastercannon.gif",
@@ -34078,7 +40329,12 @@
       "gempId": "3_65",
       "side": "Light",
       "rarity": "U2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Medium Transport",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/mediumtransport.gif",
@@ -34114,7 +40370,12 @@
       "gempId": "7_32",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Melas",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/melas.gif",
@@ -34147,7 +40408,12 @@
       "id": 5737,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Melas (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/melas.gif",
@@ -34176,7 +40442,12 @@
       "gempId": "201_3",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Melas (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Light/large/melas.gif",
@@ -34211,7 +40482,12 @@
       "gempId": "9_38",
       "side": "Light",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Menace Fades",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/menacefades.gif",
@@ -34235,7 +40511,12 @@
       "gempId": "2_36",
       "side": "Light",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Merc Sunlet",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/mercsunlet.gif",
@@ -34257,7 +40538,12 @@
       "gempId": "10_11",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "••Mercenary Armor",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Light/large/mercenaryarmor.gif",
@@ -34280,7 +40566,12 @@
       "id": 5738,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "••Mercenary Armor (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/mercenaryarmor.gif",
@@ -34299,7 +40590,12 @@
       "gempId": "12_61",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Might Of The Republic",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/mightoftherepublic.gif",
@@ -34339,7 +40635,12 @@
       "gempId": "1_143",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Millennium Falcon",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/millenniumfalcon.gif",
@@ -34406,7 +40707,12 @@
       "id": 5739,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Millennium Falcon (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/millenniumfalcon.gif",
@@ -34432,7 +40738,12 @@
       "gempId": "7_138",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Mind What You Have Learned / Save You It Can",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/mindwhatyouhavelearned.gif",
@@ -34453,7 +40764,12 @@
       "id": 5741,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "Mind What You Have Learned / Save You It Can (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/mindwhatyouhavelearned.gif",
@@ -34481,7 +40797,12 @@
       "gempId": "12_62",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Mindful Of The Future",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/mindfulofthefuture.gif",
@@ -34613,7 +40934,12 @@
       "gempId": "204_21",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Mindful Of The Future (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/mindfulofthefuture.gif",
@@ -34639,7 +40965,12 @@
       "gempId": "10_12",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Mirax Terrik",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Light/large/miraxterrik.gif",
@@ -34683,7 +41014,12 @@
       "gempId": "7_33",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Moisture Farmer",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/moisturefarmer.gif",
@@ -34710,7 +41046,12 @@
       "gempId": "1_20",
       "side": "Light",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Momaw Nadon",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/momawnadon.gif",
@@ -34745,7 +41086,12 @@
       "gempId": "9_59",
       "side": "Light",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Mon Calamari",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/moncalamari.gif",
@@ -34777,7 +41123,12 @@
       "gempId": "203_9",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "••Mon Calamari Admiral",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Light/large/moncalamariadmiral.gif",
@@ -34812,7 +41163,12 @@
       "id": 5742,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Mon Calamari Dockyards",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/moncalamaridockyards.gif",
@@ -34831,7 +41187,12 @@
       "gempId": "200_44",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Mon Calamari Dockyards",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/moncalamaridockyards.gif",
@@ -34860,7 +41221,15 @@
       "gempId": "9_79",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "107"
+        },
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "Mon Calamari Star Cruiser",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/moncalamaristarcruiser.gif",
@@ -34893,7 +41262,12 @@
       "id": 5743,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "Mon Calamari Star Cruiser (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/moncalamaristarcruiser.gif",
@@ -34921,7 +41295,15 @@
       "gempId": "8_22",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "107"
+        },
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Mon Mothma",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/monmothma.gif",
@@ -34981,7 +41363,12 @@
       "gempId": "6_89",
       "side": "Light",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Mos Eisley Blaster",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/moseisleyblaster.gif",
@@ -35007,7 +41394,12 @@
       "id": 5744,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Motivator",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/motivator.gif",
@@ -35022,7 +41414,12 @@
       "gempId": "2_80",
       "side": "Light",
       "rarity": "R2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Motti Seeker",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/mottiseeker.gif",
@@ -35047,7 +41444,12 @@
       "gempId": "1_96",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Move Along...",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/movealong.gif",
@@ -35064,7 +41466,12 @@
       "gempId": "4_57",
       "side": "Light",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Moving To Attack Position",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/movingtoattackposition.gif",
@@ -35081,7 +41488,12 @@
       "id": 5745,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "Much to Learn, You Still Have",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/muchtolearnyoustillhave.gif",
@@ -35097,7 +41509,12 @@
       "gempId": "12_18",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Murr Danod",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/murrdanod.gif",
@@ -35130,7 +41547,12 @@
       "id": 5746,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Muunilinst",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/muunilinst.gif",
@@ -35150,7 +41572,12 @@
       "id": 5747,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Muunilinst: City of Harnaidan",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/muunilinstcityofharnaidan.gif",
@@ -35170,7 +41597,12 @@
       "id": 5748,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Muunilinst: Docking Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/muunilinstdockingbay.gif",
@@ -35191,7 +41623,12 @@
       "id": 5749,
       "side": "Light",
       "rarity": "C1",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Muunilinst: Harnaidan Plains",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/muunilinstharnaidanplains.gif",
@@ -35211,7 +41648,12 @@
       "id": 5750,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Muunilinst: Republic Landing Site",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/muunilinstrepubliclandingsite.gif",
@@ -35232,7 +41674,12 @@
       "gempId": "12_63",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•My Loyal Bodyguard",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/myloyalbodyguard.gif",
@@ -35260,7 +41707,12 @@
       "gempId": "4_4",
       "side": "Light",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Mynock",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/mynock.gif",
@@ -35294,7 +41746,12 @@
       "gempId": "12_78",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Naboo",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/naboo.gif",
@@ -35326,7 +41783,12 @@
       "gempId": "12_94",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Naboo Blaster Rifle",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/nabooblasterrifle.gif",
@@ -35354,7 +41816,12 @@
       "gempId": "14_34",
       "side": "Light",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Naboo Celebration",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/naboocelebration.gif",
@@ -35378,7 +41845,12 @@
       "gempId": "12_90",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Naboo Defense Fighter",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/naboodefensefighter.gif",
@@ -35412,7 +41884,12 @@
       "gempId": "12_19",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Naboo Fighter Pilot",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/naboofighterpilot.gif",
@@ -35437,7 +41914,12 @@
       "gempId": "12_95",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Naboo Security Officer Blaster",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/naboosecurityofficerblaster.gif",
@@ -35463,7 +41945,12 @@
       "gempId": "12_79",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Naboo: Battle Plains",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/naboobattleplains.gif",
@@ -35495,7 +41982,12 @@
       "gempId": "14_49",
       "side": "Light",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Naboo: Boss Nass' Chambers",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/naboobossnassschambers.gif",
@@ -35527,7 +42019,12 @@
       "gempId": "14_50",
       "side": "Light",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Naboo: Otoh Gunga Entrance",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/naboootohgungaentrance.gif",
@@ -35555,7 +42052,12 @@
       "gempId": "12_80",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Naboo: Swamp",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/nabooswamp.gif",
@@ -35583,7 +42085,12 @@
       "gempId": "12_81",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Naboo: Theed Palace Courtyard",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/nabootheedpalacecourtyard.gif",
@@ -35611,7 +42118,12 @@
       "gempId": "12_82",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Naboo: Theed Palace Docking Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/nabootheedpalacedockingbay.gif",
@@ -35644,7 +42156,12 @@
       "gempId": "13_31",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Naboo: Theed Palace Generator",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/nabootheedpalacegenerator.gif",
@@ -35672,7 +42189,12 @@
       "gempId": "13_32",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Naboo: Theed Palace Generator Core",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/nabootheedpalacegeneratorcore.gif",
@@ -35700,7 +42222,12 @@
       "gempId": "14_51",
       "side": "Light",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Naboo: Theed Palace Hallway",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/nabootheedpalacehallway.gif",
@@ -35732,7 +42259,12 @@
       "gempId": "201_17",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Naboo: Theed Palace Hallway (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Light/large/nabootheedpalacehallway.gif",
@@ -35760,7 +42292,12 @@
       "gempId": "12_83",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Naboo: Theed Palace Throne Room",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/nabootheedpalacethroneroom.gif",
@@ -35788,7 +42325,12 @@
       "gempId": "1_97",
       "side": "Light",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Nabrun Leids",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/nabrunleids.gif",
@@ -35813,7 +42355,12 @@
       "gempId": "2_13",
       "side": "Light",
       "rarity": "U2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Nalan Cheel",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/nalancheel.gif",
@@ -35838,7 +42385,12 @@
       "id": 5751,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Nar Shaddaa",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/narshaddaa.gif",
@@ -35858,7 +42410,12 @@
       "gempId": "200_58",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Nar Shaddaa",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/narshaddaa.gif",
@@ -35892,7 +42449,12 @@
       "gempId": "6_72",
       "side": "Light",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Nar Shaddaa Wind Chimes",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/narshaddaawindchimes.gif",
@@ -35962,7 +42524,12 @@
       "gempId": "10_13",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Nar Shaddaa Wind Chimes & •Out Of Somewhere",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Light/large/narshaddaawindchimes&outofsomewhere.gif",
@@ -36028,7 +42595,12 @@
       "id": 5752,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Nar Shaddaa: Scoundrel's Rest",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/narshaddaascoundrelsrest.gif",
@@ -36047,7 +42619,12 @@
       "id": 5753,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Nar Shaddaa: Undercity",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/narshaddaaundercity.gif",
@@ -36067,7 +42644,12 @@
       "id": 5754,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Nar Shaddaa: Undercity Street",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/narshaddaaundercitystreet.gif",
@@ -36088,7 +42670,12 @@
       "gempId": "1_98",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Narrow Escape",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/narrowescape.gif",
@@ -36111,7 +42698,12 @@
       "gempId": "7_34",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Neb Dulo",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/nebdulo.gif",
@@ -36132,7 +42724,12 @@
       "id": 5755,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Neb Dulo (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/nebdulo.gif",
@@ -36157,7 +42754,12 @@
       "gempId": "9_80",
       "side": "Light",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "Nebulon-B Frigate",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/nebulonbfrigate.gif",
@@ -36188,7 +42790,12 @@
       "gempId": "11_38",
       "side": "Light",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Neck And Neck",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/neckandneck.gif",
@@ -36209,7 +42816,12 @@
       "gempId": "4_27",
       "side": "Light",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Never Tell Me The Odds",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/nevertellmetheodds.gif",
@@ -36239,7 +42851,12 @@
       "gempId": "12_64",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•New Leadership Is Needed",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/newleadershipisneeded.gif",
@@ -36260,7 +42877,12 @@
       "gempId": "3_46",
       "side": "Light",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Nice Of You Guys To Drop By",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/niceofyouguystodropby.gif",
@@ -36279,7 +42901,12 @@
       "id": 5756,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Nice Of You Guys To Drop By (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/niceofyouguystodropby.gif",
@@ -36299,7 +42926,12 @@
       "gempId": "7_72",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Nick Of Time",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/nickoftime.gif",
@@ -36319,7 +42951,12 @@
       "id": 5757,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Nick Of Time (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/nickoftime.gif",
@@ -36338,7 +42975,12 @@
       "gempId": "9_28",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Nien Nunb",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/niennunb.gif",
@@ -36366,7 +43008,12 @@
       "id": 5758,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Nien Nunb, Sullustan Smuggler",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/niennunbsullustansmuggler.gif",
@@ -36391,7 +43038,12 @@
       "gempId": "1_56",
       "side": "Light",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Nightfall",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/nightfall.gif",
@@ -36416,7 +43068,12 @@
       "id": 5759,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Nightfall (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/nightfall.gif",
@@ -36432,7 +43089,12 @@
       "gempId": "4_28",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•No Disintegrations!",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/nodisintegrations.gif",
@@ -36455,7 +43117,12 @@
       "id": 5760,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•No Disintegrations! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/nodisintegrations.gif",
@@ -36474,7 +43141,12 @@
       "gempId": "14_43",
       "side": "Light",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "No Giben Up, General Jar Jar!",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/nogibenupgeneraljarjar.gif",
@@ -36495,7 +43167,12 @@
       "gempId": "10_14",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•No Questions Asked",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Light/large/noquestionsasked.gif",
@@ -36513,7 +43190,12 @@
       "id": 5761,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•No Questions Asked (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/noquestionsasked.gif",
@@ -36531,7 +43213,12 @@
       "gempId": "1_99",
       "side": "Light",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Noble Sacrifice",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/noblesacrifice.gif",
@@ -36551,7 +43238,12 @@
       "gempId": "5_58",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "NOOOOOOOOOOOO!",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/noooooooooooo.gif",
@@ -36574,7 +43266,12 @@
       "id": 5762,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "NOOOOOOOOOOOO! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/noooooooooooo.gif",
@@ -36594,7 +43291,12 @@
       "gempId": "4_5",
       "side": "Light",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Nudj",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/nudj.gif",
@@ -36626,7 +43328,12 @@
       "id": 5763,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Obi-Wan in Radiant VII",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/obiwaninradiantvii.gif",
@@ -36655,7 +43362,12 @@
       "gempId": "200_63",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Obi-Wan in Radiant VII",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/obiwaninradiantvii.gif",
@@ -36688,7 +43400,12 @@
       "gempId": "1_21",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Obi-Wan Kenobi",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/obiwankenobi.gif",
@@ -36731,7 +43448,12 @@
       "id": 5764,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Obi-Wan Kenobi (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/obiwankenobi.gif",
@@ -36758,7 +43480,12 @@
       "gempId": "201_4",
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Obi-Wan Kenobi (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Light/large/obiwankenobi.gif",
@@ -36802,7 +43529,12 @@
       "gempId": "13_33",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Obi-Wan Kenobi, Jedi Knight",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/obiwankenobijediknight.gif",
@@ -36844,7 +43576,12 @@
       "id": 5765,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Obi-Wan Kenobi, Jedi Knight (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/obiwankenobijediknight.gif",
@@ -36874,7 +43611,12 @@
       "gempId": "11_6",
       "side": "Light",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Obi-Wan Kenobi, Padawan Learner",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/obiwankenobipadawanlearner.gif",
@@ -36918,7 +43660,12 @@
       "gempId": "11_7",
       "side": "Light",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Obi-Wan Kenobi, Padawan Learner (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/obiwankenobipadawanlearnerai.gif",
@@ -36945,7 +43692,12 @@
       "id": 5767,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Obi-Wan Kenobi, Padawan Learner (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/obiwankenobipadawanlearner.gif",
@@ -36974,7 +43726,12 @@
       "gempId": "200_23",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Obi-Wan Kenobi, Padawan Learner (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/obiwankenobipadawanlearner.gif",
@@ -37011,7 +43768,12 @@
       "id": 5768,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Obi-Wan Kenobi, Padawan Learner (V) (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/obiwankenobipadawanlearnerai.gif",
@@ -37040,7 +43802,12 @@
       "gempId": "200_145",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Obi-Wan Kenobi, Padawan Learner (V) (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/obiwankenobipadawanlearnerai.gif",
@@ -37069,7 +43836,12 @@
       "gempId": "108_4",
       "side": "Light",
       "rarity": "PM",
-      "set": "Enhanced Premiere",
+      "set": "108",
+      "printings": [
+        {
+          "set": "108"
+        }
+      ],
       "front": {
         "title": "•Obi-Wan With Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedPremiere-Light/large/obiwanwithlightsaber.gif",
@@ -37113,7 +43885,12 @@
       "id": 5770,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Obi-Wan, Crazy Wizard",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/obiwancrazywizard.gif",
@@ -37140,7 +43917,12 @@
       "gempId": "4_29",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Obi-Wan's Apparition",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/obiwansapparition.gif",
@@ -37161,7 +43943,12 @@
       "id": 5771,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Obi-Wan's Apparition (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/obiwansapparition.gif",
@@ -37180,7 +43967,12 @@
       "gempId": "1_57",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Obi-Wan's Cape",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/obiwanscape.gif",
@@ -37200,7 +43992,12 @@
       "id": 5772,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Obi-Wan's Cape (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/obiwanscape.gif",
@@ -37216,7 +44013,12 @@
       "gempId": "10_15",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Obi-Wan's Journal",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Light/large/obiwansjournal.gif",
@@ -37243,7 +44045,12 @@
       "gempId": "1_157",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Obi-Wan's Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/obiwanslightsaber.gif",
@@ -37276,7 +44083,12 @@
       "gempId": "13_34",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Obi-Wan's Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/obiwanslightsaber.gif",
@@ -37309,7 +44121,12 @@
       "gempId": "12_65",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Odin Nesloor",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/odinnesloor.gif",
@@ -37330,7 +44147,12 @@
       "id": 5773,
       "side": "Light",
       "rarity": "F",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Odin Nesloor & •First Aid",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/odinnesloor&firstaid.gif",
@@ -37350,7 +44172,12 @@
       "gempId": "209_21",
       "side": "Light",
       "rarity": "F",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Odin Nesloor & •First Aid",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/odinnesloorfirstaid.gif",
@@ -37370,7 +44197,12 @@
       "gempId": "5_59",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Off The Edge",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/offtheedge.gif",
@@ -37394,7 +44226,12 @@
       "gempId": "14_20",
       "side": "Light",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Officer Dolphe",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/officerdolphe.gif",
@@ -37423,7 +44260,12 @@
       "gempId": "14_21",
       "side": "Light",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Officer Ellberger",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/officerellberger.gif",
@@ -37455,7 +44297,12 @@
       "gempId": "14_22",
       "side": "Light",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Officer Perosei",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/officerperosei.gif",
@@ -37483,7 +44330,12 @@
       "id": 5775,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Oh, He's Not Dead, Not Yet",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/ohhesnotdeadnotyet.gif",
@@ -37502,7 +44354,12 @@
       "gempId": "204_32",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "Old Allies / We Need Your Help",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/oldallies.gif",
@@ -37532,7 +44389,12 @@
       "gempId": "1_100",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Old Ben",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/oldben.gif",
@@ -37554,7 +44416,12 @@
       "gempId": "5_60",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Old Pirates",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/oldpirates.gif",
@@ -37579,7 +44446,12 @@
       "gempId": "7_95",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Old Times",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/oldtimes.gif",
@@ -37597,7 +44469,12 @@
       "gempId": "7_96",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•On Target",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/ontarget.gif",
@@ -37616,7 +44493,12 @@
       "gempId": "1_101",
       "side": "Light",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "On The Edge",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/ontheedge.gif",
@@ -37636,7 +44518,12 @@
       "gempId": "3_47",
       "side": "Light",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•One More Pass",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/onemorepass.gif",
@@ -37658,7 +44545,12 @@
       "gempId": "13_35",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Only Jedi Carry That Weapon",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/onlyjedicarrythatweapon.gif",
@@ -37680,7 +44572,12 @@
       "gempId": "6_29",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Oola",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/oola.gif",
@@ -37710,7 +44607,12 @@
       "gempId": "13_36",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Opee Sea Killer",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/opeeseakiller.gif",
@@ -37741,7 +44643,12 @@
       "gempId": "9_91",
       "side": "Light",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "<>Orbital Mine",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/orbitalmine.gif",
@@ -37763,7 +44670,12 @@
       "gempId": "3_64",
       "side": "Light",
       "rarity": "U2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Ord Mantell",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/ordmantell.gif",
@@ -37796,7 +44708,12 @@
       "gempId": "4_30",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Order To Engage",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/ordertoengage.gif",
@@ -37826,7 +44743,12 @@
       "gempId": "7_97",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Organized Attack",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/organizedattack.gif",
@@ -37853,7 +44775,12 @@
       "gempId": "8_23",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Orrimaarko",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/orrimaarko.gif",
@@ -37887,7 +44814,12 @@
       "id": 5777,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Orrimaarko (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/orrimaarko.gif",
@@ -37916,7 +44848,12 @@
       "gempId": "6_30",
       "side": "Light",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•••Ortolan",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/ortolan.gif",
@@ -37946,7 +44883,12 @@
       "gempId": "112_4",
       "side": "Light",
       "rarity": "PM",
-      "set": "Jabba's Palace Sealed Deck",
+      "set": "112",
+      "printings": [
+        {
+          "set": "112"
+        }
+      ],
       "front": {
         "title": "•Ounee Ta",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalaceSealedDeck-Light/large/ouneeta.gif",
@@ -37974,7 +44916,12 @@
       "gempId": "13_37",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Ounee Ta",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/ouneeta.gif",
@@ -37996,7 +44943,12 @@
       "id": 5778,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•Ounee Ta (Premium) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Light/large/ouneetav.gif",
@@ -38015,7 +44967,12 @@
       "id": 5779,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•Ounee Ta (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Light/large/ouneeta.gif",
@@ -38035,7 +44992,12 @@
       "gempId": "1_58",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Our Most Desperate Hour",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/ourmostdesperatehour.gif",
@@ -38056,7 +45018,12 @@
       "id": 5780,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Our Most Desperate Hour (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/ourmostdesperatehour.gif",
@@ -38072,7 +45039,12 @@
       "gempId": "9_53",
       "side": "Light",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Our Only Hope",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/ouronlyhope.gif",
@@ -38089,7 +45061,12 @@
       "id": 5781,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Our Only Hope (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/ouronlyhope.gif",
@@ -38109,7 +45086,12 @@
       "gempId": "2_54",
       "side": "Light",
       "rarity": "U2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Out Of Commission",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/outofcommission.gif",
@@ -38130,7 +45112,12 @@
       "gempId": "10_16",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "Out Of Commission & Transmission Terminated",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Light/large/outofcommission&transmissionterminated.gif",
@@ -38159,7 +45146,12 @@
       "gempId": "1_102",
       "side": "Light",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Out Of Nowhere",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/outofnowhere.gif",
@@ -38178,7 +45170,12 @@
       "id": 5782,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "Out of Nowhere (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/outofnowhere.gif",
@@ -38195,7 +45192,12 @@
       "gempId": "5_61",
       "side": "Light",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Out Of Somewhere",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/outofsomewhere.gif",
@@ -38215,7 +45217,12 @@
       "id": 5783,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Out Of Somewhere (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/outofsomewhere.gif",
@@ -38234,7 +45241,12 @@
       "id": 5784,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "<>Outpost",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/outpost.gif",
@@ -38255,7 +45267,12 @@
       "gempId": "10_17",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Outrider",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Light/large/outrider.gif",
@@ -38297,7 +45314,12 @@
       "id": 5785,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Overseer",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/overseer.gif",
@@ -38326,7 +45348,12 @@
       "gempId": "200_64",
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Overseer",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/overseer.gif",
@@ -38366,7 +45393,12 @@
       "gempId": "1_22",
       "side": "Light",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Owen Lars",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/owenlars.gif",
@@ -38391,7 +45423,12 @@
       "gempId": "10_18",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Owen Lars & •Beru Lars",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Light/large/owenlars&berulars.gif",
@@ -38419,7 +45456,12 @@
       "id": 5786,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Owen Lars (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/owenlars.gif",
@@ -38443,7 +45485,12 @@
       "gempId": "11_8",
       "side": "Light",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Padme Naberrie",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/padmenaberrie.gif",
@@ -38502,7 +45549,12 @@
       "gempId": "11_9",
       "side": "Light",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Padme Naberrie (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/padmenaberrieai.gif",
@@ -38529,7 +45581,12 @@
       "id": 5788,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Padme Naberrie (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/padmenaberrie.gif",
@@ -38560,7 +45617,12 @@
       "gempId": "203_10",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•Padme Naberrie (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Light/large/padmenaberrie.gif",
@@ -38600,7 +45662,12 @@
       "id": 5789,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Padme Naberrie (V) (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/padmenaberrieai.gif",
@@ -38631,7 +45698,12 @@
       "gempId": "203_36",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•Padme Naberrie (V) (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Light/large/padmenaberrieai.gif",
@@ -38659,7 +45731,12 @@
       "gempId": "112_5",
       "side": "Light",
       "rarity": "PM",
-      "set": "Jabba's Palace Sealed Deck",
+      "set": "112",
+      "printings": [
+        {
+          "set": "112"
+        }
+      ],
       "front": {
         "title": "Palace Raider",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalaceSealedDeck-Light/large/palaceraider.gif",
@@ -38692,7 +45769,12 @@
       "id": 5791,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "Palace Raider (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/palaceraider.gif",
@@ -38717,7 +45799,12 @@
       "gempId": "202_2",
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Set 2",
+      "set": "202",
+      "printings": [
+        {
+          "set": "202"
+        }
+      ],
       "front": {
         "title": "Palace Raider (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual2-Light/large/palaceraider.gif",
@@ -38754,7 +45841,12 @@
       "gempId": "6_31",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Palejo Reshad",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/palejoreshad.gif",
@@ -38785,7 +45877,12 @@
       "gempId": "14_23",
       "side": "Light",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Panaka, Protector Of The Queen",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/panakaprotectorofthequeen.gif",
@@ -38824,7 +45921,12 @@
       "gempId": "14_24",
       "side": "Light",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Panaka, Protector Of The Queen (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/panakaprotectorofthequeenai.gif",
@@ -38852,7 +45954,12 @@
       "gempId": "12_96",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Panaka's Blaster",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/panakasblaster.gif",
@@ -38888,7 +45995,12 @@
       "gempId": "1_103",
       "side": "Light",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Panic",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/panic.gif",
@@ -38908,7 +46020,12 @@
       "id": 5793,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Panic (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/panic.gif",
@@ -38925,7 +46042,12 @@
       "gempId": "8_24",
       "side": "Light",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Paploo",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/paploo.gif",
@@ -38963,7 +46085,12 @@
       "gempId": "210_22",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•Paploo (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Light/large/paploo.gif",
@@ -38987,7 +46114,12 @@
       "gempId": "210_21",
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•Part Of The Tribe",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Light/large/partofthetribe.gif",
@@ -39006,7 +46138,12 @@
       "gempId": "5_62",
       "side": "Light",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Path Of Least Resistance",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/pathofleastresistance.gif",
@@ -39027,7 +46164,12 @@
       "gempId": "10_19",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Path Of Least Resistance & •Revealed",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Light/large/pathofleastresistance&revealed.gif",
@@ -39044,7 +46186,12 @@
       "gempId": "7_153",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Patrol Craft",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/patrolcraft.gif",
@@ -39070,7 +46217,12 @@
       "gempId": "3_48",
       "side": "Light",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Perimeter Scan",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/perimeterscan.gif",
@@ -39092,7 +46244,12 @@
       "id": 5796,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Perimeter Scan (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/perimeterscan.gif",
@@ -39112,7 +46269,12 @@
       "gempId": "201_14",
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "Perimeter Scan (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Light/large/perimeterscan.gif",
@@ -39136,7 +46298,12 @@
       "gempId": "208_27",
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Phantom",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/phantom.gif",
@@ -39169,7 +46336,12 @@
       "gempId": "12_20",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Phylo Gandish",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/phylogandish.gif",
@@ -39200,7 +46372,12 @@
       "id": 5797,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Phylo Gandish (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/phylogandish.gif",
@@ -39229,7 +46406,12 @@
       "gempId": "3_78",
       "side": "Light",
       "rarity": "R2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Planet Defender Ion Cannon",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/planetdefenderioncannon.gif",
@@ -39256,7 +46438,12 @@
       "id": 5798,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Planet Defender Ion Cannon (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/planetdefenderioncannon.gif",
@@ -39278,7 +46465,12 @@
       "gempId": "13_38",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Planetary Defenses",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/planetarydefenses.gif",
@@ -39298,7 +46490,12 @@
       "id": 5799,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•Planetary Defenses (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Light/large/planetarydefenses.gif",
@@ -39319,7 +46516,12 @@
       "gempId": "203_13",
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Set 3",
+      "set": "200d",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•Planetary Defenses (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Light/large/planetarydefenses.gif",
@@ -39340,7 +46542,12 @@
       "id": 5800,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Planetary Shiel",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/planetaryshield.gif",
@@ -39356,7 +46563,12 @@
       "gempId": "1_59",
       "side": "Light",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Plastoid Armor",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/plastoidarmor.gif",
@@ -39380,7 +46592,12 @@
       "id": 5801,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Plastoid Armor (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/plastoidarmor.gif",
@@ -39396,7 +46613,12 @@
       "gempId": "12_45",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Plea To The Court",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/pleatothecourt.gif",
@@ -39429,7 +46651,12 @@
       "gempId": "12_88",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Plead My Case To The Senate / Sanity And Compassion",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/pleadmycasetothesenate.gif",
@@ -39457,7 +46684,12 @@
       "gempId": "12_21",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Plo Koon",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/plokoon.gif",
@@ -39500,7 +46732,12 @@
       "id": 5803,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Plo Koon (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/plokoon.gif",
@@ -39533,7 +46770,12 @@
       "gempId": "210_23",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "•Plo Koon (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Light/large/plokoon.gif",
@@ -39562,7 +46804,12 @@
       "gempId": "11_39",
       "side": "Light",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Podrace Prep",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/podraceprep.gif",
@@ -39587,7 +46834,12 @@
       "gempId": "204_8",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Poe Dameron",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/poedameron.gif",
@@ -39621,7 +46873,12 @@
       "gempId": "4_31",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Polarized Negative Power Coupling",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/polarizednegativepowercoupling.gif",
@@ -39640,7 +46897,12 @@
       "id": 5805,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Polarized Negative Power Coupling (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/polarizednegativepowercoupling.gif",
@@ -39660,7 +46922,12 @@
       "gempId": "1_23",
       "side": "Light",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Pops",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/pops.gif",
@@ -39689,7 +46956,12 @@
       "gempId": "4_13",
       "side": "Light",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Portable Fusion Generator",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/portablefusiongenerator.gif",
@@ -39711,7 +46983,12 @@
       "gempId": "7_53",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Portable Scanner",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/portablescanner.gif",
@@ -39838,7 +47115,12 @@
       "gempId": "3_79",
       "side": "Light",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Power Harpoon",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/powerharpoon.gif",
@@ -39862,7 +47144,12 @@
       "gempId": "7_98",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Power Pivot",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/powerpivot.gif",
@@ -39885,7 +47172,12 @@
       "gempId": "7_99",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Precise Hit",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/precisehit.gif",
@@ -39906,7 +47198,12 @@
       "id": 5806,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Precise Hit (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/precisehit.gif",
@@ -39926,7 +47223,12 @@
       "gempId": "5_7",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Princess Leia",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/princessleia.gif",
@@ -39978,7 +47280,12 @@
       "id": 5807,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Princess Leia (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/princessleia.gif",
@@ -40007,7 +47314,12 @@
       "gempId": "201_5",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Princess Leia (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Light/large/princessleia.gif",
@@ -40060,7 +47372,12 @@
       "gempId": "6_32",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Princess Leia Organa",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/princessleiaorgana.gif",
@@ -40108,7 +47425,12 @@
       "id": 5808,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Princess Leia Organa (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/princessleiaorgana.gif",
@@ -40136,7 +47458,12 @@
       "id": 5809,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Princess Leia, Lost Scion",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/princessleialostscion.gif",
@@ -40165,7 +47492,12 @@
       "gempId": "7_35",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Princess Organa",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/princessorgana.gif",
@@ -40251,7 +47583,12 @@
       "gempId": "111_5",
       "side": "Light",
       "rarity": "PM",
-      "set": "Third Anthology",
+      "set": "111",
+      "printings": [
+        {
+          "set": "111"
+        }
+      ],
       "front": {
         "title": "•Prisoner 2187",
         "imageUrl": "https://res.starwarsccg.org/cards/ThirdAnthology-Light/large/prisoner2187.gif",
@@ -40294,7 +47631,12 @@
       "gempId": "207_18",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 7",
+      "set": "207",
+      "printings": [
+        {
+          "set": "207"
+        }
+      ],
       "front": {
         "title": "•Profundity",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual7-Light/large/profundity.gif",
@@ -40329,7 +47671,12 @@
       "gempId": "6_56",
       "side": "Light",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "••Projection Of A Skywalker",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/projectionofaskywalker.gif",
@@ -40359,7 +47706,12 @@
       "gempId": "208_14",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Prophecy Of The Force",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/prophecyoftheforce.gif",
@@ -40381,7 +47733,12 @@
       "gempId": "5_63",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Protector",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/protector.gif",
@@ -40405,7 +47762,12 @@
       "id": 5810,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Protector (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/protector.gif",
@@ -40425,7 +47787,12 @@
       "gempId": "1_158",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Proton Torpedoes",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/protontorpedoes.gif",
@@ -40454,7 +47821,12 @@
       "gempId": "14_66",
       "side": "Light",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "Proton Torpedoes",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/protontorpedoes.gif",
@@ -40486,7 +47858,12 @@
       "gempId": "6_33",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Pucumir Thryss",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/pucumirthryss.gif",
@@ -40539,7 +47916,12 @@
       "gempId": "10_20",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Pulsar Skate",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Light/large/pulsarskate.gif",
@@ -40589,7 +47971,12 @@
       "gempId": "5_64",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Punch It!",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/punchit.gif",
@@ -40610,7 +47997,12 @@
       "gempId": "5_65",
       "side": "Light",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Put That Down",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/putthatdown.gif",
@@ -40632,7 +48024,12 @@
       "id": 5811,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Put That Down (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/putthatdown.gif",
@@ -40652,7 +48049,12 @@
       "gempId": "200_55",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Put That Down (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/putthatdown.gif",
@@ -40673,7 +48075,12 @@
       "gempId": "1_159",
       "side": "Light",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Quad Laser Cannon",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/quadlasercannon.gif",
@@ -40699,7 +48106,12 @@
       "gempId": "14_25",
       "side": "Light",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Queen Amidala",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/queenamidala.gif",
@@ -40743,7 +48155,12 @@
       "gempId": "14_26",
       "side": "Light",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Queen Amidala (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/queenamidalaai.gif",
@@ -40771,7 +48188,12 @@
       "gempId": "12_22",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Queen Amidala, Ruler Of Naboo",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/queenamidalarulerofnaboo.gif",
@@ -40813,7 +48235,12 @@
       "gempId": "12_23",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Queen Amidala, Ruler Of Naboo (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/queenamidalarulerofnabooai.gif",
@@ -40839,7 +48266,12 @@
       "gempId": "12_91",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Queen's Royal Starship",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/queensroyalstarship.gif",
@@ -40878,7 +48310,12 @@
       "gempId": "11_10",
       "side": "Light",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Qui-Gon Jinn",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/quigonjinn.gif",
@@ -40921,7 +48358,12 @@
       "gempId": "11_11",
       "side": "Light",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Qui-Gon Jinn (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/quigonjinnai.gif",
@@ -40949,7 +48391,12 @@
       "gempId": "14_27",
       "side": "Light",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Qui-Gon Jinn With Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/quigonjinnwithlightsaber.gif",
@@ -40990,7 +48437,12 @@
       "gempId": "13_39",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Qui-Gon Jinn, Jedi Master",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/quigonjinnjedimaster.gif",
@@ -41033,7 +48485,12 @@
       "gempId": "11_49",
       "side": "Light",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Qui-Gon Jinn's Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/quigonjinnslightsaber.gif",
@@ -41069,7 +48526,12 @@
       "gempId": "11_50",
       "side": "Light",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Qui-Gon Jinn's Lightsaber (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/quigonjinnslightsaberai.gif",
@@ -41089,7 +48551,12 @@
       "gempId": "13_40",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Qui-Gon's Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/quigonslightsaber.gif",
@@ -41127,7 +48594,12 @@
       "gempId": "4_32",
       "side": "Light",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Quick Draw",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/quickdraw.gif",
@@ -41149,7 +48621,12 @@
       "id": 5816,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "Quick Draw (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/quickdraw.gif",
@@ -41169,7 +48646,12 @@
       "gempId": "109_4",
       "side": "Light",
       "rarity": "PM",
-      "set": "Enhanced Cloud City",
+      "set": "109",
+      "printings": [
+        {
+          "set": "109"
+        }
+      ],
       "front": {
         "title": "Quiet Mining Colony / Independent Operation",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedCloudCity-Light/large/quietminingcolony.gif",
@@ -41191,7 +48673,12 @@
       "gempId": "2_55",
       "side": "Light",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Quite A Mercenary",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/quiteamercenary.gif",
@@ -41212,7 +48699,12 @@
       "gempId": "3_14",
       "side": "Light",
       "rarity": "R2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•R-3PO (Ar-Threepio)",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/r3poarthreepio.gif",
@@ -41238,7 +48730,12 @@
       "id": 5818,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•R-3PO (Ar-Threepio) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/r3poarthreepio.gif",
@@ -41261,7 +48758,12 @@
       "gempId": "200_24",
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•R-3PO (Ar-Threepio) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/r3poarthreepio.gif",
@@ -41288,7 +48790,12 @@
       "gempId": "3_31",
       "side": "Light",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "R2 Sensor Array",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/r2sensorarray.gif",
@@ -41309,7 +48816,12 @@
       "gempId": "203_11",
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•R2-D2 & •C-3PO",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Light/large/r2d2c3po.gif",
@@ -41346,7 +48858,12 @@
       "gempId": "2_14",
       "side": "Light",
       "rarity": "R2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•R2-D2 (Artoo-Detoo)",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/r2d2.gif",
@@ -41387,7 +48904,12 @@
       "id": 5819,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•R2-D2 (Artoo-Detoo) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/r2d2.gif",
@@ -41413,7 +48935,12 @@
       "gempId": "201_6",
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•R2-D2 (Artoo-Detoo) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Light/large/r2d2.gif",
@@ -41455,7 +48982,12 @@
       "id": 5820,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•R2-D2, Subversive Droid",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/r2d2subversivedroid.gif",
@@ -41481,7 +49013,12 @@
       "gempId": "1_24",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "R2-X2 (Artoo-Extoo)",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/r2x2.gif",
@@ -41510,7 +49047,12 @@
       "gempId": "7_36",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•R3-A2 (Arthree-Aytoo)",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/r3a2.gif",
@@ -41540,7 +49082,12 @@
       "gempId": "7_37",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•R3-T2 (Arthree-Teetoo)",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/r3t2.gif",
@@ -41571,7 +49118,12 @@
       "gempId": "1_25",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "R4-E1 (Arfour-Eeone)",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/r4e1.gif",
@@ -41598,7 +49150,12 @@
       "gempId": "2_15",
       "side": "Light",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "R5-D4 (Arfive-Defour)",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/r5d4.gif",
@@ -41628,7 +49185,12 @@
       "gempId": "3_15",
       "side": "Light",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "R5-M2 (Arfive-Emmtoo)",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/r5m2arfiveemmtoo.gif",
@@ -41656,7 +49218,12 @@
       "id": 5821,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "R5-M2 (Arfive-Emmtoo) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/r5m2arfiveemmtoo.gif",
@@ -41683,7 +49250,12 @@
       "gempId": "2_16",
       "side": "Light",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "RA-7 (Aray-Seven)",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/ra7.gif",
@@ -41706,7 +49278,12 @@
       "gempId": "8_25",
       "side": "Light",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Rabin",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/rabin.gif",
@@ -41735,7 +49312,12 @@
       "gempId": "112_6",
       "side": "Light",
       "rarity": "PM",
-      "set": "Jabba's Palace Sealed Deck",
+      "set": "112",
+      "printings": [
+        {
+          "set": "112"
+        }
+      ],
       "front": {
         "title": "Racing Skiff",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalaceSealedDeck-Light/large/racingskiff.gif",
@@ -41761,7 +49343,12 @@
       "gempId": "1_104",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Radar Scanner",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/radarscanner.gif",
@@ -41781,7 +49368,12 @@
       "gempId": "12_92",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Radiant VII",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/radiantvii.gif",
@@ -41824,7 +49416,12 @@
       "id": 5822,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Rahm Kota, Blind Jedi",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/rahmkotablindjedi.gif",
@@ -41845,7 +49442,12 @@
       "gempId": "4_90",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Raithal",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/raithal.gif",
@@ -41876,7 +49478,12 @@
       "gempId": "2_65",
       "side": "Light",
       "rarity": "C1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Ralltiir",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/ralltiir.gif",
@@ -41906,7 +49513,12 @@
       "gempId": "7_38",
       "side": "Light",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Ralltiir Freighter Captain",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/ralltiirfreightercaptain.gif",
@@ -41944,7 +49556,12 @@
       "gempId": "7_39",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Ralltiir Operative",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/ralltiiroperative.gif",
@@ -41979,7 +49596,15 @@
       "gempId": "8_58",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "107"
+        },
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Rapid Deployment",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/rapiddeployment.gif",
@@ -41999,7 +49624,12 @@
       "id": 5823,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Rapid Deployment (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/rapiddeployment.gif",
@@ -42019,7 +49649,12 @@
       "gempId": "7_100",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Rapid Fire",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/rapidfire.gif",
@@ -42055,7 +49690,12 @@
       "gempId": "6_34",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Rayc Ryjerd",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/raycryjerd.gif",
@@ -42088,7 +49728,12 @@
       "id": 5824,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Rayc Ryjerd (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/raycryjerd.gif",
@@ -42112,7 +49757,12 @@
       "id": 5825,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Rebel Aces",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/rebelaces.gif",
@@ -42131,7 +49781,12 @@
       "gempId": "7_101",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Rebel Ambush",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/rebelambush.gif",
@@ -42151,7 +49806,12 @@
       "gempId": "12_66",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "••Rebel Artillery",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/rebelartillery.gif",
@@ -42170,7 +49830,12 @@
       "gempId": "1_105",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Rebel Barrier",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/rebelbarrier.gif",
@@ -42192,7 +49857,12 @@
       "id": 5826,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "<>Rebel Cell - Hidden Landing Site",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/rebelcellhiddenlandingsite.gif",
@@ -42212,7 +49882,12 @@
       "id": 5827,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "<>Rebel Cell - Monitoring Station",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/rebelcellmonitoringstation.gif",
@@ -42232,7 +49907,12 @@
       "id": 5828,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "<>Rebel Cell - Perimeter",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/rebelcellperimeter.gif",
@@ -42252,7 +49932,12 @@
       "id": 5829,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "<>Rebel Cell - Refugee Quarter",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/rebelcellrefugeequarter.gif",
@@ -42272,7 +49957,12 @@
       "id": 5830,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "<>Rebel Cell - Situation Room",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/rebelcellsituationroom.gif",
@@ -42294,7 +49984,12 @@
       "gempId": "2_17",
       "side": "Light",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Rebel Commander",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/rebelcommander.gif",
@@ -42326,7 +50021,12 @@
       "gempId": "7_73",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Rebel Fleet",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/rebelfleet.gif",
@@ -42349,7 +50049,12 @@
       "gempId": "4_14",
       "side": "Light",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Rebel Flight Suit",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/rebelflightsuit.gif",
@@ -42369,7 +50074,12 @@
       "gempId": "205_4",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 5",
+      "set": "205",
+      "printings": [
+        {
+          "set": "205"
+        }
+      ],
       "front": {
         "title": "Rebel Flight Suit (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual5-Light/large/rebelflightsuit.gif",
@@ -42392,7 +50102,12 @@
       "gempId": "1_26",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Rebel Guard",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/rebelguard.gif",
@@ -42417,7 +50132,12 @@
       "id": 5831,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Rebel Gunrunner",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/rebelgunrunner.gif",
@@ -42432,7 +50152,12 @@
       "id": 5832,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Rebel Infantry",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/rebelinfantry.gif",
@@ -42451,7 +50176,12 @@
       "gempId": "9_54",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "Rebel Leadership",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/rebelleadership.gif",
@@ -42469,7 +50199,12 @@
       "id": 5833,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "Rebel Leadership (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/rebelleadership.gif",
@@ -42490,7 +50225,12 @@
       "gempId": "203_17",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "Rebel Leadership (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Light/large/rebelleadership.gif",
@@ -42539,7 +50279,12 @@
       "gempId": "1_27",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Rebel Pilot",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/rebelpilot.gif",
@@ -42568,7 +50313,12 @@
       "gempId": "1_60",
       "side": "Light",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Rebel Planners",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/rebelplanners.gif",
@@ -42593,7 +50343,12 @@
       "gempId": "1_106",
       "side": "Light",
       "rarity": "C1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Rebel Reinforcements",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/rebelreinforcements.gif",
@@ -42613,7 +50368,12 @@
       "id": 5834,
       "side": "Light",
       "rarity": "C1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Rebel Reinforcements (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/rebelreinforcements.gif",
@@ -42629,7 +50389,12 @@
       "id": 5835,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Rebel Sacrifice",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/rebelsacrifice.gif",
@@ -42645,7 +50410,12 @@
       "gempId": "3_16",
       "side": "Light",
       "rarity": "C1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•••Rebel Scout",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/rebelscout.gif",
@@ -42677,7 +50447,12 @@
       "id": 5836,
       "side": "Light",
       "rarity": "C1",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•••Rebel Scout (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/rebelscout.gif",
@@ -42702,7 +50477,12 @@
       "gempId": "104_3",
       "side": "Light",
       "rarity": "PM",
-      "set": "Empire Strikes Back Introductory Two Player Game",
+      "set": "104",
+      "printings": [
+        {
+          "set": "104"
+        }
+      ],
       "front": {
         "title": "Rebel Snowspeeder",
         "imageUrl": "https://res.starwarsccg.org/cards/EmpireStrikesBackIntroductoryTwoPlayerGame-Light/large/rebelsnowspeeder.gif",
@@ -42727,7 +50507,12 @@
       "gempId": "2_18",
       "side": "Light",
       "rarity": "C3",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Rebel Squad Leader",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/rebelsquadleader.gif",
@@ -42762,7 +50547,12 @@
       "gempId": "8_78",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "Rebel Strike Team / Garrison Destroyed",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/rebelstriketeam.gif",
@@ -42783,7 +50573,12 @@
       "id": 5839,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "Rebel Strike Team / Garrison Destroyed (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/rebelstriketeam.gif",
@@ -42805,7 +50600,12 @@
       "gempId": "2_19",
       "side": "Light",
       "rarity": "C1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•••Rebel Tech",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/rebeltech.gif",
@@ -42833,7 +50633,12 @@
       "id": 5840,
       "side": "Light",
       "rarity": "C1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•••Rebel Tech (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/rebeltech.gif",
@@ -42857,7 +50662,12 @@
       "gempId": "1_28",
       "side": "Light",
       "rarity": "C3",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Rebel Trooper",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/rebeltrooper.gif",
@@ -42893,7 +50703,12 @@
       "id": 5841,
       "side": "Light",
       "rarity": "C3",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Rebel Trooper (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/rebeltrooper.gif",
@@ -42917,7 +50732,12 @@
       "gempId": "106_6",
       "side": "Light",
       "rarity": "PM",
-      "set": "Official Tournament Sealed Deck",
+      "set": "106",
+      "printings": [
+        {
+          "set": "106"
+        }
+      ],
       "front": {
         "title": "Rebel Trooper Recruit",
         "imageUrl": "https://res.starwarsccg.org/cards/OfficialTournamentSealedDeck-Light/large/rebeltrooperrecruit.gif",
@@ -42946,7 +50766,12 @@
       "gempId": "211_56",
       "side": "Light",
       "rarity": "C1",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•••Rebel Trooper Reinforcements",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/rebeltrooperreinforcements.gif",
@@ -42971,7 +50796,12 @@
       "gempId": "207_11",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 7",
+      "set": "207",
+      "printings": [
+        {
+          "set": "207"
+        }
+      ],
       "front": {
         "title": "•Rebellions Are Built on Hope",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual7-Light/large/rebellionsarebuiltonhope.gif",
@@ -42993,7 +50823,12 @@
       "gempId": "4_58",
       "side": "Light",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Recoil In Fear",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/recoilinfear.gif",
@@ -43010,7 +50845,12 @@
       "gempId": "2_27",
       "side": "Light",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Rectenna",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/rectenna.gif",
@@ -43030,7 +50870,12 @@
       "gempId": "1_144",
       "side": "Light",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Red 1",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/red1.gif",
@@ -43069,7 +50914,12 @@
       "id": 5843,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Red 1 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/red1.gif",
@@ -43095,7 +50945,12 @@
       "gempId": "200_65",
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Red 1 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/red1.gif",
@@ -43144,7 +50999,12 @@
       "gempId": "7_145",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Red 10",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/red10.gif",
@@ -43185,7 +51045,12 @@
       "gempId": "2_70",
       "side": "Light",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Red 2",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/red2.gif",
@@ -43231,7 +51096,12 @@
       "gempId": "1_145",
       "side": "Light",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Red 3",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/red3.gif",
@@ -43272,7 +51142,12 @@
       "id": 5844,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Red 3 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/red3.gif",
@@ -43298,7 +51173,12 @@
       "gempId": "2_71",
       "side": "Light",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Red 5",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/red5.gif",
@@ -43350,7 +51230,12 @@
       "id": 5845,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Red 5 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/red5.gif",
@@ -43376,7 +51261,12 @@
       "gempId": "209_31",
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Red 5 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/red5.gif",
@@ -43403,7 +51293,12 @@
       "gempId": "2_72",
       "side": "Light",
       "rarity": "U1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Red 6",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/red6.gif",
@@ -43444,7 +51339,12 @@
       "gempId": "7_146",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Red 7",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/red7.gif",
@@ -43484,7 +51384,12 @@
       "gempId": "7_147",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Red 8",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/red8.gif",
@@ -43523,7 +51428,12 @@
       "id": 5847,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Red 8 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/red8.gif",
@@ -43551,7 +51461,12 @@
       "gempId": "200_66",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Red 8 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/red8.gif",
@@ -43587,7 +51502,12 @@
       "gempId": "7_148",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Red 9",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/red9.gif",
@@ -43627,7 +51547,12 @@
       "gempId": "1_29",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Red Leader",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/redleader.gif",
@@ -43663,7 +51588,12 @@
       "id": 5848,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Red Leader (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/redleader.gif",
@@ -43688,7 +51618,12 @@
       "gempId": "103_2",
       "side": "Light",
       "rarity": "PM",
-      "set": "Rebel Leader Pack",
+      "set": "103",
+      "printings": [
+        {
+          "set": "103"
+        }
+      ],
       "front": {
         "title": "•Red Leader In Red 1",
         "imageUrl": "https://res.starwarsccg.org/cards/RebelLeader-Light/large/redleaderinred1.gif",
@@ -43714,7 +51649,12 @@
       "gempId": "9_81",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Red Squadron 1",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/redsquadron1.gif",
@@ -43759,7 +51699,12 @@
       "gempId": "9_82",
       "side": "Light",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Red Squadron 4",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/redsquadron4.gif",
@@ -43799,7 +51744,12 @@
       "gempId": "208_28",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Red Squadron 6",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/redsquadron6.gif",
@@ -43838,7 +51788,12 @@
       "gempId": "9_83",
       "side": "Light",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Red Squadron 7",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/redsquadron7.gif",
@@ -43877,7 +51832,12 @@
       "id": 5850,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Red Squadron 7 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/redsquadron7.gif",
@@ -43904,7 +51864,12 @@
       "gempId": "106_7",
       "side": "Light",
       "rarity": "PM",
-      "set": "Official Tournament Sealed Deck",
+      "set": "106",
+      "printings": [
+        {
+          "set": "106"
+        }
+      ],
       "front": {
         "title": "•••Red Squadron X-wing",
         "imageUrl": "https://res.starwarsccg.org/cards/OfficialTournamentSealedDeck-Light/large/redsquadronxwing.gif",
@@ -43941,7 +51906,12 @@
       "id": 5851,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Redeemed Apprentice",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/redeemedapprentice.gif",
@@ -43958,7 +51928,12 @@
       "gempId": "5_87",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Redemption",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/redemption.gif",
@@ -43989,7 +51964,12 @@
       "id": 5852,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Redemption (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/redemption.gif",
@@ -44017,7 +51997,12 @@
       "gempId": "205_8",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 5",
+      "set": "205",
+      "printings": [
+        {
+          "set": "205"
+        }
+      ],
       "front": {
         "title": "•Redemption (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual5-Light/large/redemption.gif",
@@ -44048,7 +52033,12 @@
       "id": 5853,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Redemption: Command Post",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/redemptioncommandpost.gif",
@@ -44070,7 +52060,12 @@
       "gempId": "4_33",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Reflection",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/reflection.gif",
@@ -44094,7 +52089,12 @@
       "id": 5854,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Reflection (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/reflection.gif",
@@ -44113,7 +52113,12 @@
       "gempId": "209_17",
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Relatively Unprotected",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/relativelyunprotected.gif",
@@ -44129,7 +52134,12 @@
       "gempId": "2_28",
       "side": "Light",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Remote",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/remote.gif",
@@ -44154,7 +52164,12 @@
       "gempId": "7_123",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Rendezvous Point",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/rendezvouspoint.gif",
@@ -44180,7 +52195,12 @@
       "gempId": "5_66",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Rendezvous Point On Tatooine",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/rendezvouspointontatooine.gif",
@@ -44197,7 +52217,12 @@
       "gempId": "211_30",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "Rendezvous Point On Tatooine (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/rendezvouspointontatooine.gif",
@@ -44217,7 +52242,12 @@
       "gempId": "6_35",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Rennek",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/rennek.gif",
@@ -44244,7 +52274,12 @@
       "id": 5857,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Rennek (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/rennek.gif",
@@ -44268,7 +52303,12 @@
       "gempId": "14_28",
       "side": "Light",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Rep Been",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/repbeen.gif",
@@ -44306,7 +52346,12 @@
       "gempId": "4_34",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Report To Lord Vader",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/reporttolordvader.gif",
@@ -44331,7 +52376,12 @@
       "id": 5858,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "Republic At War / Aggressive Negotiations",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/republicatwar.gif",
@@ -44358,7 +52408,12 @@
       "id": 5859,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "Republic Corvette",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/republiccorvette.gif",
@@ -44387,7 +52442,12 @@
       "gempId": "12_93",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Republic Cruiser",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/republiccruiser.gif",
@@ -44424,7 +52484,12 @@
       "id": 5860,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "••Republic Gunship Wing",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/republicgunshipwing.gif",
@@ -44449,7 +52514,12 @@
       "id": 5861,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Republic Logistics",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/republiclogistics.gif",
@@ -44468,7 +52538,12 @@
       "id": 5862,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "Republic Starfighter",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/republicstarfighter.gif",
@@ -44496,7 +52571,12 @@
       "id": 5863,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "Republic Trooper With Blaster Rifle",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/republictrooperwithblasterrifle.gif",
@@ -44521,7 +52601,12 @@
       "gempId": "5_67",
       "side": "Light",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Rescue In The Clouds",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/rescueintheclouds.gif",
@@ -44539,7 +52624,12 @@
       "gempId": "209_22",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Rescue In The Clouds (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/rescueintheclouds.gif",
@@ -44558,7 +52648,12 @@
       "id": 5865,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Rescue On Geonosis",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/rescueongeonosis.gif",
@@ -44577,7 +52672,12 @@
       "gempId": "7_139",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Rescue The Princess / Sometimes I Amaze Even Myself",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/rescuetheprincess.gif",
@@ -44598,7 +52698,12 @@
       "id": 5867,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Restore Freedom To The Galaxy",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/restorefreedomtothegalaxy.gif",
@@ -44618,7 +52723,12 @@
       "gempId": "208_17",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Restore Freedom To The Galaxy",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/restorefreedomtothegalaxy.gif",
@@ -44634,7 +52744,12 @@
       "gempId": "1_38",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Restraining Bolt",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/restrainingbolt.gif",
@@ -44656,7 +52771,12 @@
       "gempId": "1_61",
       "side": "Light",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Restricted Deployment",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/restricteddeployment.gif",
@@ -44682,7 +52802,12 @@
       "gempId": "4_15",
       "side": "Light",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Retractable Arm",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/retractablearm.gif",
@@ -44703,7 +52828,12 @@
       "gempId": "1_107",
       "side": "Light",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Return Of A Jedi",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/returnofajedi.gif",
@@ -44735,7 +52865,12 @@
       "id": 5868,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Return Of A Jedi (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/returnofajedi.gif",
@@ -44751,7 +52886,12 @@
       "id": 5869,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "Return Of The Jedi",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/returnofthejedi.gif",
@@ -44771,7 +52911,12 @@
       "gempId": "12_67",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Reveal Ourselves To The Jedi",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/revealourselvestothejedi.gif",
@@ -44793,7 +52938,12 @@
       "gempId": "6_73",
       "side": "Light",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Revealed",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/revealed.gif",
@@ -44811,7 +52961,12 @@
       "gempId": "1_62",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Revolution",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/revolution.gif",
@@ -44842,7 +52997,12 @@
       "gempId": "204_9",
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Rey",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/rey.gif",
@@ -44880,7 +53040,12 @@
       "gempId": "204_9",
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Rey (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/OfficialAI-Light/large/rey.gif",
@@ -44906,7 +53071,12 @@
       "gempId": "209_10",
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Rey With Lightsaber",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/reywithlightsaber.gif",
@@ -44933,7 +53103,12 @@
       "gempId": "205_9",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 5",
+      "set": "205",
+      "printings": [
+        {
+          "set": "205"
+        }
+      ],
       "front": {
         "title": "•Ric in Queen's Royal Starship",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual5-Light/large/ricinqueensroyalstarship.gif",
@@ -44965,7 +53140,12 @@
       "gempId": "12_24",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Ric Olie",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/ricolie.gif",
@@ -45005,7 +53185,12 @@
       "gempId": "14_29",
       "side": "Light",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Ric Olie, Bravo Leader",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/ricoliebravoleader.gif",
@@ -45045,7 +53230,12 @@
       "gempId": "6_36",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•R'kik D'nec, Hero Of The Dune Sea",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/rkikdnecheroofthedunesea.gif",
@@ -45076,7 +53266,12 @@
       "gempId": "208_10",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•R'kik D'nec, Hero Of The Dune Sea (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/rkikdnecheroofthedunesea.gif",
@@ -45107,7 +53302,12 @@
       "gempId": "7_124",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Roche",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/roche.gif",
@@ -45142,7 +53342,12 @@
       "id": 5872,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Roche (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/roche.gif",
@@ -45163,7 +53368,12 @@
       "gempId": "3_66",
       "side": "Light",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Rogue 1",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/rogue1.gif",
@@ -45215,7 +53425,12 @@
       "gempId": "3_67",
       "side": "Light",
       "rarity": "R2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Rogue 2",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/rogue2.gif",
@@ -45253,7 +53468,12 @@
       "gempId": "3_68",
       "side": "Light",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Rogue 3",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/rogue3.gif",
@@ -45296,7 +53516,12 @@
       "gempId": "7_154",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Rogue 4",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/rogue4.gif",
@@ -45334,7 +53559,12 @@
       "gempId": "4_35",
       "side": "Light",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "<>Rogue Asteroid",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/rogueasteroid.gif",
@@ -45360,7 +53590,12 @@
       "gempId": "2_76",
       "side": "Light",
       "rarity": "C1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Rogue Bantha",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/roguebantha.gif",
@@ -45389,7 +53624,12 @@
       "gempId": "3_17",
       "side": "Light",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Rogue Gunner",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/roguegunner.gif",
@@ -45419,7 +53659,12 @@
       "id": 5873,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Rogue Insertion",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/rogueinsertion.gif",
@@ -45435,7 +53680,12 @@
       "gempId": "206_7",
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Set 6",
+      "set": "206",
+      "printings": [
+        {
+          "set": "206"
+        }
+      ],
       "front": {
         "title": "•Rogue One",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual6-Light/large/rogueone.gif",
@@ -45470,7 +53720,12 @@
       "id": 5874,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Rogue Squadron Tactics",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/roguesquadrontactics.gif",
@@ -45485,7 +53740,12 @@
       "id": 5875,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "Rogue Squadron X-wing",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/roguesquadronxwing.gif",
@@ -45511,7 +53771,12 @@
       "gempId": "3_18",
       "side": "Light",
       "rarity": "U2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Romas 'Lock' Navander",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/romaslocknavander.gif",
@@ -45538,7 +53803,12 @@
       "id": 5876,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Romas 'Lock' Navander (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/romaslocknavander.gif",
@@ -45563,7 +53833,12 @@
       "gempId": "8_26",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Romba",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/romba.gif",
@@ -45593,7 +53868,12 @@
       "gempId": "7_155",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Ronto",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/ronto.gif",
@@ -45616,7 +53896,12 @@
       "gempId": "209_11",
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Rose Tico",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/rosetico.gif",
@@ -45642,7 +53927,12 @@
       "gempId": "14_30",
       "side": "Light",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "Royal Naboo Security Officer",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/royalnaboosecurityofficer.gif",
@@ -45670,7 +53960,12 @@
       "gempId": "3_49",
       "side": "Light",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Rug Hug",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/rughug.gif",
@@ -45687,7 +53982,12 @@
       "id": 5878,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Rug Hug (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/rughug.gif",
@@ -45704,7 +54004,12 @@
       "gempId": "101_3",
       "side": "Light",
       "rarity": "PM",
-      "set": "Premiere Introductory Two Player Game",
+      "set": "101",
+      "printings": [
+        {
+          "set": "101"
+        }
+      ],
       "front": {
         "title": "•Run Luke, Run!",
         "imageUrl": "https://res.starwarsccg.org/cards/PremiereIntroductoryTwoPlayerGame-Light/large/runlukerun.gif",
@@ -45727,7 +54032,12 @@
       "id": 5879,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Run Luke, Run! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/runlukerun.gif",
@@ -45744,7 +54054,12 @@
       "gempId": "1_63",
       "side": "Light",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Rycar Ryjerd",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/rycarryjerd.gif",
@@ -45764,7 +54079,12 @@
       "id": 5880,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Rycar Ryjerd (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/rycarryjerd.gif",
@@ -45780,7 +54100,12 @@
       "gempId": "4_36",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Rycar's Run",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/rycarsrun.gif",
@@ -45802,7 +54127,12 @@
       "gempId": "7_40",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Ryle Torsyn",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/ryletorsyn.gif",
@@ -45830,7 +54160,12 @@
       "gempId": "7_75",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•S-foils",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/sfoils.gif",
@@ -45856,7 +54191,12 @@
       "id": 5881,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•S-foils (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/sfoils.gif",
@@ -45875,7 +54215,12 @@
       "gempId": "12_25",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Sabe",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/sabe.gif",
@@ -45914,7 +54259,12 @@
       "gempId": "207_9",
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Set 7",
+      "set": "207",
+      "printings": [
+        {
+          "set": "207"
+        }
+      ],
       "front": {
         "title": "•Sabine Wren",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual7-Light/large/sabinewren.gif",
@@ -45950,7 +54300,12 @@
       "gempId": "2_56",
       "side": "Light",
       "rarity": "U1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Sabotage",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/sabotage.gif",
@@ -45981,7 +54336,12 @@
       "id": 5882,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Sabotage (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/sabotage.gif",
@@ -46001,7 +54361,12 @@
       "gempId": "201_15",
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Sabotage (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Light/large/sabotage.gif",
@@ -46033,7 +54398,12 @@
       "gempId": "12_26",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Sache",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/sache.gif",
@@ -46065,7 +54435,12 @@
       "gempId": "6_37",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Saelt-Marae",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/saeltmarae.gif",
@@ -46090,7 +54465,12 @@
       "gempId": "1_64",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Sai'torr Kal Fas",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/saitorrkalfas.gif",
@@ -46111,7 +54491,12 @@
       "id": 5883,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Sai'torr Kal Fas (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/saitorrkalfas.gif",
@@ -46127,7 +54512,12 @@
       "gempId": "200_45",
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "Sai'torr Kal Fas (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/saitorrkalfas.gif",
@@ -46152,7 +54542,12 @@
       "gempId": "1_150",
       "side": "Light",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Sandcrawler",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/sandcrawler.gif",
@@ -46178,7 +54573,12 @@
       "id": 5884,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Sandcrawler (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/sandcrawler.gif",
@@ -46203,7 +54603,12 @@
       "gempId": "2_66",
       "side": "Light",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•••Sandcrawler: Loading Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/sandcrawlerloadingbay.gif",
@@ -46227,7 +54632,12 @@
       "gempId": "13_41",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Sando Aqua Monster",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/sandoaquamonster.gif",
@@ -46255,7 +54665,12 @@
       "gempId": "7_156",
       "side": "Light",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Sandspeeder",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/sandspeeder.gif",
@@ -46289,7 +54704,12 @@
       "gempId": "6_57",
       "side": "Light",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "<>Sandwhirl",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/sandwhirl.gif",
@@ -46316,7 +54736,12 @@
       "gempId": "2_20",
       "side": "Light",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•••Saurin",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/saurin.gif",
@@ -46346,7 +54771,12 @@
       "gempId": "209_12",
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Saw Gerrera",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/sawgerrera.gif",
@@ -46373,7 +54803,12 @@
       "gempId": "2_37",
       "side": "Light",
       "rarity": "U1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Scanner Techs",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/scannertechs.gif",
@@ -46393,7 +54828,12 @@
       "id": 5886,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Scanner Techs (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/scannertechs.gif",
@@ -46412,7 +54852,12 @@
       "gempId": "209_23",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Scarif",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/scarif.gif",
@@ -46434,7 +54879,12 @@
       "gempId": "209_24",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Scarif: Beach",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/scarifbeach.gif",
@@ -46456,7 +54906,12 @@
       "gempId": "209_25",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Scarif: Data Vault",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/scarifdatavault.gif",
@@ -46479,7 +54934,12 @@
       "gempId": "209_26",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Scarif: Landing Pad Nine (Docking Bay)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/scariflandingpadnine.gif",
@@ -46502,7 +54962,12 @@
       "gempId": "209_27",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Scarif: Turbolift Complex",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/scarifturboliftcomplex.gif",
@@ -46526,7 +54991,12 @@
       "gempId": "1_108",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Scomp Link Access",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/scomplinkaccess.gif",
@@ -46554,7 +55024,12 @@
       "id": 5892,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "Scomp Link Access (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/scomplinkaccess.gif",
@@ -46571,7 +55046,12 @@
       "id": 5893,
       "side": "Light",
       "rarity": "C1",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Scoundrel's Bravado",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/scoundrelsbravado.gif",
@@ -46589,7 +55069,12 @@
       "id": 5894,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Scoundrel's Charm",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/scoundrelscharm.gif",
@@ -46607,7 +55092,12 @@
       "id": 5895,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Scoundrel's Ingenuity",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/scoundrelsingenuity.gif",
@@ -46625,7 +55115,12 @@
       "id": 5896,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Scoundrel's Luck",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/scoundrelsluck.gif",
@@ -46641,7 +55136,12 @@
       "gempId": "4_37",
       "side": "Light",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Scramble",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/scramble.gif",
@@ -46667,7 +55167,12 @@
       "gempId": "7_74",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Scrambled Transmission",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/scrambledtransmission.gif",
@@ -46691,7 +55196,12 @@
       "id": 5897,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Scrambled Transmission (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/scrambledtransmission.gif",
@@ -46710,7 +55220,12 @@
       "gempId": "7_52",
       "side": "Light",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Scurrier",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/scurrier.gif",
@@ -46746,7 +55261,12 @@
       "gempId": "12_46",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Secure Route",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/secureroute.gif",
@@ -46770,7 +55290,12 @@
       "id": 5898,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Security Breach",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/securitybreach.gif",
@@ -46789,7 +55314,12 @@
       "gempId": "12_47",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Security Control",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/securitycontrol.gif",
@@ -46829,7 +55359,12 @@
       "gempId": "211_2",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•See You Around, Kid",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/seeyouaroundkid.gif",
@@ -46849,7 +55384,12 @@
       "gempId": "110_3",
       "side": "Light",
       "rarity": "PM",
-      "set": "Enhanced Jabba's Palace",
+      "set": "110",
+      "printings": [
+        {
+          "set": "110"
+        }
+      ],
       "front": {
         "title": "•See-Threepio",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedJabbasPalace-Light/large/seethreepio.gif",
@@ -46880,7 +55420,12 @@
       "id": 5900,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•See-Threepio (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/seethreepio.gif",
@@ -46906,7 +55451,12 @@
       "gempId": "112_7",
       "side": "Light",
       "rarity": "PM",
-      "set": "Jabba's Palace Sealed Deck",
+      "set": "112",
+      "printings": [
+        {
+          "set": "112"
+        }
+      ],
       "front": {
         "title": "•Seeking An Audience",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalaceSealedDeck-Light/large/seekinganaudience.gif",
@@ -46952,7 +55502,12 @@
       "id": 5901,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Seeking An Audience (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/seekinganaudience.gif",
@@ -46972,7 +55527,12 @@
       "gempId": "201_9",
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Seeking An Audience (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Light/large/seekinganaudience.gif",
@@ -47040,7 +55600,12 @@
       "gempId": "12_27",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Sei Taria",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/seitaria.gif",
@@ -47076,7 +55641,12 @@
       "gempId": "14_35",
       "side": "Light",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Senate Hovercam",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/senatehovercam.gif",
@@ -47101,7 +55671,12 @@
       "id": 5902,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Senator Jar Jar Binks",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/senatorjarjarbinks.gif",
@@ -47128,7 +55703,12 @@
       "id": 5903,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Senator Jar Jar Binks (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/senatorjarjarbinksai.gif",
@@ -47155,7 +55735,12 @@
       "id": 5904,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Senator Leia Organa",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/senatorleiaorgana.gif",
@@ -47180,7 +55765,12 @@
       "id": 5905,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Senator Mon Mothma",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/senatormonmothma.gif",
@@ -47206,7 +55796,12 @@
       "gempId": "204_10",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Senator Mon Mothma",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/senatormonmothma.gif",
@@ -47244,7 +55839,12 @@
       "id": 5906,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Senator Padme Amidala",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/senatorpadmeamidala.gif",
@@ -47270,7 +55870,12 @@
       "gempId": "12_28",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Senator Palpatine",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/senatorpalpatine.gif",
@@ -47305,7 +55910,12 @@
       "gempId": "12_29",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Senator Palpatine (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/senatorpalpatineai.gif",
@@ -47330,7 +55940,12 @@
       "gempId": "12_68",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "Sense",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/sense.gif",
@@ -47372,7 +55987,12 @@
       "gempId": "1_109",
       "side": "Light",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Sense",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/sense.gif",
@@ -47411,7 +56031,12 @@
       "gempId": "10_21",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "Sense & Recoil In Fear",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Light/large/sense&recoilinfear.gif",
@@ -47442,7 +56067,12 @@
       "gempId": "2_29",
       "side": "Light",
       "rarity": "U2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Sensor Panel",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/sensorpanel.gif",
@@ -47466,7 +56096,12 @@
       "gempId": "8_27",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Sergeant Brooks Carlson",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/sergeantbrookscarlson.gif",
@@ -47497,7 +56132,12 @@
       "gempId": "8_28",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Sergeant Bruckman",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/sergeantbruckman.gif",
@@ -47529,7 +56169,12 @@
       "gempId": "6_38",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Sergeant Doallyn",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/sergeantdoallyn.gif",
@@ -47562,7 +56207,12 @@
       "id": 5908,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Sergeant Doallyn (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/sergeantdoallyn.gif",
@@ -47590,7 +56240,12 @@
       "gempId": "7_41",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Sergeant Edian",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/sergeantedian.gif",
@@ -47621,7 +56276,12 @@
       "id": 5909,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Sergeant Edian (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/sergeantedian.gif",
@@ -47645,7 +56305,12 @@
       "gempId": "7_42",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Sergeant Hollis",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/sergeanthollis.gif",
@@ -47678,7 +56343,12 @@
       "gempId": "8_29",
       "side": "Light",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Sergeant Junkin",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/sergeantjunkin.gif",
@@ -47709,7 +56379,12 @@
       "gempId": "6_39",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Shasa Tiel",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/shasatiel.gif",
@@ -47739,7 +56414,12 @@
       "gempId": "3_19",
       "side": "Light",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Shawn Valdez",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/shawnvaldez.gif",
@@ -47774,7 +56454,12 @@
       "gempId": "1_30",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•••Shistavanen Wolfman",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/shistavanenwolfman.gif",
@@ -47809,7 +56494,12 @@
       "gempId": "11_12",
       "side": "Light",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Shmi Skywalker",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/shmiskywalker.gif",
@@ -47849,7 +56539,12 @@
       "gempId": "5_68",
       "side": "Light",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Shocking Information",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/shockinginformation.gif",
@@ -47878,7 +56573,12 @@
       "gempId": "10_22",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Shocking Information & •Grimtaash",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Light/large/shockinginformation&grimtaash.gif",
@@ -47901,7 +56601,12 @@
       "id": 5910,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Shocking Information (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/shockinginformation.gif",
@@ -47921,7 +56626,12 @@
       "gempId": "4_59",
       "side": "Light",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Shoo! Shoo!",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/shooshoo.gif",
@@ -47944,7 +56654,12 @@
       "id": 5911,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Shoo! Shoo! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/shooshoo.gif",
@@ -47964,7 +56679,12 @@
       "gempId": "6_40",
       "side": "Light",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Sic-Six",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/sicsix.gif",
@@ -47990,7 +56710,12 @@
       "id": 5912,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•Simple Tricks And Nonsense",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Light/large/simpletricksandnonsense.gif",
@@ -48011,7 +56736,12 @@
       "gempId": "200_28",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 0",
+      "set": "200d",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Simple Tricks And Nonsense",
         "imageUrl": "https://res.starwarsccg.org/cards/ResetDS-Light/large/simpletricksandnonsense.gif",
@@ -48037,7 +56767,12 @@
       "gempId": "13_42",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Sio Bibble",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/siobibble.gif",
@@ -48066,7 +56801,12 @@
       "gempId": "4_79",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Size Matters Not",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/sizemattersnot.gif",
@@ -48084,7 +56824,12 @@
       "gempId": "6_88",
       "side": "Light",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Skiff",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/skiff.gif",
@@ -48110,7 +56855,12 @@
       "gempId": "6_74",
       "side": "Light",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Skull",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/skull.gif",
@@ -48135,7 +56885,12 @@
       "id": 5913,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Skull (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/skull.gif",
@@ -48155,7 +56910,12 @@
       "gempId": "1_110",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Skywalkers",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/skywalkers.gif",
@@ -48181,7 +56941,12 @@
       "gempId": "7_76",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Slayn & Korpil Facilities",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/slaynkorpilfacilities.gif",
@@ -48206,7 +56971,12 @@
       "gempId": "7_102",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Slight Weapons Malfunction",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/slightweaponsmalfunction.gif",
@@ -48227,7 +56997,12 @@
       "gempId": "5_69",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Smoke Screen",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/smokescreen.gif",
@@ -48251,7 +57026,12 @@
       "gempId": "4_38",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Smuggler's Blues",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/smugglersblues.gif",
@@ -48275,7 +57055,12 @@
       "id": 5914,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Smuggler's Blues (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/smugglersblues.gif",
@@ -48294,7 +57079,12 @@
       "gempId": "6_41",
       "side": "Light",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Snivvian",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/snivvian.gif",
@@ -48325,7 +57115,12 @@
       "gempId": "3_69",
       "side": "Light",
       "rarity": "U2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Snowspeeder",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/snowspeeder.gif",
@@ -48358,7 +57153,12 @@
       "id": 5915,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Snowspeeder Garrison",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/snowspeedergarrison.gif",
@@ -48383,7 +57183,12 @@
       "id": 5916,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•So This Is How Liberty Dies",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/sothisishowlibertydies.gif",
@@ -48403,7 +57208,12 @@
       "gempId": "204_11",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Solo",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/solo.gif",
@@ -48447,7 +57257,12 @@
       "gempId": "1_111",
       "side": "Light",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Solo Han",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/solohan.gif",
@@ -48467,7 +57282,12 @@
       "id": 5917,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Solo Han (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/solohan.gif",
@@ -48484,7 +57304,12 @@
       "gempId": "2_38",
       "side": "Light",
       "rarity": "C2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Solomahal",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/solomahal.gif",
@@ -48504,7 +57329,12 @@
       "id": 5918,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Solomahal (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/solomahal.gif",
@@ -48523,7 +57353,12 @@
       "gempId": "6_75",
       "side": "Light",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Someone Who Loves You",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/someonewholovesyou.gif",
@@ -48543,7 +57378,12 @@
       "gempId": "5_70",
       "side": "Light",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Somersault",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/somersault.gif",
@@ -48564,7 +57404,12 @@
       "gempId": "4_1",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Son Of Skywalker",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/sonofskywalker.gif",
@@ -48617,7 +57462,12 @@
       "id": 5919,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Son Of Skywalker (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/sonofskywalker.gif",
@@ -48646,7 +57496,12 @@
       "gempId": "1_151",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "SoroSuub V-35 Landspeeder",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/sorosuubv35landspeeder.gif",
@@ -48671,7 +57526,12 @@
       "gempId": "2_57",
       "side": "Light",
       "rarity": "U1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Sorry About The Mess",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/sorryaboutthemess.gif",
@@ -48694,7 +57554,12 @@
       "gempId": "10_23",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Sorry About The Mess & •Blaster Proficiency",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Light/large/sorryaboutthemess&blasterproficiency.gif",
@@ -48722,7 +57587,12 @@
       "gempId": "7_43",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Soth Petikkin",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/sothpetikkin.gif",
@@ -48793,7 +57663,12 @@
       "gempId": "8_59",
       "side": "Light",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Sound The Attack",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/soundtheattack.gif",
@@ -48826,7 +57701,12 @@
       "gempId": "4_6",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "<>Space Slug",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/spaceslug.gif",
@@ -48854,7 +57734,12 @@
       "gempId": "7_125",
       "side": "Light",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "<>Spaceport City",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/spaceportcity.gif",
@@ -48879,7 +57764,12 @@
       "gempId": "7_126",
       "side": "Light",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "<>Spaceport Docking Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/spaceportdockingbay.gif",
@@ -48909,7 +57799,12 @@
       "id": 5920,
       "side": "Light",
       "rarity": "F",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "<>Spaceport Scoundrels Guild",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/spaceportscoundrelsguild.gif",
@@ -48931,7 +57826,12 @@
       "gempId": "1_112",
       "side": "Light",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•••Spaceport Speeders",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/spaceportspeeders.gif",
@@ -48949,7 +57849,12 @@
       "gempId": "7_127",
       "side": "Light",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "<>Spaceport Street",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/spaceportstreet.gif",
@@ -48974,7 +57879,12 @@
       "gempId": "12_69",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Speak With The Jedi Council",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/speakwiththejedicouncil.gif",
@@ -49022,7 +57932,12 @@
       "gempId": "1_65",
       "side": "Light",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Special Modifications",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/specialmodifications.gif",
@@ -49045,7 +57960,12 @@
       "id": 5921,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Special Modifications (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/specialmodifications.gif",
@@ -49061,7 +57981,12 @@
       "gempId": "8_83",
       "side": "Light",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "Speeder Bike",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/speederbike.gif",
@@ -49087,7 +58012,12 @@
       "gempId": "7_149",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Spiral",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/spiral.gif",
@@ -49122,7 +58052,12 @@
       "gempId": "9_39",
       "side": "Light",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Squadron Assignments",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/squadronassignments.gif",
@@ -49147,7 +58082,12 @@
       "gempId": "211_52",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Squadron Assignments (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/squadronassignments.gif",
@@ -49166,7 +58106,12 @@
       "gempId": "9_40",
       "side": "Light",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "Staging Areas",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/stagingareas.gif",
@@ -49192,7 +58137,12 @@
       "gempId": "7_103",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Star Destroyer!",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/stardestroyer.gif",
@@ -49210,7 +58160,12 @@
       "gempId": "209_18",
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Stardust",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/stardust.gif",
@@ -49226,7 +58181,12 @@
       "gempId": "4_60",
       "side": "Light",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Starship Levitation",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/starshiplevitation.gif",
@@ -49249,7 +58209,12 @@
       "id": 5924,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Starship Levitation (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/starshiplevitation.gif",
@@ -49269,7 +58234,12 @@
       "gempId": "200_56",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "Starship Levitation (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/starshiplevitation.gif",
@@ -49293,7 +58263,12 @@
       "gempId": "12_70",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Stay Here, Where It's Safe",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/stayherewhereitssafe.gif",
@@ -49314,7 +58289,12 @@
       "gempId": "7_104",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Stay Sharp!",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/staysharp.gif",
@@ -49332,7 +58312,12 @@
       "gempId": "7_105",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Steady Aim",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/steadyaim.gif",
@@ -49350,7 +58335,12 @@
       "gempId": "14_36",
       "side": "Light",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Steady, Steady",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/steadysteady.gif",
@@ -49374,7 +58364,12 @@
       "gempId": "203_14",
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•Stolen Data Tapes",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Light/large/stolendatatapes.gif",
@@ -49396,7 +58391,12 @@
       "gempId": "204_34",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Stolen First Order TIE Fighter",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/stolenfirstordertiefighter.gif",
@@ -49423,7 +58423,12 @@
       "gempId": "4_39",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "••Stone Pile",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/stonepile.gif",
@@ -49445,7 +58450,12 @@
       "gempId": "6_76",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Strangle",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/strangle.gif",
@@ -49466,7 +58476,12 @@
       "gempId": "13_43",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Strike Blocked",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/strikeblocked.gif",
@@ -49494,7 +58509,12 @@
       "gempId": "9_41",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Strike Planning",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/strikeplanning.gif",
@@ -49535,7 +58555,12 @@
       "gempId": "9_42",
       "side": "Light",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Strikeforce",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/strikeforce.gif",
@@ -49557,7 +58582,12 @@
       "id": 5926,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Strikeforce (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/strikeforce.gif",
@@ -49577,7 +58607,12 @@
       "gempId": "200_46",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Strikeforce (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/strikeforce.gif",
@@ -49605,7 +58640,12 @@
       "id": 5927,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Strong Is Vader",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/strongisvader.gif",
@@ -49623,7 +58663,12 @@
       "gempId": "112_8",
       "side": "Light",
       "rarity": "PM",
-      "set": "Jabba's Palace Sealed Deck",
+      "set": "112",
+      "printings": [
+        {
+          "set": "112"
+        }
+      ],
       "front": {
         "title": "Stun Blaster",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalaceSealedDeck-Light/large/stunblaster.gif",
@@ -49647,7 +58692,12 @@
       "gempId": "9_60",
       "side": "Light",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Sullust",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/sullust.gif",
@@ -49678,7 +58728,12 @@
       "gempId": "9_43",
       "side": "Light",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Superficial Damage",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/superficialdamage.gif",
@@ -49704,7 +58759,12 @@
       "id": 5928,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Superficial Damage (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/superficialdamage.gif",
@@ -49723,7 +58783,12 @@
       "gempId": "7_106",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Suppressive Fire",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/suppressivefire.gif",
@@ -49741,7 +58806,12 @@
       "gempId": "208_21",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Suppressive Fire (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/suppressivefire.gif",
@@ -49758,7 +58828,12 @@
       "id": 5929,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Supreme Chancellor Palpatine",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/supremechancellorpalpatine.gif",
@@ -49784,7 +58859,12 @@
       "gempId": "12_30",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Supreme Chancellor Valorum",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/supremechancellorvalorum.gif",
@@ -49817,7 +58897,12 @@
       "gempId": "12_31",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Supreme Chancellor Valorum (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/supremechancellorvalorumai.gif",
@@ -49841,7 +58926,12 @@
       "id": 5931,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Supreme Chancellor Valorum (AI) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/supremechancellorvalorumai.gif",
@@ -49865,7 +58955,12 @@
       "id": 5932,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Supreme Chancellor Valorum (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/supremechancellorvalorum.gif",
@@ -49890,7 +58985,12 @@
       "gempId": "3_80",
       "side": "Light",
       "rarity": "R2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Surface Defense Cannon",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/surfacedefensecannon.gif",
@@ -49915,7 +59015,12 @@
       "gempId": "1_113",
       "side": "Light",
       "rarity": "C1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Surprise Assault",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/surpriseassault.gif",
@@ -49942,7 +59047,12 @@
       "gempId": "8_60",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "Surprise Counter Assault",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/surprisecounterassault.gif",
@@ -49974,7 +59084,12 @@
       "gempId": "5_71",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Surreptitious Glance",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/surreptitiousglance.gif",
@@ -49994,7 +59109,12 @@
       "id": 5933,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Surreptitious Glance (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/surreptitiousglance.gif",
@@ -50014,7 +59134,12 @@
       "gempId": "2_81",
       "side": "Light",
       "rarity": "R2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "SW-4 Ion Cannon",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/sw4ioncannon.gif",
@@ -50040,7 +59165,12 @@
       "gempId": "7_128",
       "side": "Light",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "<>Swamp",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/swamp.gif",
@@ -50073,7 +59203,12 @@
       "gempId": "5_72",
       "side": "Light",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•••Swing-And-A-Miss",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/swingandamiss.gif",
@@ -50101,7 +59236,12 @@
       "gempId": "7_107",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "T-47 Battle Formation",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/t47battleformation.gif",
@@ -50126,7 +59266,12 @@
       "gempId": "1_160",
       "side": "Light",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Tagge Seeker",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/taggeseeker.gif",
@@ -50150,7 +59295,12 @@
       "gempId": "209_13",
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Taidu Sefla",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/taidusefla.gif",
@@ -50174,7 +59324,12 @@
       "gempId": "8_61",
       "side": "Light",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Take The Initiative",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/taketheinitiative.gif",
@@ -50196,7 +59351,12 @@
       "gempId": "14_44",
       "side": "Light",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Take This!",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/takethis.gif",
@@ -50225,7 +59385,12 @@
       "gempId": "9_5",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Taking Them With Us",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/takingthemwithus.gif",
@@ -50244,7 +59409,12 @@
       "id": 5935,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Taking Them With Us (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/takingthemwithus.gif",
@@ -50262,7 +59432,12 @@
       "gempId": "211_37",
       "side": "Light",
       "rarity": "C1",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Takodana",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/takodana.gif",
@@ -50285,7 +59460,12 @@
       "gempId": "211_38",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Takodana: Maz's Castle",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/takodanamazscastle.gif",
@@ -50308,7 +59488,12 @@
       "gempId": "9_84",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Tala 1",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/tala1.gif",
@@ -50344,7 +59529,12 @@
       "gempId": "9_85",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Tala 2",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/tala2.gif",
@@ -50380,7 +59570,12 @@
       "gempId": "211_35",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Tallie Lintra In Blue 1",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/tallielintrainblue1.gif",
@@ -50409,7 +59604,12 @@
       "gempId": "10_24",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Talon Karrde",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Light/large/talonkarrde.gif",
@@ -50443,7 +59643,12 @@
       "id": 5939,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Talon Karrde (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/talonkarrde.gif",
@@ -50471,7 +59676,12 @@
       "gempId": "1_31",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•••Talz",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/talz.gif",
@@ -50501,7 +59711,12 @@
       "gempId": "3_20",
       "side": "Light",
       "rarity": "U2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Tamizander Rey",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/tamizanderrey.gif",
@@ -50528,7 +59743,12 @@
       "id": 5940,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Tamizander Rey (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/tamizanderrey.gif",
@@ -50553,7 +59773,12 @@
       "gempId": "6_42",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Tamtel Skreej",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/tamtelskreej.gif",
@@ -50604,7 +59829,12 @@
       "id": 5941,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Tamtel Skreej (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/tamtelskreej.gif",
@@ -50633,7 +59863,12 @@
       "gempId": "2_73",
       "side": "Light",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Tantive IV",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/tantiveiv.gif",
@@ -50667,7 +59902,12 @@
       "id": 5942,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Tantive IV (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/tantiveiv.gif",
@@ -50695,7 +59935,12 @@
       "gempId": "201_19",
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Tantive IV (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Light/large/tantiveiv.gif",
@@ -50731,7 +59976,12 @@
       "gempId": "6_43",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Tanus Spijek",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/tanusspijek.gif",
@@ -50763,7 +60013,12 @@
       "id": 5943,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Tanus Spijek (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/tanusspijek.gif",
@@ -50786,7 +60041,12 @@
       "id": 5944,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Tarfful, Wookiee Insurgent",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/tarffulwookieeinsurgent.gif",
@@ -50811,7 +60071,12 @@
       "gempId": "1_39",
       "side": "Light",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Targeting Computer",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/targetingcomputer.gif",
@@ -50831,7 +60096,12 @@
       "gempId": "1_161",
       "side": "Light",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Tarkin Seeker",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/tarkinseeker.gif",
@@ -50855,7 +60125,12 @@
       "gempId": "12_84",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Tatooine",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/tatooine.gif",
@@ -50891,7 +60166,12 @@
       "gempId": "1_127",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Tatooine",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/tatooine.gif",
@@ -50923,7 +60203,12 @@
       "gempId": "7_77",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Tatooine Celebration",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/tatooinecelebration.gif",
@@ -50949,7 +60234,12 @@
       "gempId": "1_40",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Tatooine Utility Belt",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/tatooineutilitybelt.gif",
@@ -50968,7 +60258,12 @@
       "id": 5945,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Tatooine Utility Belt (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/tatooineutilitybelt.gif",
@@ -50985,7 +60280,12 @@
       "gempId": "7_129",
       "side": "Light",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Anchorhead",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/tatooineanchorhead.gif",
@@ -51014,7 +60314,12 @@
       "gempId": "7_130",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Beggar's Canyon",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/tatooinebeggarscanyon.gif",
@@ -51046,7 +60351,12 @@
       "gempId": "1_128",
       "side": "Light",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Cantina",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/tatooinecantina.gif",
@@ -51075,7 +60385,12 @@
       "id": 5946,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Cantina (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/tatooinecantina.gif",
@@ -51095,7 +60410,12 @@
       "gempId": "11_42",
       "side": "Light",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Tatooine: City Outskirts",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/tatooinecityoutskirts.gif",
@@ -51155,7 +60475,12 @@
       "gempId": "6_85",
       "side": "Light",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•••Tatooine: Desert",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/tatooinedesert.gif",
@@ -51185,7 +60510,12 @@
       "gempId": "1_129",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Docking Bay 94",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/tatooinedockingbay94.gif",
@@ -51221,7 +60551,12 @@
       "gempId": "1_130",
       "side": "Light",
       "rarity": "C1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Dune Sea",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/tatooinedunesea.gif",
@@ -51250,7 +60585,12 @@
       "gempId": "6_86",
       "side": "Light",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Hutt Canyon",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/tatooinehuttcanyon.gif",
@@ -51282,7 +60622,12 @@
       "gempId": "112_9",
       "side": "Light",
       "rarity": "PM",
-      "set": "Jabba's Palace Sealed Deck",
+      "set": "112",
+      "printings": [
+        {
+          "set": "112"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Hutt Trade Route (Desert)",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalaceSealedDeck-Light/large/tatooinehutttraderoutedesert.gif",
@@ -51311,7 +60656,12 @@
       "gempId": "7_131",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Jabba's Palace",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/tatooinejabbaspalace.gif",
@@ -51344,7 +60694,12 @@
       "gempId": "1_131",
       "side": "Light",
       "rarity": "C1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Jawa Camp",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/tatooinejawacamp.gif",
@@ -51373,7 +60728,12 @@
       "id": 5947,
       "side": "Light",
       "rarity": "C1",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Jawa Camp (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/tatooinejawacamp.gif",
@@ -51393,7 +60753,12 @@
       "gempId": "7_132",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Jawa Canyon",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/tatooinejawacanyon.gif",
@@ -51423,7 +60788,12 @@
       "gempId": "106_8",
       "side": "Light",
       "rarity": "PM",
-      "set": "Official Tournament Sealed Deck",
+      "set": "106",
+      "printings": [
+        {
+          "set": "106"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Jundland Wastes",
         "imageUrl": "https://res.starwarsccg.org/cards/OfficialTournamentSealedDeck-Light/large/tatooinejundlandwastes.gif",
@@ -51457,7 +60827,12 @@
       "gempId": "1_132",
       "side": "Light",
       "rarity": "C1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Lars' Moisture Farm",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/tatooinelarsmoisturefarm.gif",
@@ -51488,7 +60863,12 @@
       "id": 5948,
       "side": "Light",
       "rarity": "C1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Lars' Moisture Farm (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/tatooinelarsmoisturefarm.gif",
@@ -51509,7 +60889,12 @@
       "gempId": "205_6",
       "side": "Light",
       "rarity": "C1",
-      "set": "Virtual Set 5",
+      "set": "205",
+      "printings": [
+        {
+          "set": "205"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Lars' Moisture Farm (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual5-Light/large/tatooinelarsmoisturefarm.gif",
@@ -51541,7 +60926,12 @@
       "gempId": "12_85",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Marketplace",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/tatooinemarketplace.gif",
@@ -51572,7 +60962,12 @@
       "gempId": "1_133",
       "side": "Light",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Mos Eisley",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/tatooinemoseisley.gif",
@@ -51608,7 +61003,12 @@
       "gempId": "11_43",
       "side": "Light",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Mos Espa",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/tatooinemosespa.gif",
@@ -51639,7 +61039,12 @@
       "gempId": "12_86",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Mos Espa Docking Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/tatooinemosespadockingbay.gif",
@@ -51675,7 +61080,12 @@
       "gempId": "1_134",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Obi-Wan's Hut",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/tatooineobiwanshut.gif",
@@ -51700,7 +61110,12 @@
       "id": 5949,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Obi-Wan's Hut (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/tatooineobiwanshut.gif",
@@ -51720,7 +61135,12 @@
       "gempId": "11_44",
       "side": "Light",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Podrace Arena",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/tatooinepodracearena.gif",
@@ -51751,7 +61171,12 @@
       "gempId": "11_45",
       "side": "Light",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Podracer Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/tatooinepodracerbay.gif",
@@ -51784,7 +61209,12 @@
       "id": 5950,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Queen's Landing Site",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/tatooinequeenslandingsite.gif",
@@ -51806,7 +61236,12 @@
       "gempId": "11_46",
       "side": "Light",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Slave Quarters",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/tatooineslavequarters.gif",
@@ -51833,7 +61268,12 @@
       "gempId": "7_133",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Tosche Station",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/tatooinetoschestation.gif",
@@ -51862,7 +61302,12 @@
       "gempId": "12_87",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Tatooine: Watto's Junkyard",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/tatooinewattosjunkyard.gif",
@@ -51893,7 +61338,12 @@
       "gempId": "3_70",
       "side": "Light",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Tauntaun",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/tauntaun.gif",
@@ -51915,7 +61365,12 @@
       "gempId": "3_38",
       "side": "Light",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Tauntaun Bones",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/tauntaunbones.gif",
@@ -51936,7 +61391,12 @@
       "id": 5951,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Tauntaun Bones (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/tauntaunbones.gif",
@@ -51955,7 +61415,12 @@
       "gempId": "3_21",
       "side": "Light",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•••Tauntaun Handler",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/tauntaunhandler.gif",
@@ -51987,7 +61452,12 @@
       "id": 5952,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•••Tauntaun Handler (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/tauntaunhandler.gif",
@@ -52012,7 +61482,12 @@
       "gempId": "7_44",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Tawss Khaa",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/tawsskhaa.gif",
@@ -52039,7 +61514,12 @@
       "id": 5953,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Tawss Khaa (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/tawsskhaa.gif",
@@ -52066,7 +61546,12 @@
       "gempId": "102_5",
       "side": "Light",
       "rarity": "PM",
-      "set": "Jedi Pack",
+      "set": "102",
+      "printings": [
+        {
+          "set": "102"
+        }
+      ],
       "front": {
         "title": "•Tedn Dahai",
         "imageUrl": "https://res.starwarsccg.org/cards/JediPack-Light/large/tedndahai.gif",
@@ -52097,7 +61582,12 @@
       "gempId": "8_30",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Teebo",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/teebo.gif",
@@ -52124,7 +61614,12 @@
       "gempId": "208_11",
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Temmin 'Snap' Wexley",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/temminsnapwexley.gif",
@@ -52150,7 +61645,12 @@
       "id": 5954,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Temporary Foothold",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/temporaryfoothold.gif",
@@ -52169,7 +61669,12 @@
       "gempId": "9_29",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Ten Numb",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/tennumb.gif",
@@ -52199,7 +61704,12 @@
       "id": 5955,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Ten Numb (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/tennumb.gif",
@@ -52223,7 +61733,12 @@
       "gempId": "12_32",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Tendau Bendon",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/tendaubendon.gif",
@@ -52259,7 +61774,12 @@
       "gempId": "6_44",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Tessek",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/tessek.gif",
@@ -52289,7 +61809,12 @@
       "gempId": "1_114",
       "side": "Light",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Thank The Maker",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/thankthemaker.gif",
@@ -52309,7 +61834,12 @@
       "gempId": "8_41",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•That's One",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/thatsone.gif",
@@ -52333,7 +61863,12 @@
       "id": 5956,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•That's One (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/thatsone.gif",
@@ -52352,7 +61887,12 @@
       "gempId": "1_115",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "The Bith Shuffle",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/thebithshuffle.gif",
@@ -52370,7 +61910,12 @@
       "gempId": "10_25",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "The Bith Shuffle & Desperate Reach",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Light/large/thebithshuffle&desperatereach.gif",
@@ -52391,7 +61936,12 @@
       "gempId": "11_21",
       "side": "Light",
       "rarity": "C",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•The Camp",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/thecamp.gif",
@@ -52414,7 +61964,12 @@
       "id": 5957,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•The Camp (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/thecamp.gif",
@@ -52433,7 +61988,12 @@
       "id": 5958,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•The Dark Side is Growing",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/thedarksideisgrowing.gif",
@@ -52453,7 +62013,12 @@
       "gempId": "206_8",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 6",
+      "set": "206",
+      "printings": [
+        {
+          "set": "206"
+        }
+      ],
       "front": {
         "title": "•The Falcon",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual6-Light/large/thefalcon.gif",
@@ -52506,7 +62071,12 @@
       "gempId": "204_35",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•The Falcon, Junkyard Garbage/•The Falcon, Junkyard Garbage",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/thefalconjunkyardgarbagefront.gif",
@@ -52555,7 +62125,12 @@
       "gempId": "3_39",
       "side": "Light",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•The First Transport Is Away!",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/thefirsttransportisaway.gif",
@@ -52579,7 +62154,12 @@
       "id": 5960,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•The First Transport Is Away! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/thefirsttransportisaway.gif",
@@ -52599,7 +62179,12 @@
       "gempId": "1_116",
       "side": "Light",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "The Force Is Strong With This One",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/theforceisstrongwiththisone.gif",
@@ -52619,7 +62204,12 @@
       "gempId": "203_18",
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "The Force Is Strong With This One (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Light/large/theforceisstrongwiththisone.gif",
@@ -52642,7 +62232,12 @@
       "gempId": "211_36",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "The Galaxy May Need A Legend / We Need Luke Skywalker",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/thegalaxymayneedalegend.gif",
@@ -52670,7 +62265,12 @@
       "gempId": "204_22",
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•The Garbage Will Do",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/thegarbagewilldo.gif",
@@ -52690,7 +62290,12 @@
       "gempId": "12_48",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•The Gravest Of Circumstances",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/thegravestofcircumstances.gif",
@@ -52724,7 +62329,12 @@
       "gempId": "12_89",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "The Hyperdrive Generator's Gone / We'll Need A New One",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/thehyperdrivegeneratorsgone.gif",
@@ -52752,7 +62362,12 @@
       "gempId": "210_25",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "The Hyperdrive Generator's Gone / We'll Need A New One (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Light/large/thehyperdrivegeneratorsgone.gif",
@@ -52782,7 +62397,12 @@
       "gempId": "7_78",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•The Planet That It's Farthest From",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/theplanetthatitsfarthestfrom.gif",
@@ -52803,7 +62423,12 @@
       "id": 5964,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•The Planet That It's Farthest From (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/theplanetthatitsfarthestfrom.gif",
@@ -52822,7 +62447,12 @@
       "gempId": "4_40",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•The Professor",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/theprofessor.gif",
@@ -52846,7 +62476,12 @@
       "id": 5965,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•The Professor (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Light/large/theprofessor.gif",
@@ -52867,7 +62502,12 @@
       "gempId": "200_29",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200d",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•The Republic No Longer Functions",
         "imageUrl": "https://res.starwarsccg.org/cards/ResetDS-Light/large/therepublicnolongerfunctions.gif",
@@ -52885,7 +62525,12 @@
       "gempId": "11_22",
       "side": "Light",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•The Shield Is Down!",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/theshieldisdown.gif",
@@ -52909,7 +62554,12 @@
       "id": 5967,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•The Shield Is Down! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/theshieldisdown.gif",
@@ -52925,7 +62575,12 @@
       "gempId": "203_15",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•The Shield Is Down! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Light/large/theshieldisdown.gif",
@@ -52962,7 +62617,12 @@
       "gempId": "6_77",
       "side": "Light",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•The Signal",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/thesignal.gif",
@@ -52986,7 +62646,12 @@
       "id": 5968,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•The Signal (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/thesignal.gif",
@@ -53006,7 +62671,12 @@
       "gempId": "9_44",
       "side": "Light",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•The Time For Our Attack Has Come",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/thetimeforourattackhascome.gif",
@@ -53031,7 +62701,12 @@
       "id": 5969,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•The Time For Our Attack Has Come (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/thetimeforourattackhascome.gif",
@@ -53052,7 +62727,12 @@
       "gempId": "9_45",
       "side": "Light",
       "rarity": "C",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "The Way Of Things",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/thewayofthings.gif",
@@ -53078,7 +62758,12 @@
       "gempId": "7_45",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Thedit",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/thedit.gif",
@@ -53107,7 +62792,12 @@
       "id": 5970,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 8",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•There is Another",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/thereisanother.gif",
@@ -53128,7 +62818,12 @@
       "gempId": "209_15",
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Set 9",
+      "set": "200d",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•There Is Another",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/thereisanother.gif",
@@ -53148,7 +62843,12 @@
       "gempId": "9_61",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "There Is Good In Him / I Can Save Him",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/thereisgoodinhim.gif",
@@ -53170,7 +62870,12 @@
       "gempId": "7_46",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Theron Nett",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/theronnett.gif",
@@ -53200,7 +62905,12 @@
       "id": 5973,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Theron Nett (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/theronnett.gif",
@@ -53226,7 +62936,12 @@
       "gempId": "204_12",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•Theron Nett (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/theronnett.gif",
@@ -53259,7 +62974,12 @@
       "gempId": "209_29",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "They Have No Idea We're Coming / Until We Win, Or The Chances Are Spent",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/theyhavenoideawerecoming.gif",
@@ -53287,7 +63007,12 @@
       "gempId": "14_37",
       "side": "Light",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•They Win This Round",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/theywinthisround.gif",
@@ -53317,7 +63042,12 @@
       "gempId": "4_61",
       "side": "Light",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•They'd Be Crazy To Follow Us",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/theydbecrazytofollowus.gif",
@@ -53335,7 +63065,12 @@
       "gempId": "2_39",
       "side": "Light",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "They're On Dantooine",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/theyreondantooine.gif",
@@ -53359,7 +63094,12 @@
       "gempId": "7_108",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•They're Tracking Us",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/theyretrackingus.gif",
@@ -53383,7 +63123,12 @@
       "gempId": "207_14",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 7",
+      "set": "207",
+      "printings": [
+        {
+          "set": "207"
+        }
+      ],
       "front": {
         "title": "•They're Tracking Us (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual7-Light/large/theyretrackingus.gif",
@@ -53405,7 +63150,12 @@
       "gempId": "8_62",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•This Is Absolutely Right",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/thisisabsolutelyright.gif",
@@ -53429,7 +63179,12 @@
       "gempId": "1_117",
       "side": "Light",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "This Is All Your Fault",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/thisisallyourfault.gif",
@@ -53450,7 +63205,12 @@
       "gempId": "5_73",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•This Is Even Better",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/thisisevenbetter.gif",
@@ -53471,7 +63231,12 @@
       "gempId": "4_62",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "This Is More Like It",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/thisismorelikeit.gif",
@@ -53496,7 +63261,12 @@
       "id": 5975,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "This Is More Like It (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/thisismorelikeit.gif",
@@ -53513,7 +63283,12 @@
       "gempId": "207_15",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 7",
+      "set": "207",
+      "printings": [
+        {
+          "set": "207"
+        }
+      ],
       "front": {
         "title": "•This is MY Ship!",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual7-Light/large/thisismyship.gif",
@@ -53534,7 +63309,12 @@
       "gempId": "4_63",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "This Is No Cave",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/thisisnocave.gif",
@@ -53554,7 +63334,12 @@
       "gempId": "8_31",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Threepio",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/threepio.gif",
@@ -53593,7 +63378,12 @@
       "gempId": "11_13",
       "side": "Light",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Threepio With His Parts Showing",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/threepiowithhispartsshowing.gif",
@@ -53633,7 +63423,12 @@
       "gempId": "11_14",
       "side": "Light",
       "rarity": "R",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Threepio With His Parts Showing (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/threepiowithhispartsshowingai.gif",
@@ -53659,7 +63454,12 @@
       "gempId": "4_64",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Through The Force Things You Will See",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/throughtheforcethingsyouwillsee.gif",
@@ -53675,7 +63475,12 @@
       "id": 5977,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "Through The Force Things You Will See (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/throughtheforcethingsyouwillsee.gif",
@@ -53695,7 +63500,12 @@
       "gempId": "8_63",
       "side": "Light",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Throw Me Another Charge",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/throwmeanothercharge.gif",
@@ -53730,7 +63540,12 @@
       "gempId": "12_49",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Thrown Back",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/thrownback.gif",
@@ -53755,7 +63570,12 @@
       "id": 5978,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Thrown Back (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/thrownback.gif",
@@ -53775,7 +63595,12 @@
       "gempId": "203_16",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•Thrown Back (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Light/large/thrownback.gif",
@@ -53802,7 +63627,12 @@
       "gempId": "5_8",
       "side": "Light",
       "rarity": "C",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "Tibanna Gas Miner",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/tibannagasminer.gif",
@@ -53836,7 +63666,12 @@
       "gempId": "6_87",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Tibrin",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/tibrin.gif",
@@ -53868,7 +63703,12 @@
       "gempId": "7_47",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Tibrin Operative",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/tibrinoperative.gif",
@@ -53905,7 +63745,12 @@
       "gempId": "4_65",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Tight Squeeze",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/tightsqueeze.gif",
@@ -53923,7 +63768,12 @@
       "gempId": "3_22",
       "side": "Light",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Tigran Jamiro",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/tigranjamiro.gif",
@@ -53947,7 +63797,12 @@
       "id": 5979,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Tigran Jamiro (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/tigranjamiro.gif",
@@ -53972,7 +63827,12 @@
       "gempId": "1_162",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Timer Mine",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/timermine.gif",
@@ -53994,7 +63854,12 @@
       "gempId": "2_21",
       "side": "Light",
       "rarity": "U2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Tiree",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/tiree.gif",
@@ -54023,7 +63888,12 @@
       "gempId": "7_48",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•TK-422",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/tk422.gif",
@@ -54065,7 +63935,12 @@
       "gempId": "11_40",
       "side": "Light",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Too Close For Comfort",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/toocloseforcomfort.gif",
@@ -54096,7 +63971,12 @@
       "gempId": "3_23",
       "side": "Light",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Toryn Farr",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/torynfarr.gif",
@@ -54123,7 +64003,12 @@
       "id": 5980,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Toryn Farr (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/torynfarr.gif",
@@ -54148,7 +64033,12 @@
       "gempId": "203_12",
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•Toryn Farr (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Light/large/torynfarr.gif",
@@ -54178,7 +64068,12 @@
       "gempId": "1_66",
       "side": "Light",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Traffic Control",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/trafficcontrol.gif",
@@ -54198,7 +64093,12 @@
       "id": 5981,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "Traffic Control (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Light/large/trafficcontrol.gif",
@@ -54217,7 +64117,12 @@
       "gempId": "4_66",
       "side": "Light",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Transmission Terminated",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/transmissionterminated.gif",
@@ -54245,7 +64150,12 @@
       "gempId": "5_9",
       "side": "Light",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Treva Horme",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/trevahorme.gif",
@@ -54270,7 +64180,12 @@
       "gempId": "7_109",
       "side": "Light",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Trooper Sabacc",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/troopersabacc.gif",
@@ -54289,7 +64204,12 @@
       "gempId": "5_10",
       "side": "Light",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Trooper Utris M'toc",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/trooperutrismtoc.gif",
@@ -54326,7 +64246,12 @@
       "id": 5982,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Trooper Utris M'toc (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/trooperutrismtoc.gif",
@@ -54350,7 +64275,12 @@
       "gempId": "204_13",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•••Tuanul Villager",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/tuanulvillager.gif",
@@ -54379,7 +64309,12 @@
       "gempId": "4_67",
       "side": "Light",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Tunnel Vision",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/tunnelvision.gif",
@@ -54399,7 +64334,12 @@
       "gempId": "1_67",
       "side": "Light",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Tusken Breath Mask",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/tuskenbreathmask.gif",
@@ -54420,7 +64360,12 @@
       "id": 5983,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Tusken Breath Mask (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/tuskenbreathmask.gif",
@@ -54436,7 +64381,12 @@
       "gempId": "9_46",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "Twilight Is Upon Me",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/twilightisuponme.gif",
@@ -54467,7 +64417,12 @@
       "gempId": "9_30",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Tycho Celchu",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/tychocelchu.gif",
@@ -54499,7 +64454,12 @@
       "id": 5984,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Tycho Celchu (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/tychocelchu.gif",
@@ -54524,7 +64484,12 @@
       "gempId": "205_3",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 5",
+      "set": "205",
+      "printings": [
+        {
+          "set": "205"
+        }
+      ],
       "front": {
         "title": "•Tycho Celchu (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual5-Light/large/tychocelchu.gif",
@@ -54558,7 +64523,12 @@
       "gempId": "205_10",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 5",
+      "set": "205",
+      "printings": [
+        {
+          "set": "205"
+        }
+      ],
       "front": {
         "title": "•Tycho In Green Squadron 3",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual5-Light/large/tychoingreensquadron3.gif",
@@ -54589,7 +64559,12 @@
       "gempId": "8_79",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Tydirium",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/tydirium.gif",
@@ -54630,7 +64605,12 @@
       "id": 5985,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Tydirium (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/tydirium.gif",
@@ -54657,7 +64637,12 @@
       "gempId": "2_22",
       "side": "Light",
       "rarity": "R2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Tzizvvt",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/tzizvvt.gif",
@@ -54679,7 +64664,12 @@
       "gempId": "7_79",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Uh-oh!",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/uhoh.gif",
@@ -54705,7 +64695,12 @@
       "id": 5986,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Uh-oh! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/uhoh.gif",
@@ -54724,7 +64719,12 @@
       "gempId": "6_58",
       "side": "Light",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Ultimatum",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/ultimatum.gif",
@@ -54749,7 +64749,12 @@
       "gempId": "13_44",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Ultimatum",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/ultimatum.gif",
@@ -54769,7 +64774,12 @@
       "id": 5987,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Uncharted Settlements",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/unchartedsettlements.gif",
@@ -54787,7 +64797,12 @@
       "gempId": "5_29",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Uncontrollable Fury",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/uncontrollablefury.gif",
@@ -54813,7 +64828,12 @@
       "gempId": "3_50",
       "side": "Light",
       "rarity": "U1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Under Attack",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/underattack.gif",
@@ -54832,7 +64852,12 @@
       "id": 5988,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Under Jabba's Protection",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/underjabbasprotection.gif",
@@ -54849,7 +64874,12 @@
       "gempId": "2_40",
       "side": "Light",
       "rarity": "U2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Undercover",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/undercover.gif",
@@ -54872,7 +64902,12 @@
       "id": 5989,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Undercover (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/undercover.gif",
@@ -54891,7 +64926,12 @@
       "gempId": "112_10",
       "side": "Light",
       "rarity": "PM",
-      "set": "Jabba's Palace Sealed Deck",
+      "set": "112",
+      "printings": [
+        {
+          "set": "112"
+        }
+      ],
       "front": {
         "title": "•Underworld Contacts",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalaceSealedDeck-Light/large/underworldcontacts.gif",
@@ -54913,7 +64953,12 @@
       "id": 5990,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Underworld Contacts & •Uncharted Settlements",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/underworldcontactsandunchartedsettlements.gif",
@@ -54927,7 +64972,12 @@
       "id": 5991,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Underworld Contacts (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/underworldcontacts.gif",
@@ -54947,7 +64997,12 @@
       "gempId": "6_78",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Unfriendly Fire",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/unfriendlyfire.gif",
@@ -54963,7 +65018,12 @@
       "id": 5992,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Use The Force",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/usetheforce.gif",
@@ -54980,7 +65040,12 @@
       "gempId": "1_118",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Utinni!",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/utinni.gif",
@@ -55005,7 +65070,12 @@
       "id": 5993,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "Utinni! (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/utinni.gif",
@@ -55022,7 +65092,12 @@
       "gempId": "7_49",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Uutkik",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/uutkik.gif",
@@ -55051,7 +65126,12 @@
       "id": 5994,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Uutkik (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/uutkik.gif",
@@ -55072,7 +65152,12 @@
       "gempId": "210_26",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "V-4X-D Ski Speeder",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Light/large/v4xdskispeeder.gif",
@@ -55097,7 +65182,12 @@
       "gempId": "1_41",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Vaporator",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/vaporator.gif",
@@ -55119,7 +65209,12 @@
       "gempId": "3_81",
       "side": "Light",
       "rarity": "C2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Vehicle Mine",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/vehiclemine.gif",
@@ -55140,7 +65235,12 @@
       "id": 5996,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "Veteran Rogue",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/veteranrogue.gif",
@@ -55164,7 +65264,12 @@
       "gempId": "6_90",
       "side": "Light",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "Vibro-Ax",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/vibroax.gif",
@@ -55188,7 +65293,12 @@
       "gempId": "211_55",
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Vice Admiral Holdo",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/viceadmiralholdo.gif",
@@ -55214,7 +65324,12 @@
       "id": 5998,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Vilmarh 'Villie' Grahrk",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/vilmarhvilliegrahrk.gif",
@@ -55239,7 +65354,12 @@
       "gempId": "4_7",
       "side": "Light",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "Vine Snake",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/vinesnake.gif",
@@ -55273,7 +65393,12 @@
       "gempId": "4_68",
       "side": "Light",
       "rarity": "C",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "••Visored Vision",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/visoredvision.gif",
@@ -55293,7 +65418,12 @@
       "id": 5999,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "••Visored Vision (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/visoredvision.gif",
@@ -55312,7 +65442,12 @@
       "id": 6000,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•Voolvif Monn",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/voolvifmonn.gif",
@@ -55341,7 +65476,12 @@
       "gempId": "12_71",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Vote Now!",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/votenow.gif",
@@ -55363,7 +65503,12 @@
       "gempId": "6_45",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Vul Tazaene",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/vultazaene.gif",
@@ -55396,7 +65541,12 @@
       "gempId": "3_51",
       "side": "Light",
       "rarity": "U2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Walker Sighting",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/walkersighting.gif",
@@ -55416,7 +65566,12 @@
       "id": 6001,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Walker Sighting (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/walkersighting.gif",
@@ -55436,7 +65591,12 @@
       "gempId": "208_22",
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Walker Sighting (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/walkersighting.gif",
@@ -55464,7 +65624,12 @@
       "gempId": "1_119",
       "side": "Light",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Warrior's Courage",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/warriorscourage.gif",
@@ -55485,7 +65650,12 @@
       "id": 6002,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Warrior's Courage (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/warriorscourage.gif",
@@ -55502,7 +65672,12 @@
       "gempId": "4_41",
       "side": "Light",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Wars Not Make One Great",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/warsnotmakeonegreat.gif",
@@ -55524,7 +65699,12 @@
       "id": 6003,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Wars Not Make One Great (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/warsnotmakeonegreat.gif",
@@ -55543,7 +65723,12 @@
       "gempId": "10_26",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "Watch Your Step / This Place Can Be A Little Rough",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Light/large/watchyourstep.gif",
@@ -55564,7 +65749,12 @@
       "id": 6005,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "Watch Your Step / This Place Can Be A Little Rough (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/watchyourstep.gif",
@@ -55592,7 +65782,12 @@
       "gempId": "4_69",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•We Can Still Outmaneuver Them",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/wecanstilloutmaneuverthem.gif",
@@ -55614,7 +65809,12 @@
       "gempId": "14_38",
       "side": "Light",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•We Didn't Hit It",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/wedidnthitit.gif",
@@ -55638,7 +65838,12 @@
       "gempId": "14_45",
       "side": "Light",
       "rarity": "R",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•We Don't Have Time For This",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/wedonthavetimeforthis.gif",
@@ -55662,7 +65867,12 @@
       "gempId": "4_70",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "We Don't Need Their Scum",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/wedontneedtheirscum.gif",
@@ -55686,7 +65896,12 @@
       "gempId": "14_52",
       "side": "Light",
       "rarity": "U",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "We Have A Plan / They Will Be Lost And Confused",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/wehaveaplan.gif",
@@ -55713,7 +65928,12 @@
       "id": 6007,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "We Have A Plan / They Will Be Lost And Confused (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/wehaveaplan.gif",
@@ -55743,7 +65963,12 @@
       "gempId": "12_72",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•We Wish To Board At Once",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/wewishtoboardatonce.gif",
@@ -55781,7 +66006,12 @@
       "gempId": "6_79",
       "side": "Light",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Weapon Levitation",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/weaponlevitation.gif",
@@ -55812,7 +66042,12 @@
       "gempId": "13_45",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Weapon Of A Fallen Mentor",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/weaponofafallenmentor.gif",
@@ -55841,7 +66076,12 @@
       "gempId": "7_80",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Weapons Display",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/weaponsdisplay.gif",
@@ -55866,7 +66106,12 @@
       "id": 6008,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•Weapons Display (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Light/large/weaponsdisplay.gif",
@@ -55886,7 +66131,12 @@
       "gempId": "5_30",
       "side": "Light",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Weather Vane",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/weathervane.gif",
@@ -55908,7 +66158,12 @@
       "id": 6009,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Weather Vane (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/weathervane.gif",
@@ -55927,7 +66182,12 @@
       "gempId": "3_24",
       "side": "Light",
       "rarity": "C1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•WED-1016 'Techie' Droid",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/wed1016techiedroid.gif",
@@ -55954,7 +66214,12 @@
       "gempId": "1_32",
       "side": "Light",
       "rarity": "R2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•WED-9-M1 'Bantha' Droid",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/wed9m1banthadroid.gif",
@@ -55984,7 +66249,12 @@
       "gempId": "2_23",
       "side": "Light",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Wedge Antilles",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/wedgeantilles.gif",
@@ -56029,7 +66299,12 @@
       "id": 6010,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Wedge Antilles (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/wedgeantilles.gif",
@@ -56056,7 +66331,12 @@
       "gempId": "202_3",
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Set 2",
+      "set": "202",
+      "printings": [
+        {
+          "set": "202"
+        }
+      ],
       "front": {
         "title": "•Wedge Antilles (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual2-Light/large/wedgeantilles.gif",
@@ -56092,7 +66372,12 @@
       "id": 6011,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Wedge Antilles, Legendary Rogue",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/wedgeantilleslegendaryrogue.gif",
@@ -56118,7 +66403,12 @@
       "gempId": "9_31",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Wedge Antilles, Red Squadron Leader",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/wedgeantillesredsquadronleader.gif",
@@ -56162,7 +66452,12 @@
       "id": 6012,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 6",
+      "set": "1006",
+      "printings": [
+        {
+          "set": "1006"
+        }
+      ],
       "front": {
         "title": "•Wedge In Red Squadron 1",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual6-Light/large/wedgeinredsquadron1.gif",
@@ -56190,7 +66485,12 @@
       "gempId": "200_67",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Wedge In Red Squadron 1",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/wedgeinredsquadron1.gif",
@@ -56225,7 +66525,12 @@
       "gempId": "5_74",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•We'll Find Han",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/wellfindhan.gif",
@@ -56245,7 +66550,12 @@
       "id": 6013,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•We'll Find Han (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/wellfindhan.gif",
@@ -56265,7 +66575,12 @@
       "gempId": "13_46",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "We'll Handle This / Duel Of The Fates",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/wellhandlethis.gif",
@@ -56292,7 +66607,12 @@
       "id": 6015,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "We'll Handle This / Duel Of The Fates (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/wellhandlethis.gif",
@@ -56321,7 +66641,12 @@
       "id": 6016,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•We'll Take The Long Way",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/welltakethelongway.gif",
@@ -56341,7 +66666,12 @@
       "gempId": "201_10",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•We'll Take The Long Way",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Light/large/welltakethelongway.gif",
@@ -56367,7 +66697,12 @@
       "gempId": "1_120",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "We're Doomed",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/weredoomed.gif",
@@ -56387,7 +66722,12 @@
       "gempId": "12_50",
       "side": "Light",
       "rarity": "C",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•We're Leaving",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/wereleaving.gif",
@@ -56412,7 +66752,12 @@
       "gempId": "204_15",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•We're Leaving (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/wereleaving.gif",
@@ -56437,7 +66782,12 @@
       "gempId": "8_64",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "Were You Looking For Me?",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/wereyoulookingforme.gif",
@@ -56469,7 +66819,12 @@
       "gempId": "3_25",
       "side": "Light",
       "rarity": "R2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Wes Janson",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/wesjanson.gif",
@@ -56496,7 +66851,12 @@
       "id": 6017,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Wes Janson (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/wesjanson.gif",
@@ -56522,7 +66882,12 @@
       "id": 6018,
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Wes Janson, Rogue Veteran",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/wesjansonrogueveteran.gif",
@@ -56547,7 +66912,12 @@
       "gempId": "14_46",
       "side": "Light",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Wesa Gotta Grand Army",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/wesagottagrandarmy.gif",
@@ -56576,7 +66946,12 @@
       "gempId": "14_39",
       "side": "Light",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Wesa Ready To Do Our-sa Part",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/wesareadytodooursapart.gif",
@@ -56599,7 +66974,12 @@
       "id": 6019,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Wesa Ready To Do Our-sa Part (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/wesareadytodooursapart.gif",
@@ -56619,7 +66999,12 @@
       "gempId": "4_71",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•WHAAAAAAAAAOOOOW!",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/whaaaaaaaaaoooow.gif",
@@ -56635,7 +67020,12 @@
       "id": 6020,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 9",
+      "set": "1009",
+      "printings": [
+        {
+          "set": "1009"
+        }
+      ],
       "front": {
         "title": "•What About That Blue One?",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual9-Light/large/whataboutthatblueone.gif",
@@ -56651,7 +67041,12 @@
       "gempId": "206_6",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 6",
+      "set": "206",
+      "printings": [
+        {
+          "set": "206"
+        }
+      ],
       "front": {
         "title": "•What Chance Do We Have?",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual6-Light/large/whatchancedowehave.gif",
@@ -56673,7 +67068,12 @@
       "gempId": "4_42",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•What Is Thy Bidding, My Master?",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/whatisthybiddingmymaster.gif",
@@ -56698,7 +67098,12 @@
       "gempId": "11_23",
       "side": "Light",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•What Was It?",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/whatwasit.gif",
@@ -56730,7 +67135,12 @@
       "gempId": "2_41",
       "side": "Light",
       "rarity": "U2",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•••What're You Tryin' To Push On Us?",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/whatreyoutryintopushonus.gif",
@@ -56767,7 +67177,12 @@
       "gempId": "211_50",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Where's Han?",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/whereshan.gif",
@@ -56787,7 +67202,12 @@
       "gempId": "14_47",
       "side": "Light",
       "rarity": "C",
-      "set": "Theed Palace",
+      "set": "14",
+      "printings": [
+        {
+          "set": "14"
+        }
+      ],
       "front": {
         "title": "•Whoooo!",
         "imageUrl": "https://res.starwarsccg.org/cards/TheedPalace-Light/large/whoooo.gif",
@@ -56817,7 +67237,12 @@
       "gempId": "3_52",
       "side": "Light",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "Who's Scruffy-Looking?",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/whosscruffylooking.gif",
@@ -56844,7 +67269,12 @@
       "gempId": "208_15",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Why Does Everyone Want To Go Back To Jakku?!",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/whydoeseveryonewanttogobacktojakku.gif",
@@ -56871,7 +67301,12 @@
       "gempId": "8_32",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Wicket",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/wicket.gif",
@@ -56900,7 +67335,12 @@
       "id": 6022,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Wicket (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/wicket.gif",
@@ -56924,7 +67364,12 @@
       "gempId": "203_21",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 3",
+      "set": "203",
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
       "front": {
         "title": "•Wild Karrde",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual3-Light/large/wildkarrde.gif",
@@ -56962,7 +67407,12 @@
       "gempId": "5_11",
       "side": "Light",
       "rarity": "U",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Wiorkettle",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/wiorkettle.gif",
@@ -56990,7 +67440,12 @@
       "gempId": "1_33",
       "side": "Light",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Wioslea",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/wioslea.gif",
@@ -57021,7 +67476,12 @@
       "gempId": "13_47",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Wise Advice",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/wiseadvice.gif",
@@ -57042,7 +67502,12 @@
       "gempId": "7_81",
       "side": "Light",
       "rarity": "U",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Wise Advice",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/wiseadvice.gif",
@@ -57063,7 +67528,12 @@
       "gempId": "8_42",
       "side": "Light",
       "rarity": "R",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Wokling",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/wokling.gif",
@@ -57083,7 +67553,12 @@
       "id": 6023,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Wokling (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/wokling.gif",
@@ -57103,7 +67578,12 @@
       "gempId": "200_47",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 0",
+      "set": "200",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Wokling (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/wokling.gif",
@@ -57134,7 +67614,12 @@
       "gempId": "7_50",
       "side": "Light",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Wookiee",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/wookiee.gif",
@@ -57165,7 +67650,12 @@
       "id": 6024,
       "side": "Light",
       "rarity": "F",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "Wookiee (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/wookiee.gif",
@@ -57191,7 +67681,12 @@
       "gempId": "8_65",
       "side": "Light",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Wookiee Guide",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/wookieeguide.gif",
@@ -57208,7 +67703,12 @@
       "id": 6025,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Wookiee Guide (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/wookieeguide.gif",
@@ -57229,7 +67729,12 @@
       "gempId": "2_58",
       "side": "Light",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Wookiee Roar",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/wookieeroar.gif",
@@ -57255,7 +67760,12 @@
       "id": 6026,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Wookiee Roar (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/wookieeroar.gif",
@@ -57276,7 +67786,12 @@
       "gempId": "5_75",
       "side": "Light",
       "rarity": "R",
-      "set": "Cloud City",
+      "set": "5",
+      "printings": [
+        {
+          "set": "5"
+        }
+      ],
       "front": {
         "title": "•Wookiee Strangle",
         "imageUrl": "https://res.starwarsccg.org/cards/CloudCity-Light/large/wookieestrangle.gif",
@@ -57296,7 +67811,12 @@
       "id": 6027,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Wookiee Strangle (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/wookieestrangle.gif",
@@ -57316,7 +67836,12 @@
       "gempId": "6_48",
       "side": "Light",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Worrt",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/worrt.gif",
@@ -57347,7 +67872,12 @@
       "gempId": "7_54",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Wrist Comlink",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/wristcomlink.gif",
@@ -57367,7 +67897,12 @@
       "gempId": "8_33",
       "side": "Light",
       "rarity": "U",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Wuta",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/wuta.gif",
@@ -57414,7 +67949,12 @@
       "gempId": "3_26",
       "side": "Light",
       "rarity": "U2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Wyron Serper",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/wyronserper.gif",
@@ -57441,7 +67981,12 @@
       "id": 6028,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Wyron Serper (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/wyronserper.gif",
@@ -57465,7 +68010,12 @@
       "gempId": "1_146",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "X-wing",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/xwing.gif",
@@ -57502,7 +68052,15 @@
       "gempId": "7_150",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "105"
+        },
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "X-wing Assault Squadron",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/xwingassaultsquadron.gif",
@@ -57532,7 +68090,12 @@
       "gempId": "7_162",
       "side": "Light",
       "rarity": "C",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "X-wing Laser Cannon",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/xwinglasercannon.gif",
@@ -57558,7 +68121,12 @@
       "gempId": "1_147",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "Y-wing",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/ywing.gif",
@@ -57595,7 +68163,12 @@
       "gempId": "2_74",
       "side": "Light",
       "rarity": "U1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "Y-wing Assault Squadron",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/ywingassaultsquadron.gif",
@@ -57625,7 +68198,12 @@
       "gempId": "12_33",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Yane",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/yane.gif",
@@ -57658,7 +68236,12 @@
       "gempId": "201_7",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 1",
+      "set": "201",
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
       "front": {
         "title": "•Yane (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Light/large/yane.gif",
@@ -57692,7 +68275,12 @@
       "gempId": "6_46",
       "side": "Light",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•••Yarkora",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/yarkora.gif",
@@ -57728,7 +68316,12 @@
       "gempId": "6_59",
       "side": "Light",
       "rarity": "U",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Yarna d'al' Gargan",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/yarnadalgargan.gif",
@@ -57750,7 +68343,12 @@
       "id": 6029,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 3",
+      "set": "1003",
+      "printings": [
+        {
+          "set": "1003"
+        }
+      ],
       "front": {
         "title": "•Yarna d'al' Gargan (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual3-Light/large/yarnadalgargan.gif",
@@ -57769,7 +68367,12 @@
       "gempId": "208_16",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Yarna d'al' Gargan (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/yarnadalgargan.gif",
@@ -57821,7 +68424,12 @@
       "gempId": "12_34",
       "side": "Light",
       "rarity": "U",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Yarua",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/yarua.gif",
@@ -57853,7 +68461,12 @@
       "id": 6030,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Yarua (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/yarua.gif",
@@ -57880,7 +68493,12 @@
       "gempId": "1_135",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Yavin 4",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/yavin4.gif",
@@ -57910,7 +68528,12 @@
       "id": 6031,
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Yavin 4 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/yavin4.gif",
@@ -57930,7 +68553,12 @@
       "gempId": "211_32",
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Set 11",
+      "set": "211",
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
       "front": {
         "title": "•Yavin 4 (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/yavin4.gif",
@@ -57952,7 +68580,12 @@
       "gempId": "208_26",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "Yavin 4 Base Operations / The Time To Fight Is Now",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/yavin4baseoperations.gif",
@@ -57974,7 +68607,12 @@
       "gempId": "7_51",
       "side": "Light",
       "rarity": "F",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "Yavin 4 Trooper",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/yavin4trooper.gif",
@@ -58006,7 +68644,12 @@
       "gempId": "2_67",
       "side": "Light",
       "rarity": "U1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Yavin 4: Briefing Room",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/yavin4briefingroom.gif",
@@ -58030,7 +68673,12 @@
       "gempId": "1_136",
       "side": "Light",
       "rarity": "C1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Yavin 4: Docking Bay",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/yavin4dockingbay.gif",
@@ -58062,7 +68710,12 @@
       "id": 6034,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "•Yavin 4: Jedi Academy",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/yavin4jediacademy.gif",
@@ -58084,7 +68737,12 @@
       "gempId": "1_137",
       "side": "Light",
       "rarity": "C2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Yavin 4: Jungle",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/yavin4jungle.gif",
@@ -58108,7 +68766,12 @@
       "gempId": "7_134",
       "side": "Light",
       "rarity": "R",
-      "set": "Special Edition",
+      "set": "7",
+      "printings": [
+        {
+          "set": "7"
+        }
+      ],
       "front": {
         "title": "•Yavin 4: Massassi Headquarters",
         "imageUrl": "https://res.starwarsccg.org/cards/SpecialEdition-Light/large/yavin4massassiheadquarters.gif",
@@ -58131,7 +68794,12 @@
       "gempId": "2_68",
       "side": "Light",
       "rarity": "U1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Yavin 4: Massassi Ruins",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/yavin4massassiruins.gif",
@@ -58154,7 +68822,12 @@
       "gempId": "209_28",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Yavin 4: Massassi Ruins (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/yavin4massassiruins.gif",
@@ -58176,7 +68849,12 @@
       "gempId": "1_138",
       "side": "Light",
       "rarity": "R1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Yavin 4: Massassi Throne Room",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/yavin4massassithroneroom.gif",
@@ -58199,7 +68877,12 @@
       "gempId": "1_139",
       "side": "Light",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Yavin 4: Massassi War Room",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/yavin4massassiwarroom.gif",
@@ -58222,7 +68905,12 @@
       "id": 6036,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•Yavin 4: Massassi War Room (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/yavin4massassiwarroom.gif",
@@ -58243,7 +68931,12 @@
       "gempId": "208_24",
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Yavin 4: Massassi War Room (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/yavin4massassiwarroom.gif",
@@ -58311,7 +69004,12 @@
       "gempId": "1_68",
       "side": "Light",
       "rarity": "U2",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Yavin Sentry",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/yavinsentry.gif",
@@ -58334,7 +69032,12 @@
       "id": 6037,
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•Yavin Sentry (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Light/large/yavinsentry.gif",
@@ -58353,7 +69056,12 @@
       "gempId": "200_31",
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Set 0",
+      "set": "200d",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Yavin Sentry (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/ResetDS-Light/large/yavinsentry.gif",
@@ -58375,7 +69083,12 @@
       "gempId": "1_69",
       "side": "Light",
       "rarity": "U1",
-      "set": "Premiere",
+      "set": "1",
+      "printings": [
+        {
+          "set": "1"
+        }
+      ],
       "front": {
         "title": "•Yerka Mig",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/yerkamig.gif",
@@ -58396,7 +69109,12 @@
       "id": 6038,
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Block 1",
+      "set": "1001",
+      "printings": [
+        {
+          "set": "1001"
+        }
+      ],
       "front": {
         "title": "•Yerka Mig (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual1-Light/large/yerkamig.gif",
@@ -58412,7 +69130,12 @@
       "gempId": "4_2",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Yoda",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/yoda.gif",
@@ -58444,7 +69167,12 @@
       "id": 6039,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "•Yoda (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/yoda.gif",
@@ -58471,7 +69199,12 @@
       "gempId": "207_10",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 7",
+      "set": "207",
+      "printings": [
+        {
+          "set": "207"
+        }
+      ],
       "front": {
         "title": "•Yoda (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual7-Light/large/yoda.gif",
@@ -58496,7 +69229,12 @@
       "gempId": "4_72",
       "side": "Light",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Yoda Stew",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/yodastew.gif",
@@ -58514,7 +69252,12 @@
       "gempId": "10_27",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections II",
+      "set": "10",
+      "printings": [
+        {
+          "set": "10"
+        }
+      ],
       "front": {
         "title": "•Yoda Stew & •You Do Have Your Moments",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Light/large/yodastew&youdohaveyourmoments.gif",
@@ -58530,7 +69273,12 @@
       "id": 6040,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Yoda, Great Warrior",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/yodagreatwarrior.gif",
@@ -58559,7 +69307,12 @@
       "gempId": "202_4",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 2",
+      "set": "202",
+      "printings": [
+        {
+          "set": "202"
+        }
+      ],
       "front": {
         "title": "•Yoda, Keeper Of The Peace",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual2-Light/large/yodakeeperofthepeace.gif",
@@ -58588,7 +69341,12 @@
       "gempId": "13_48",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Yoda, Master Of The Force",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/yodamasteroftheforce.gif",
@@ -58640,7 +69398,12 @@
       "gempId": "12_35",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Yoda, Senior Council Member",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/yodaseniorcouncilmember.gif",
@@ -58684,7 +69447,12 @@
       "gempId": "12_36",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Yoda, Senior Council Member (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/yodaseniorcouncilmemberai.gif",
@@ -58710,7 +69478,12 @@
       "id": 6042,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Yoda, Senior Council Member (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/yodaseniorcouncilmember.gif",
@@ -58738,7 +69511,12 @@
       "id": 6043,
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Block 5",
+      "set": "1005",
+      "printings": [
+        {
+          "set": "1005"
+        }
+      ],
       "front": {
         "title": "•Yoda, Senior Council Member (V) (AI)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual5-Light/large/yodaseniorcouncilmemberai.gif",
@@ -58767,7 +69545,12 @@
       "gempId": "4_73",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Yoda, You Seek Yoda",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/yodayouseekyoda.gif",
@@ -58792,7 +69575,12 @@
       "gempId": "4_43",
       "side": "Light",
       "rarity": "R",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Yoda's Gimer Stick",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/yodasgimerstick.gif",
@@ -58814,7 +69602,12 @@
       "gempId": "4_44",
       "side": "Light",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•Yoda's Hope",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/yodashope.gif",
@@ -58845,7 +69638,12 @@
       "gempId": "11_15",
       "side": "Light",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•Yotts Orren",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/yottsorren.gif",
@@ -58882,7 +69680,12 @@
       "gempId": "204_16",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•You Assume Too Much",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/youassumetoomuch.gif",
@@ -58909,7 +69712,12 @@
       "gempId": "110_4",
       "side": "Light",
       "rarity": "PM",
-      "set": "Enhanced Jabba's Palace",
+      "set": "110",
+      "printings": [
+        {
+          "set": "110"
+        }
+      ],
       "front": {
         "title": "You Can Either Profit By This... / Or Be Destroyed",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedJabbasPalace-Light/large/youcaneitherprofitbythis.gif",
@@ -58931,7 +69739,12 @@
       "gempId": "4_74",
       "side": "Light",
       "rarity": "U",
-      "set": "Dagobah",
+      "set": "4",
+      "printings": [
+        {
+          "set": "4"
+        }
+      ],
       "front": {
         "title": "•You Do Have Your Moments",
         "imageUrl": "https://res.starwarsccg.org/cards/Dagobah-Light/large/youdohaveyourmoments.gif",
@@ -58949,7 +69762,12 @@
       "gempId": "204_23",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 4",
+      "set": "204",
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
       "front": {
         "title": "•You Do Have Your Moments (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/youdohaveyourmoments.gif",
@@ -58971,7 +69789,12 @@
       "gempId": "3_53",
       "side": "Light",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "You Have Failed Me For The Last Time",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/youhavefailedmeforthelasttime.gif",
@@ -58988,7 +69811,12 @@
       "gempId": "9_55",
       "side": "Light",
       "rarity": "R",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "You Must Confront Vader",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/youmustconfrontvader.gif",
@@ -59006,7 +69834,12 @@
       "gempId": "3_54",
       "side": "Light",
       "rarity": "R1",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "You Will Go To The Dagobah System",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/youwillgotothedagobahsystem.gif",
@@ -59022,7 +69855,12 @@
       "id": 6045,
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Block 2",
+      "set": "1002",
+      "printings": [
+        {
+          "set": "1002"
+        }
+      ],
       "front": {
         "title": "You Will Go To The Dagobah System (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual2-Light/large/youwillgotothedagobahsystem.gif",
@@ -59042,7 +69880,12 @@
       "gempId": "6_80",
       "side": "Light",
       "rarity": "C",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•You Will Take Me To Jabba Now",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/youwilltakemetojabbanow.gif",
@@ -59062,7 +69905,12 @@
       "id": 6046,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 8",
+      "set": "1008",
+      "printings": [
+        {
+          "set": "1008"
+        }
+      ],
       "front": {
         "title": "•You Will Take Me To Jabba Now (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual8-Light/large/youwilltakemetojabbanow.gif",
@@ -59079,7 +69927,12 @@
       "gempId": "11_41",
       "side": "Light",
       "rarity": "U",
-      "set": "Tatooine",
+      "set": "11",
+      "printings": [
+        {
+          "set": "11"
+        }
+      ],
       "front": {
         "title": "•You'll Find I'm Full Of Surprises",
         "imageUrl": "https://res.starwarsccg.org/cards/Tatooine-Light/large/youllfindimfullofsurprises.gif",
@@ -59097,7 +69950,12 @@
       "gempId": "9_47",
       "side": "Light",
       "rarity": "U",
-      "set": "Death Star II",
+      "set": "9",
+      "printings": [
+        {
+          "set": "9"
+        }
+      ],
       "front": {
         "title": "•Your Insight Serves You Well",
         "imageUrl": "https://res.starwarsccg.org/cards/DeathStarII-Light/large/yourinsightservesyouwell.gif",
@@ -59153,7 +70011,12 @@
       "gempId": "13_49",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Your Insight Serves You Well",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/yourinsightservesyouwell.gif",
@@ -59189,7 +70052,12 @@
       "gempId": "12_51",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•Your Insight Serves You Well & •Staging Areas",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/yourinsightservesyouwell&stagingareas.gif",
@@ -59241,7 +70109,12 @@
       "id": 6047,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•Your Insight Serves You Well (Death Star II) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Light/large/yourinsightservesyouwellv.gif",
@@ -59260,7 +70133,12 @@
       "gempId": "200_32",
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Set 0",
+      "set": "200d",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Your Insight Serves You Well (Death Star II) (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/ResetDS-Light/large/yourinsightservesyouwellv.gif",
@@ -59279,7 +70157,12 @@
       "id": 6049,
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Defensive Shield",
+      "set": "1000d",
+      "printings": [
+        {
+          "set": "1000d"
+        }
+      ],
       "front": {
         "title": "•Your Insight Serves You Well (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/VirtualDS-Light/large/yourinsightservesyouwell.gif",
@@ -59299,7 +70182,12 @@
       "gempId": "200_32",
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Set 0",
+      "set": "200d",
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
       "front": {
         "title": "•Your Insight Serves You Well (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/ResetDS-Light/large/yourinsightservesyouwell.gif",
@@ -59336,7 +70224,12 @@
       "gempId": "13_50",
       "side": "Light",
       "rarity": "PM",
-      "set": "Reflections III",
+      "set": "13",
+      "printings": [
+        {
+          "set": "13"
+        }
+      ],
       "front": {
         "title": "•Your Ship?",
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsIII-Light/large/yourship.gif",
@@ -59359,7 +70252,12 @@
       "gempId": "2_59",
       "side": "Light",
       "rarity": "R1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•You're All Clear Kid!",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/youreallclearkid.gif",
@@ -59380,7 +70278,12 @@
       "gempId": "12_52",
       "side": "Light",
       "rarity": "R",
-      "set": "Coruscant",
+      "set": "12",
+      "printings": [
+        {
+          "set": "12"
+        }
+      ],
       "front": {
         "title": "•You've Got A Lot Of Guts Coming Here",
         "imageUrl": "https://res.starwarsccg.org/cards/Coruscant-Light/large/youvegotalotofgutscominghere.gif",
@@ -59404,7 +70307,12 @@
       "gempId": "6_47",
       "side": "Light",
       "rarity": "R",
-      "set": "Jabba's Palace",
+      "set": "6",
+      "printings": [
+        {
+          "set": "6"
+        }
+      ],
       "front": {
         "title": "•Yoxgit",
         "imageUrl": "https://res.starwarsccg.org/cards/JabbasPalace-Light/large/yoxgit.gif",
@@ -59436,7 +70344,12 @@
       "gempId": "209_14",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 9",
+      "set": "209",
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
       "front": {
         "title": "•Yoxgit (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/yoxgit.gif",
@@ -59460,7 +70373,12 @@
       "gempId": "8_80",
       "side": "Light",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "YT-1300 Transport",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/yt1300transport.gif",
@@ -59495,7 +70413,12 @@
       "id": 6051,
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Block 4",
+      "set": "1004",
+      "printings": [
+        {
+          "set": "1004"
+        }
+      ],
       "front": {
         "title": "YT-1300 Transport (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual4-Light/large/yt1300transport.gif",
@@ -59524,7 +70447,12 @@
       "gempId": "8_66",
       "side": "Light",
       "rarity": "C",
-      "set": "Endor",
+      "set": "8",
+      "printings": [
+        {
+          "set": "8"
+        }
+      ],
       "front": {
         "title": "•Yub Yub!",
         "imageUrl": "https://res.starwarsccg.org/cards/Endor-Light/large/yubyub.gif",
@@ -59546,7 +70474,12 @@
       "id": 6052,
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Block 7",
+      "set": "1007",
+      "printings": [
+        {
+          "set": "1007"
+        }
+      ],
       "front": {
         "title": "•Yub Yub, Commander",
         "imageUrl": "https://res.starwarsccg.org/cards/Images-HT/cards/legacy/Virtual7-Light/large/yubyubcommander.gif",
@@ -59562,7 +70495,12 @@
       "gempId": "109_5",
       "side": "Light",
       "rarity": "PM",
-      "set": "Enhanced Cloud City",
+      "set": "109",
+      "printings": [
+        {
+          "set": "109"
+        }
+      ],
       "front": {
         "title": "•••Z-95 Bespin Defense Fighter",
         "imageUrl": "https://res.starwarsccg.org/cards/EnhancedCloudCity-Light/large/z95bespindefensefighter.gif",
@@ -59598,7 +70536,12 @@
       "gempId": "106_9",
       "side": "Light",
       "rarity": "PM",
-      "set": "Official Tournament Sealed Deck",
+      "set": "106",
+      "printings": [
+        {
+          "set": "106"
+        }
+      ],
       "front": {
         "title": "Z-95 Headhunter",
         "imageUrl": "https://res.starwarsccg.org/cards/OfficialTournamentSealedDeck-Light/large/z95headhunter.gif",
@@ -59637,7 +70580,12 @@
       "gempId": "208_13",
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Set 8",
+      "set": "208",
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
       "front": {
         "title": "•Zeb Orrelios",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/zeborrelios.gif",
@@ -59666,7 +70614,12 @@
       "gempId": "3_27",
       "side": "Light",
       "rarity": "R2",
-      "set": "Hoth",
+      "set": "3",
+      "printings": [
+        {
+          "set": "3"
+        }
+      ],
       "front": {
         "title": "•Zev Senesca",
         "imageUrl": "https://res.starwarsccg.org/cards/Hoth-Light/large/zevsenesca.gif",
@@ -59701,7 +70654,12 @@
       "gempId": "2_24",
       "side": "Light",
       "rarity": "C1",
-      "set": "A New Hope",
+      "set": "2",
+      "printings": [
+        {
+          "set": "2"
+        }
+      ],
       "front": {
         "title": "•Zutton",
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/zutton.gif",
@@ -59726,7 +70684,12 @@
       "gempId": "301_5",
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Premium Set",
+      "set": "200d",
+      "printings": [
+        {
+          "set": "301"
+        }
+      ],
       "front": {
         "title": "•Your Ship? (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/VirtualPremium-Light/large/yourship.gif",
@@ -59750,7 +70713,12 @@
       "gempId": "210_24",
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Set 10",
+      "set": "210",
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
       "front": {
         "title": "Quite A Mercenary (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Light/large/quiteamercenary.gif",
@@ -59770,7 +70738,12 @@
       "gempId": "213_35",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Captain Lando Calrissian",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Light/large/captainlandocalrissian.gif",
@@ -59803,7 +70776,12 @@
       "gempId": "213_38",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•L3-37 (Elthree-Threeseven)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Light/large/l337.gif",
@@ -59836,7 +70814,12 @@
       "gempId": "213_36",
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Chewbacca (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Light/large/chewbacca.gif",
@@ -59886,7 +70869,12 @@
       "gempId": "213_39",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Qi'ra",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Light/large/qira.gif",
@@ -59921,7 +70909,12 @@
       "gempId": "213_41",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Rio Durant",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Light/large/riodurant.gif",
@@ -59954,7 +70947,12 @@
       "gempId": "213_37",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Han… Solo",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Light/large/hansolo.gif",
@@ -59989,7 +70987,12 @@
       "gempId": "213_40",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Qui-Gon Jinn, Serene Jedi",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Light/large/quigonjinnserenejedi.gif",
@@ -60018,7 +71021,12 @@
       "gempId": "213_42",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Tobias Beckett",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Light/large/tobiasbeckett.gif",
@@ -60052,7 +71060,12 @@
       "gempId": "213_43",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Val",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Light/large/val.gif",
@@ -60084,7 +71097,12 @@
       "gempId": "213_44",
       "side": "Light",
       "rarity": "PM",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Yoda, Master Of The Force (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Light/large/yodamasteroftheforce.gif",
@@ -60122,7 +71140,12 @@
       "gempId": "213_45",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 13",
+      "set": "200d",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Clumsy And Stupid",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Light/large/clumsyandstupid.gif",
@@ -60142,7 +71165,12 @@
       "gempId": "213_46",
       "side": "Light",
       "rarity": "R2",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Kessel Run (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Light/large/kesselrun.gif",
@@ -60167,7 +71195,12 @@
       "gempId": "213_48",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "Twilight Is Upon Me (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Light/large/twilightisuponme.gif",
@@ -60193,7 +71226,12 @@
       "gempId": "213_47",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Meditation (V)",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Light/large/meditation.gif",
@@ -60215,7 +71253,12 @@
       "gempId": "213_51",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•He's The Best Smuggler Around",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Light/large/hesthebestsmuggleraround.gif",
@@ -60233,7 +71276,12 @@
       "gempId": "213_49",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Anakin Skywalker",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Light/large/anakinskywalker.gif",
@@ -60254,7 +71302,12 @@
       "gempId": "213_52",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "Help Me Obi-Wan Kenobi & Quite A Mercenary",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Light/large/helpmeobiwankenobi&quiteamercenary.gif",
@@ -60271,7 +71324,12 @@
       "gempId": "213_50",
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "Han's Dice",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Light/large/hansdice.gif",
@@ -60288,7 +71346,12 @@
       "gempId": "213_53",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•I've Got A Really Good Feeling About This",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Light/large/ivegotareallygoodfeelingaboutthis.gif",
@@ -60305,7 +71368,12 @@
       "gempId": "213_54",
       "side": "Light",
       "rarity": "R",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Savareen Standoff",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Light/large/savareenstandoff.gif",
@@ -60322,7 +71390,12 @@
       "gempId": "213_55",
       "side": "Light",
       "rarity": "R1",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Corellia",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Light/large/corellia.gif",
@@ -60355,7 +71428,12 @@
       "gempId": "213_56",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Death Star II: Chasm Walkway",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Light/large/deathstariichasmwalkway.gif",
@@ -60379,7 +71457,12 @@
       "gempId": "213_57",
       "side": "Light",
       "rarity": "U2",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "•Kessel",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Light/large/kessel.gif",
@@ -60413,7 +71496,12 @@
       "gempId": "213_58",
       "side": "Light",
       "rarity": "U",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "Leia's Resistance Transport",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Light/large/leiasresistancetransport.gif",
@@ -60446,7 +71534,12 @@
       "gempId": "213_59",
       "side": "Light",
       "rarity": "C",
-      "set": "Virtual Set 13",
+      "set": "213",
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
       "front": {
         "title": "Rock",
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Light/large/rock.gif",
@@ -60463,7 +71556,12 @@
       "gempId": "301_8",
       "side": "Light",
       "rarity": "U1",
-      "set": "Virtual Premium Set",
+      "set": "301",
+      "printings": [
+        {
+          "set": "301"
+        }
+      ],
       "front": {
         "title": "•Red 12",
         "imageUrl": "https://res.starwarsccg.org/cards/VirtualPremium-Light/large/red12.gif",
@@ -60499,7 +71597,12 @@
       "gempId": "301_7",
       "side": "Light",
       "rarity": "C2",
-      "set": "Virtual Premium Set",
+      "set": "301",
+      "printings": [
+        {
+          "set": "301"
+        }
+      ],
       "front": {
         "title": "•Puck",
         "imageUrl": "https://res.starwarsccg.org/cards/VirtualPremium-Light/large/puck.gif",

--- a/sets.json
+++ b/sets.json
@@ -1,217 +1,380 @@
 [
   {
-    "id": 1,
+    "id": "1",
     "name": "Premiere",
-    "gempName": "Premiere"
+    "gempName": "Premiere",
+    "abbr": "P",
+    "legacy": false
   },
   {
-    "id": 101,
+    "id": "101",
     "name": "Premiere Introductory Two Player Game",
-    "gempName": "Premiere 2-Player"
+    "gempName": "Premiere 2-Player",
+    "abbr": "P2P",
+    "legacy": false
   },
   {
-    "id": 102,
+    "id": "102",
     "name": "Jedi Pack",
-    "gempName": "Jedi Pack"
+    "gempName": "Jedi Pack",
+    "abbr": "J",
+    "legacy": false
   },
   {
-    "id": 103,
+    "id": "103",
     "name": "Rebel Leader Pack",
-    "gempName": "Rebel Leader"
+    "gempName": "Rebel Leader",
+    "abbr": "RLP",
+    "legacy": false
   },
   {
-    "id": 2,
+    "id": "2",
     "name": "A New Hope",
-    "gempName": "A New Hope"
+    "gempName": "A New Hope",
+    "abbr": "ANH",
+    "legacy": false
   },
   {
-    "id": 3,
+    "id": "3",
     "name": "Hoth",
-    "gempName": "Hoth"
+    "gempName": "Hoth",
+    "abbr": "H",
+    "legacy": false
   },
   {
-    "id": 104,
+    "id": "104",
     "name": "Empire Strikes Back Introductory Two Player Game",
-    "gempName": "ESB 2-Player"
+    "gempName": "ESB 2-Player",
+    "abbr": "ESB2P",
+    "legacy": false
   },
   {
-    "id": 4,
+    "id": "4",
     "name": "Dagobah",
-    "gempName": "Dagobah"
+    "gempName": "Dagobah",
+    "abbr": "DAG",
+    "legacy": false
   },
   {
-    "id": 105,
+    "id": "105",
     "name": "First Anthology",
-    "gempName": "1st Anthology"
+    "gempName": "1st Anthology",
+    "abbr": "1A",
+    "legacy": false
   },
   {
-    "id": 5,
+    "id": "5",
     "name": "Cloud City",
-    "gempName": "Cloud City"
+    "gempName": "Cloud City",
+    "abbr": "CC",
+    "legacy": false
   },
   {
-    "id": 6,
+    "id": "6",
     "name": "Jabba's Palace",
-    "gempName": "Jabba's Palace"
+    "gempName": "Jabba's Palace",
+    "abbr": "JP",
+    "legacy": false
   },
   {
-    "id": 106,
+    "id": "106",
     "name": "Official Tournament Sealed Deck",
-    "gempName": "Sealed Deck"
+    "gempName": "Sealed Deck",
+    "abbr": "OTSD",
+    "legacy": false
   },
   {
-    "id": 107,
+    "id": "107",
     "name": "Second Anthology",
-    "gempName": "2nd Anthology"
+    "gempName": "2nd Anthology",
+    "abbr": "2A",
+    "legacy": false
   },
   {
-    "id": 7,
+    "id": "7",
     "name": "Special Edition",
-    "gempName": "Special Edition"
+    "gempName": "Special Edition",
+    "abbr": "SE",
+    "legacy": false
   },
   {
-    "id": 108,
+    "id": "108",
     "name": "Enhanced Premiere",
-    "gempName": "Enhanced Premiere Pack"
+    "gempName": "Enhanced Premiere Pack",
+    "abbr": "EP",
+    "legacy": false
   },
   {
-    "id": 8,
+    "id": "8",
     "name": "Endor",
-    "gempName": "Endor"
+    "gempName": "Endor",
+    "abbr": "EDR",
+    "legacy": false
   },
   {
-    "id": 109,
+    "id": "109",
     "name": "Enhanced Cloud City",
-    "gempName": "Enhanced Cloud City"
+    "gempName": "Enhanced Cloud City",
+    "abbr": "ECC",
+    "legacy": false
   },
   {
-    "id": 110,
+    "id": "110",
     "name": "Enhanced Jabba's Palace",
-    "gempName": "Enhanced Jabba's Palace"
+    "gempName": "Enhanced Jabba's Palace",
+    "abbr": "EJP",
+    "legacy": false
   },
   {
-    "id": 111,
+    "id": "111",
     "name": "Third Anthology",
-    "gempName": "3rd Anthology"
+    "gempName": "3rd Anthology",
+    "abbr": "3A",
+    "legacy": false
   },
   {
-    "id": 9,
+    "id": "9",
     "name": "Death Star II",
-    "gempName": "Death Star II"
+    "gempName": "Death Star II",
+    "abbr": "DS2",
+    "legacy": false
   },
   {
-    "id": 112,
+    "id": "112",
     "name": "Jabba's Palace Sealed Deck",
-    "gempName": "Jabba's Palace Sealed Deck"
+    "gempName": "Jabba's Palace Sealed Deck",
+    "abbr": "JPSD",
+    "legacy": false
   },
   {
-    "id": 10,
+    "id": "10",
     "name": "Reflections II",
-    "gempName": "Reflections II"
+    "gempName": "Reflections II",
+    "abbr": "Ref2",
+    "legacy": false
   },
   {
-    "id": 11,
+    "id": "11",
     "name": "Tatooine",
-    "gempName": "Tatooine"
+    "gempName": "Tatooine",
+    "abbr": "TAT",
+    "legacy": false
   },
   {
-    "id": 12,
+    "id": "12",
     "name": "Coruscant",
-    "gempName": "Coruscant"
+    "gempName": "Coruscant",
+    "abbr": "COR",
+    "legacy": false
   },
   {
-    "id": 13,
+    "id": "13",
     "name": "Reflections III",
-    "gempName": "Reflections III"
+    "gempName": "Reflections III",
+    "abbr": "Ref3",
+    "legacy": false
   },
   {
-    "id": 14,
+    "id": "14",
     "name": "Theed Palace",
-    "gempName": "Theed Palace"
+    "gempName": "Theed Palace",
+    "abbr": "TP",
+    "legacy": false
   },
   {
-    "id": 200,
+    "id": "200",
     "name": "Virtual Set 0",
-    "gempName": "Set 0"
+    "gempName": "Set 0",
+    "abbr": "V0",
+    "legacy": false
   },
   {
-    "id": 201,
+    "id": "201",
     "name": "Virtual Set 1",
-    "gempName": "Set 1"
+    "gempName": "Set 1",
+    "abbr": "V1",
+    "legacy": false
   },
   {
-    "id": 202,
+    "id": "202",
     "name": "Virtual Set 2",
-    "gempName": "Set 2"
+    "gempName": "Set 2",
+    "abbr": "V2",
+    "legacy": false
   },
   {
-    "id": 203,
+    "id": "203",
     "name": "Virtual Set 3",
-    "gempName": "Set 3"
+    "gempName": "Set 3",
+    "abbr": "V3",
+    "legacy": false
   },
   {
-    "id": 204,
+    "id": "204",
     "name": "Virtual Set 4",
-    "gempName": "Set 4"
+    "gempName": "Set 4",
+    "abbr": "V4",
+    "legacy": false
   },
   {
-    "id": 205,
+    "id": "205",
     "name": "Virtual Set 5",
-    "gempName": "Set 5"
+    "gempName": "Set 5",
+    "abbr": "V5",
+    "legacy": false
   },
   {
-    "id": 206,
+    "id": "206",
     "name": "Virtual Set 6",
-    "gempName": "Set 6"
+    "gempName": "Set 6",
+    "abbr": "V6",
+    "legacy": false
   },
   {
-    "id": 207,
+    "id": "207",
     "name": "Virtual Set 7",
-    "gempName": "Set 7"
+    "gempName": "Set 7",
+    "abbr": "V7",
+    "legacy": false
   },
   {
-    "id": 208,
+    "id": "208",
     "name": "Virtual Set 8",
-    "gempName": "Set 8"
+    "gempName": "Set 8",
+    "abbr": "V8",
+    "legacy": false
   },
   {
-    "id": 209,
+    "id": "209",
     "name": "Virtual Set 9",
-    "gempName": "Set 9"
+    "gempName": "Set 9",
+    "abbr": "V9",
+    "legacy": false
   },
   {
-    "id": 210,
+    "id": "210",
     "name": "Virtual Set 10",
-    "gempName": "Set 10"
+    "gempName": "Set 10",
+    "abbr": "V10",
+    "legacy": false
   },
   {
-    "id": 211,
+    "id": "211",
     "name": "Virtual Set 11",
-    "gempName": "Set 11"
+    "gempName": "Set 11",
+    "abbr": "V11",
+    "legacy": false
   },
   {
-    "id": 212,
+    "id": "212",
     "name": "Virtual Set 12",
-    "gempName": "Set 12"
+    "gempName": "Set 12",
+    "abbr": "V12",
+    "legacy": false
   },
   {
-    "id": 213,
+    "id": "213",
     "name": "Virtual Set 13",
-    "gempName": "Set 13"
+    "gempName": "Set 13",
+    "abbr": "V13",
+    "legacy": false
   },
   {
-    "id": 301,
+    "id": "301",
     "name": "Demo Deck",
-    "gempName": "Virtual Premium Set"
+    "gempName": "Virtual Premium Set",
+    "abbr": "VP",
+    "legacy": false
   },
   {
-    "id": 401,
+    "id": "401",
     "name": "Dream Cards",
-    "gempName": "Dream Cards"
+    "gempName": "Dream Cards",
+    "abbr": "DC",
+    "legacy": false
   },
   {
-    "id": 501,
+    "id": "501",
     "name": "Playtesting",
-    "gempName": "Playtesting"
+    "gempName": "Playtesting",
+    "abbr": "PT",
+    "legacy": false
+  },
+  {
+    "id": "200d",
+    "name": "Virtual Defensive Shields",
+    "gempName": "Set D",
+    "abbr": "VDS",
+    "legacy": false
+  },
+  {
+    "id": "1001",
+    "name": "Virtual Block 1",
+    "gempName": "Block 1",
+    "abbr": "VB1",
+    "legacy": true
+  },
+  {
+    "id": "1002",
+    "name": "Virtual Block 2",
+    "gempName": "Block 2",
+    "abbr": "VB2",
+    "legacy": true
+  },
+  {
+    "id": "1003",
+    "name": "Virtual Block 3",
+    "gempName": "Block 3",
+    "abbr": "VB3",
+    "legacy": true
+  },
+  {
+    "id": "1004",
+    "name": "Virtual Block 4",
+    "gempName": "Block 4",
+    "abbr": "VB4",
+    "legacy": true
+  },
+  {
+    "id": "1005",
+    "name": "Virtual Block 5",
+    "gempName": "Block 5",
+    "abbr": "VB5",
+    "legacy": true
+  },
+  {
+    "id": "1006",
+    "name": "Virtual Block 6",
+    "gempName": "Block 6",
+    "abbr": "VB6",
+    "legacy": true
+  },
+  {
+    "id": "1007",
+    "name": "Virtual Block 7",
+    "gempName": "Block 7",
+    "abbr": "VB7",
+    "legacy": true
+  },
+  {
+    "id": "1008",
+    "name": "Virtual Block 8",
+    "gempName": "Block 8",
+    "abbr": "VB8",
+    "legacy": true
+  },
+  {
+    "id": "1009",
+    "name": "Virtual Block 9",
+    "gempName": "Block 9",
+    "abbr": "VB9",
+    "legacy": true
+  },
+  {
+    "id": "1000d",
+    "name": "Virtual Block Shields",
+    "gempName": "Block D",
+    "abbr": "VBDS",
+    "legacy": true
   }
 ]


### PR DESCRIPTION
- Updated sets.json with legacy sets and the defensive shields sets. Added "legacy" and "abbr" fields. Converted the "id" to be a String instead of an Int. Moved all virtual defensive shields into the new shield sets.
- Added the "printings" field for every card.  For now, each printing only contains a set id, but we can expand on this in the future.  This handles the anthology cards as discussed in #50.
