### PR TITLE
Fixed LS Space Slug ferocity.

### DIFF
--- a/Light.json
+++ b/Light.json
@@ -48784,7 +48784,7 @@
         "extraText": [
           "HIDE: 3"
         ],
-        "ferocity": "2",
+        "ferocity": "two destiny",
         "forfeit": "0",
         "gametext": "* Ferocity = two destiny. Habitat: Big One (Cave is now Belly). Attacks starfighters (defeated cards are eaten or relocated to Belly, opponent of victim chooses). Once per turn, may open or close mouth.",
         "icons": [


### PR DESCRIPTION
I noticed this inconsistency.  This brings it in line with the other creatures.

As a side note, I'm not sure ferocity is being handled the same as all other fields now, and I think we may want to update all ferocity's that contain an asterisk to actually have the asterisk in the data.  That way the data represents exactly what is printed on the card.