### PR TITLE
Fix Slave I, Symbol of Fear in matching lists

### DIFF
--- a/Dark.json
+++ b/Dark.json
@@ -5937,8 +5937,7 @@
       ],
       "matching": [
         "Slave I",
-        "Slave I",
-        "Symbol of Fear"
+        "Slave I, Symbol of Fear"
       ],
       "matchingWeapon": [
         "Boba Fett's Blaster Rifle",
@@ -5993,8 +5992,7 @@
       ],
       "matching": [
         "Slave I",
-        "Slave I",
-        "Symbol of Fear"
+        "Slave I, Symbol of Fear"
       ],
       "matchingWeapon": [
         "Boba Fett's Blaster Rifle",
@@ -6168,8 +6166,7 @@
       ],
       "matching": [
         "Slave I",
-        "Slave I",
-        "Symbol of Fear"
+        "Slave I, Symbol of Fear"
       ],
       "cancels": [
         "Mace Windu (V) prevents Fetts from adding battle destiny draws at same location"
@@ -6222,8 +6219,7 @@
       ],
       "matching": [
         "Slave I",
-        "Slave I",
-        "Symbol of Fear"
+        "Slave I, Symbol of Fear"
       ],
       "matchingWeapon": [
         "Boba Fett's Blaster Rifle"


### PR DESCRIPTION
I think the `,` in `Slave I, Symbol of Fear` messed up on someone's JSON parser at some point, and the `matching` key has separated them as though they were two different array elements.