### PR TITLE
Updating sets.json for Set 18

### DIFF
--- a/sets.json
+++ b/sets.json
@@ -484,6 +484,17 @@
     "size": 52
   },
   {
+    "id": "218",
+    "name": "Virtual Set 18",
+    "gempName": "Set 18",
+    "abbr": "V18",
+    "legacy": false,
+    "cycle_code": "full",
+    "date_release": "2022-03-09",
+    "position": 218,
+    "size": 6
+  },
+  {
     "id": "301",
     "name": "Demo Deck",
     "gempName": "Virtual Premium Set",


### PR DESCRIPTION
For now we list it as March 9 release of 6 cards, but later we update the date and size when the rest of the set releases.