### PR TITLE
Admiral Trench

### DIFF
--- a/Dark.json
+++ b/Dark.json
@@ -52299,7 +52299,7 @@
       "id": 6781,
       "gempId": "212_5",
       "side": "Dark",
-      "rarity": "C",
+      "rarity": "C2",
       "set": "212",
       "printings": [
         {


### PR DESCRIPTION
The admiral should be rarity C2 to match the Bespin Motors Void Spider THX 1138 card rarity he is based on.