### PR TITLE
Blank Lore Shields

### DIFF
--- a/Dark.json
+++ b/Dark.json
@@ -23026,7 +23026,8 @@
         "icons": [
           "Defensive Shield"
         ],
-        "gametext": "Plays on table. Goo Nee Tay is canceled. Unless Deep Hatred on table, opponent may use only one combat card per turn. We'll Handle This may target only Undercover spies and 5D6-RA-7."
+        "gametext": "Plays on table. Goo Nee Tay is canceled. Unless Deep Hatred on table, opponent may use only one combat card per turn. We'll Handle This may target only Undercover spies and 5D6-RA-7.",
+        "lore": "Darth Vader ruthlessly used the Force to strike down enemies and soldiers who displeased him. He could choke victims from afar without touching them."
       },
       "counterpart": "Affect Mind (V) - Defensive Shield",
       "cancels": [
@@ -24330,7 +24331,8 @@
           "Defensive Shield",
           "Reflections III"
         ],
-        "gametext": "Plays on table. For opponent to deploy a character, starship, or vehicle for free (except by that card's own game text), opponent must first use 2 Force."
+        "gametext": "Plays on table. For opponent to deploy a character, starship, or vehicle for free (except by that card's own game text), opponent must first use 2 Force.",
+        "lore": "Blank."
       },
       "legacy": false
     },
@@ -49688,7 +49690,8 @@
         "icons": [
           "Defensive Shield"
         ],
-        "gametext": "Plays on table. While you have 12 or fewer cards in hand, opponent may not remove cards from your hand (except with Grimtaash). Once per turn (even at start of turn), may target a [Coruscant] Political Effect; it is suspended for the remainder of the turn."
+        "gametext": "Plays on table. While you have 12 or fewer cards in hand, opponent may not remove cards from your hand (except with Grimtaash). Once per turn (even at start of turn), may target a [Coruscant] Political Effect; it is suspended for the remainder of the turn.",
+        "lore": "Blank."
       },
       "counterpart": "The Republic No Longer Functions",
       "legacy": false

--- a/Light.json
+++ b/Light.json
@@ -53743,7 +53743,7 @@
           "Defensive Shield"
         ],
         "gametext": "Plays on table. Colo Claw Fish is canceled. Opponent must first use X Force to deploy a non-unique card (except a Jawa or Tusken Raider) to a location, where X = the number of copies of that card at that location.",
-        "lore": "Blank."
+        "lore": "Rebel sentries are stationed on raised sensor platforms. On watch for Imperial scouts and other hazards, they supplement data gathered by Yavin Base's main sensors."
       },
       "cancels": [
         "Colo Claw Fish"

--- a/Light.json
+++ b/Light.json
@@ -18947,7 +18947,8 @@
         "icons": [
           "Defensive Shield"
         ],
-        "gametext": "Plays on table. For opponent to deploy a character, starship, or vehicle for free (except by that card's own game text), opponent must first use 2 Force."
+        "gametext": "Plays on table. For opponent to deploy a character, starship, or vehicle for free (except by that card's own game text), opponent must first use 2 Force.",
+        "lore": "Blank."
       },
       "counterpart": "Imperial Detention",
       "legacy": false
@@ -48670,7 +48671,8 @@
         "icons": [
           "Defensive Shield"
         ],
-        "gametext": "Plays on table. While you have 12 or fewer cards in hand, opponent may not remove cards from your hand (except with Monnok). Once per turn (even at start of turn), may target a [Coruscant] Political Effect; it is suspended for the remainder of the turn."
+        "gametext": "Plays on table. While you have 12 or fewer cards in hand, opponent may not remove cards from your hand (except with Monnok). Once per turn (even at start of turn), may target a [Coruscant] Political Effect; it is suspended for the remainder of the turn.",
+        "lore": "Blank."
       },
       "legacy": false
     },
@@ -53740,7 +53742,8 @@
         "icons": [
           "Defensive Shield"
         ],
-        "gametext": "Plays on table. Colo Claw Fish is canceled. Opponent must first use X Force to deploy a non-unique card (except a Jawa or Tusken Raider) to a location, where X = the number of copies of that card at that location."
+        "gametext": "Plays on table. Colo Claw Fish is canceled. Opponent must first use X Force to deploy a non-unique card (except a Jawa or Tusken Raider) to a location, where X = the number of copies of that card at that location.",
+        "lore": "Blank."
       },
       "cancels": [
         "Colo Claw Fish"


### PR DESCRIPTION
Added Lore: Blank to some defensive shields consistent with other defensive shields with blank lore.

Added actual lore text to some defensive shields where the card image includes the lore from the virtualized case.
