### PR TITLE
Set 20, 2020 AIs, PreErrata files, minor fixes

### DIFF
--- a/Dark.json
+++ b/Dark.json
@@ -429,7 +429,7 @@
           "rifle"
         ],
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 4 Force to deploy on your warrior, free on 4-LOM. May target a character or creature for free at same site or exterior site up to 2 sites away. Draw destiny. Add 1 if Blaster Scope attached. If total destiny - distance to target > defense value, target hit.",
         "icons": [
           "Dagobah"
@@ -473,7 +473,7 @@
         ],
         "deploy": "4",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Servant Droid"
         ],
@@ -639,7 +639,7 @@
       "counterpart": "They're Tracking Us (V)",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If opponent's starting location was Massassi Throne Room, opponent loses 1 Force when you play this Interrupt. Add or subtract 1 from opponent's just drawn destiny. OR Activate 1 Force. OR Until end of turn, battle destiny draws may not be canceled (unless being redrawn) or modified.",
         "icons": [
           "Set 1"
@@ -736,7 +736,7 @@
       "counterpart": "A Tremor In The Force",
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Once per game, during your deploy phase, 'insert' (face down) into opponent's Reserve Deck; reshuffle. When effect reaches top it is immediately lost, but opponent may not activate any more Force that turn. (Immune to Alter.)",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/adisturbanceintheforce.gif",
         "lore": "The destruction of Alderaan caused a great disturbance in the Force '...as if millions of voices suddenly cried out in terror and were suddenly silenced.'",
@@ -1056,7 +1056,7 @@
       "counterpart": "Civil Disorder",
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on opponent's side of table. At the end of opponent's deploy phase, if they did not deploy a card with ability, opponent loses 2 Force. Effect lost if opponent has more cards with ability on table than you. (Immune to Alter.)",
         "icons": [
           "Cloud City"
@@ -1436,7 +1436,7 @@
         ],
         "deploy": "3",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Attuned"
         ],
@@ -1540,7 +1540,7 @@
         ],
         "deploy": "0",
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "Adds 2 to the power of anything he pilots. Subtracts 1 from deploy cost of each of your capital starships at same system. Lost if Vader on table and opponent 'reacts' to same location as Ozzel.",
         "icons": [
@@ -1656,7 +1656,7 @@
         ],
         "deploy": "3",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "2",
         "gametext": "Adds 2 to power of anything he pilots. Whenever you deploy a weapon or device from hand at same location, activate 1 Force as a 'kickback.' Limit of one Advosze per location.",
         "icons": [
@@ -2126,7 +2126,7 @@
       ],
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If an opponent's character at the Carbonite Chamber was just 'hit' by a lightsaber, deploy on that character. Character is instead immediately captured and 'frozen.' If captive released, lose Immediate Effect. (Immune to Control.)",
         "icons": [
           "Cloud City"
@@ -2160,7 +2160,7 @@
     {
       "front": {
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your side of table. We Have A Prisoner and Oo-ta Goo-ta, Solo? play for free and are immune to Sense. If opponent's character is about to be forfeited, your bounty hunter present may capture that character (character is first restored to normal). (Immune to Alter.)",
         "icons": [
           "Jabba's Palace"
@@ -2716,7 +2716,7 @@
           "laser cannon"
         ],
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 3 Force to deploy on your transport vehicle. If your warrior aboard here, may target a character or creature using 3 Force. Draw destiny. Target hit if destiny +2 > defense value. May fire repeatedly for 2 Force each time.",
         "icons": [
           "Jabba's Palace"
@@ -3019,7 +3019,7 @@
         ],
         "deploy": "5",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Sensitive"
         ],
@@ -3269,7 +3269,7 @@
           "rifle"
         ],
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 3 Force to deploy on your warrior. May target a character, creature or vehicle at same or adjacent site using 2 Force. Draw destiny. Target hit if destiny +1 > defense value.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/assaultrifle.gif",
         "lore": "BlasTech model DLT-19 'heavy blaster rifle.' Enhanced with extra power packs and greater range.",
@@ -3329,7 +3329,7 @@
       ],
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 3 Force to deploy on opponent's side of table. All opponent's starships with a [Nav Computer] icon are deploy +1.",
         "icons": [
           "A New Hope"
@@ -3394,7 +3394,7 @@
           "laser cannon"
         ],
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 2 Force to deploy on your AT-AT. May target a starfighter (use 3 as defense value), character, creature or vehicle at same or adjacent site using 2 Force. Draw destiny. Add 1 if targeting a character or creature, 2 if a vehicle. Target hit if total destiny > defense value.",
         "icons": [
           "Hoth"
@@ -3524,7 +3524,7 @@
       ],
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If you just initiated a battle at a Cloud City sector, add one battle destiny. OR During your deploy phase, deploy one TIE Assault Squadron for free (no replacement is necessary).",
         "icons": [
           "Cloud City"
@@ -3649,7 +3649,7 @@
           "rifle"
         ],
         "destiny": "7",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on Aurra Sing. May target a character or creature for free. Target loses all immunity to attrition for remainder of turn. Draw destiny. Target hit if destiny +1 > defense value. Jedi hit by Aurra Sing are power = 0 for remainder of battle.",
         "icons": [
           "Episode I",
@@ -3935,7 +3935,7 @@
       "counterpart": "Ellorrs Madak",
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your non-pilot character (except droids) to give that character [Pilot] skill.  Adds 2 to power of anything that character pilots. OR Deploy on your pilot. Adds 1 to power of anything that character pilots. (Immune to Alter.)",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/banisskeeg.gif",
         "lore": "Duros are famous spacers and starship engineers. Many are forced to work for the Empire. Some, like Baniss Keeg, train pilots for deep space missions.",
@@ -4096,7 +4096,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on an exterior Tatooine site. Specify starting location. During your control phase, moves to next adjacent site (reversing direction as necessary). During battle here, if your tusken raider or bantha here may add one battle destiny.",
         "icons": [
           "Special Edition"
@@ -4129,7 +4129,7 @@
         "ability": "1",
         "deploy": "5",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Deploys only to a Jabba's Palace site. Power = 0 at any location other than a Tatooine site. Power +2 at any Jabba's Palace site while Jabba is on the table. Your transport vehicles lost from same site may go to your Used Pile rather than your Lost Pile.",
         "icons": [
@@ -4554,7 +4554,7 @@
         ],
         "deploy": "*",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "2",
         "gametext": "* Replaces any male Rodian for free (Rodian goes to the Used Pile) or deploys for 3 Force. While at Audience Chamber, all your Rodians are power +2, and whenever Greedo threatens a smuggler, may add 2 to destiny draw.",
         "icons": [
@@ -4665,7 +4665,7 @@
       ],
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on a captured starship. Your characters present with captured starship may battle opponent's characters aboard it (as if present together at a site). Effect canceled if starship escapes or is stolen.",
         "icons": [
           "A New Hope"
@@ -4737,7 +4737,7 @@
         ],
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "May add 3 passengers.  Permanent pilot provides ability of 1. May move as a 'react.'  *Landspeed = 3.  OR  Up to 3 characters may shuttle to or from same site for free.",
         "icons": [
@@ -5128,7 +5128,7 @@
         ],
         "deploy": "1",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "No Hyperdrive"
         ],
@@ -5296,7 +5296,7 @@
         ],
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "No Hyperdrive"
         ],
@@ -5430,7 +5430,7 @@
         ],
         "deploy": "4",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "No Hyperdrive"
         ],
@@ -5564,7 +5564,7 @@
       ],
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "During your control phase, fire (for free) one of your blasters carried by a trooper or one of your automated weapons. Any hit targets are immediately lost.",
         "icons": [
           "Cloud City"
@@ -5594,7 +5594,7 @@
     {
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your side of table. At any time, you may transfer one of your character weapons from any site to the Blaster Rack. During your deploy phase, weapon may be transferred to your character on table for an expenditure of Force equal to the weapon's deploy cost.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/blasterrack.gif",
         "lore": "Imperial facilities like the Death Star and garrison bases have blaster racks at key locations to equip soldiers with weapons like blaster rifles and thermal detonators.",
@@ -5625,7 +5625,7 @@
       "counterpart": "Sai'torr Kal Fas (V)",
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on table. Once per turn, may deploy a matching weapon on your unique (•) character present at a site from Reserve Deck; reshuffle. (Immune to Alter.)",
         "icons": [
           "Set 0"
@@ -5666,7 +5666,7 @@
           "rifle"
         ],
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 2 Force to deploy on your warrior. May target a character, creature or vehicle using 2 Force. Draw destiny. Target hit if destiny +1 > defense value.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/blasterrifle.gif",
         "lore": "Stormtrooper BlasTech E-11 blaster rifle. Can convert from a pistol to a rifle configuration by using extendable stock. Carries 100 shots. Military issue only.",
@@ -5736,7 +5736,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on [Dagobah] 4-LOM's Concussion Rifle or on your blaster weapon card. Allows that weapon to target at an adjacent site.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/blasterscope.gif",
         "lore": "The effectiveness of a blaster can sometimes be enhanced through an electronic targeting scope mounted on top, especially for long range targets.",
@@ -5769,7 +5769,7 @@
         ],
         "deploy": "6",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "7",
         "gametext": "May add 2 pilots and 8 passengers. Immune to attrition < 4. When using AT-AT cannon to Target The Main Generator, adds 1 to total. Landspeed may not be increased.",
         "icons": [
@@ -5817,7 +5817,7 @@
         ],
         "deploy": "6",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "6",
         "gametext": "May add 1 pilot and 8 passengers. Immune to attrition < 4. Permanent pilot aboard provides ability of 2. Landspeed may not be increased.",
         "icons": [
@@ -6065,7 +6065,7 @@
         ],
         "deploy": "3",
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "5",
         "gametext": "May add 1 pilot or passenger. May move as a 'react.' Power +1 at any Hoth site. Permanent pilot provides ability of 1.",
         "icons": [
@@ -6158,7 +6158,7 @@
         ],
         "deploy": "6",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "6",
         "gametext": "May add 2 pilots and 8 passengers. Immune to attrition < 4. Landspeed may not be increased.",
         "icons": [
@@ -6335,7 +6335,7 @@
       "front": {
         "darkSideIcons": 1,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Dark:  If you occupy, Force generation +1 here, and opponent's characters may not move from here.  Light:  Your Jedi deploy +2 here.",
         "icons": [
           "Interior",
@@ -6855,7 +6855,7 @@
           "rifle"
         ],
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to deploy on Boba Fett, or 3 on your other bounty hunter. May deploy as a 'react.' May target a character, creature or vehicle using 2 Force. Draw destiny. Add 1 if targeting a vehicle. Target hit if total destiny > defense value. May fire repeatedly for 1 Force each time.",
         "icons": [
           "Cloud City"
@@ -6980,7 +6980,7 @@
         ],
         "deploy": "2",
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "FLIGHT: 2"
         ],
@@ -7109,7 +7109,7 @@
           "cannon"
         ],
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to deploy on your TIE Advanced x1. May target a starship using 1 Force. Draw destiny. Subtract 1 if targeting a capital starship. Add 1 if targeting a starfighter. Target hit if total destiny > defense value.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/boostedtiecannon.gif",
         "lore": "Enhanced TIE blaster cannon prototype. Greater range and power. Improved targeting software. Requires more powerful energy cells. Tested by elite TIE squadrons.",
@@ -7182,7 +7182,7 @@
         ],
         "deploy": "4",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Adds 2 to power of anything he pilots. When piloting Hound's Tooth, draws one battle destiny if not able to otherwise. Adds 1 to attrition against opponent in battles at same site. While present, may reduce Chewie's forfeit to zero while here.",
         "icons": [
@@ -7447,7 +7447,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on an opponent's non-droid character. If subsequently captured, seized by a bounty hunter and then transferred to a prison, retrieve Force equal to character's forfeit -2 and place Effect in Used Pile. (Immune to Alter.)",
         "icons": [
           "Cloud City"
@@ -7484,7 +7484,7 @@
       "conceptBy": "(Original concept by Justin Desai)",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on table. Once per game, may take Finalizer into hand from Reserve Deck; reshuffle. Once per character, when you deploy Hux, Kylo, Phasma, or Snoke to an [Episode VII] battleground, may take any one card from Used Pile into hand; reshuffle. (Immune to Alter.)",
         "icons": [
           "Episode VII",
@@ -7792,7 +7792,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If opponent just initiated a Force drain at a non-shielded planet location, deploy on that location. Your characters, vehicles and starships may deploy here regardless of presence and location deployment restrictions. (Immune to Control.)",
         "icons": [
           "Jabba's Palace"
@@ -8051,7 +8051,7 @@
         ],
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Deploys -2 aboard Scimitar 2. Adds 2 to power of anything he pilots. When forfeited from a TIE/sa he is piloting, also satisfies all remaining attrition and battle damage against you.",
         "icons": [
@@ -8134,7 +8134,7 @@
         ],
         "deploy": "3",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Once during each of your control phases, you may use 2 Force to take one Scanning Crew into hand from Reserve Deck; reshuffle.",
         "icons": [
@@ -8178,7 +8178,7 @@
         ],
         "deploy": "3",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "5",
         "gametext": "Adds 2 to power of anything he pilots (3 if starship is Tyrant). When on a Star Destroyer, may use its tractor beam once during each of your control phases.",
         "icons": [
@@ -8220,7 +8220,7 @@
         ],
         "deploy": "3",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Attuned"
         ],
@@ -8268,7 +8268,7 @@
         ],
         "deploy": "3",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "5",
         "gametext": "Adds 3 to power of anything he pilots. Deploys -1 to Finalizer. While piloting Finalizer, it is immune to attrition <8 (< 10 while with a Resistance character or [Resistance] starship). May be targeted by Imperial Command as an admiral (even if a unit of Force).",
         "icons": [
@@ -8405,7 +8405,7 @@
         "ability": "3",
         "deploy": "3",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Attuned"
         ],
@@ -8605,7 +8605,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on Carbonite Chamber. Adds 3 to Carbon-Freezing destiny. Also, once during each of your turns, you may use 1 Force to take one Ugnaught, Prepare The Chamber or Carbon-Freezing into hand from Reserve Deck; reshuffle.",
         "icons": [
           "Cloud City"
@@ -8747,7 +8747,7 @@
         ],
         "deploy": "4",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Attuned"
         ],
@@ -8851,7 +8851,7 @@
         "ability": "2",
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Adds 2 to power of anything he pilots. Power +1 at same site as Tarkin. If a battle was just initiated at a system where Bast is present with your non-droid character, may 'evacuate' (relocate) both to a related site.",
         "icons": [
@@ -8919,7 +8919,7 @@
         "ability": "2",
         "deploy": "3",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "May use 3 Force to 'hide' (be excluded) from a battle. May use 2 Force to target one device or weapon present which deploys on a site. Draw destiny. If destiny > target's deploy cost, target is lost.",
         "icons": [
@@ -9231,7 +9231,7 @@
           "blaster"
         ],
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 2 Force to deploy on your warrior at a Cloud City site. May target a character or creature using 2 Force. Draw destiny. Target hit (and may not be used to satisfy attrition) if destiny > defense value.",
         "icons": [
           "Cloud City"
@@ -9469,7 +9469,7 @@
       "front": {
         "darkSideIcons": 2,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Dark:  If Weather Vane on table, characters 'hit' here are instead immediately relocated there.  Light:  If Weather Vane on table, characters 'hit' here are instead immediately relocated there.",
         "icons": [
           "Interior",
@@ -9706,7 +9706,7 @@
       "front": {
         "darkSideIcons": 1,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Dark:  Force drain +1 here. Your aliens are deploy -1 and power +1 here.  Light:  Force drain +1 here.",
         "icons": [
           "Exterior",
@@ -10067,7 +10067,7 @@
       "counterpart": "Colo Claw Fish",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on table. Cancels Opee Sea Killer. While no card here, you may place a card from hand face-up here. If you just drew weapon or battle destiny, you may exchange it for card here, which then counts as that destiny draw. (Immune to Alter.)",
         "icons": [
           "Episode I",
@@ -10528,7 +10528,7 @@
       ],
       "front": {
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Plays on table. While you occupy a battleground and opponent occupies less than two battlegrounds, cancel: Asteroid Sanctuary, opponent's Force drains at non-battleground locations, and opponent's Force retrieval.",
         "icons": [
           "Defensive Shield",
@@ -10555,7 +10555,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on table. Unless opponent occupies at least two battlegrounds, cancels: Asteroid Sanctuary, opponent's Force drains at non-battleground locations and opponent's Force retrieval. (Immune to Alter if you occupy any battleground.)",
         "icons": [
           "Special Edition"
@@ -10582,7 +10582,7 @@
       "counterpart": "Eject! Eject!",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to target a starfighter having one or more permanent pilots. Draw destiny. If destiny > 2, deploy on starfighter to remove all permanent pilots (otherwise, Effect is lost). May add one pilot for each permanent pilot removed. (Immune to Alter.)",
         "icons": [
           "A New Hope"
@@ -10642,7 +10642,7 @@
         "ability": "2",
         "deploy": "3",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Adds 2 to power of anything he pilots, and that starship or vehicle moves for free.",
         "icons": [
@@ -10680,7 +10680,7 @@
         ],
         "deploy": "3",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Attuned"
         ],
@@ -10795,7 +10795,7 @@
         ],
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Adds 2 to power of anything he pilots. Your shuttling, landing and taking off to or from same location is free. During your control phase, may take one Lambda shuttle or Landing Craft into hand from Reserve Deck; reshuffle.",
         "icons": [
@@ -11012,7 +11012,7 @@
         ],
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Adds 1 to power and maneuver of anything he pilots. Opponent may not 'react' to or from same location.",
         "icons": [
@@ -11112,7 +11112,7 @@
         ],
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Adds 2 to power of anything he pilots. When piloting Devastator, also adds 1 to hyperspeed. Where present, cancels game text of C-3PO or R2-D2.",
         "icons": [
@@ -11301,7 +11301,7 @@
     {
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on table. Once during your deploy phase, you may deploy a non-Interrupt card with 'door' in title from your Reserve Deck; reshuffle. At Endor sites where you have a scout, Rebel scouts are power -1 and forfeit -3. (Immune to Alter.)",
         "icons": [
           "Reflections 3"
@@ -11347,7 +11347,7 @@
         ],
         "deploy": "8",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "9",
         "gametext": "May add 6 pilots, 8 passengers, 2 vehicles and 4 TIEs. Has ship-docking capability. Permanent pilot provides ability of 1. Just after initiating battle against Falcon, may peek at opponent's hand.",
         "hyperspeed": "3",
@@ -12461,7 +12461,7 @@
       "front": {
         "darkSideIcons": 2,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Dark:  Emperor deploys free here. If your moff here, all Imperials are deploy -1 at sites.  Light:  Force drain +1 here. If you control, Emperor may not deploy to Coruscant.",
         "icons": [
           "Exterior",
@@ -12604,8 +12604,7 @@
         }
       ],
       "pulledBy": [
-        "Always Two There Are",
-        "Sith Fury (V)"
+        "Always Two There Are"
       ],
       "pulls": [
         "Force Lightning or Force Push"
@@ -12769,7 +12768,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If you have a piloted AT-AT present at a site, target opponent's non-creature vehicle present at same or adjacent exterior site. Draw destiny. If AT-AT has a vehicle weapon, add 1 to destiny draw. Target 'crashes' if total destiny > 3.",
         "icons": [
           "Hoth"
@@ -12928,7 +12927,7 @@
       "front": {
         "darkSideIcons": 2,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Dark:  If you occupy, opponent may not Force drain at related locations.  Light:  Neither player may Force drain here.",
         "icons": [
           "Planet",
@@ -12995,7 +12994,7 @@
         ],
         "deploy": "4",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Attuned"
         ],
@@ -13033,7 +13032,7 @@
       "front": {
         "darkSideIcons": 1,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Dark:  Your starships may move here as a 'react'.  Light:  (none)",
         "icons": [
           "Planet"
@@ -13108,7 +13107,7 @@
         ],
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Adds 3 to power of anything he pilots. Adds 1 to weapon destiny draws of anything he is aboard as a passenger.",
         "icons": [
@@ -13245,7 +13244,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Select one site under 'nighttime conditions.' Target every character there (except droids) and draw one destiny each. If destiny > ability, character 'sleeps' (power, forfeit and ability = 0, 'game text' unusable) until the end of your next turn.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/darkhours.gif",
         "lore": "After surviving Tarkin's extortion, kidnapping, threats of execution and the assault of the Interceptor droid, Princess Leia was asleep when her rescuers came.",
@@ -13281,7 +13280,7 @@
           "lightsaber"
         ],
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use X Force to deploy on your warrior where X = (7 - warrior's ability). May add 1 to Force drain where present. May target a character or creature using X Force. Draw two destiny. Target hit if total destiny > defense value.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/darkjedilightsaber.gif",
         "lore": "Multifaceted jewels focus light into a deadly blade. Projects a meter-long beam of pure energy. A lightsaber is constructed personally by a Jedi as a part of training.",
@@ -13424,7 +13423,7 @@
       ],
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If opponent just initiated a duel, use 3 Force to cancel it. OR Take Deep Hatred into hand from Reserve Deck; reshuffle. OR If Maul has no combat cards, target a Jedi to place one of their combat cards (random selection) in opponent's Used Pile. (Immune to Sense.)",
         "icons": [
           "Episode I",
@@ -13463,7 +13462,7 @@
       "counterpart": "Blaster Proficiency",
       "front": {
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If you just targeted with a lightsaber, add 3 to your weapon destiny. OR Cancel Swing-And-A-Miss. OR Lose 1 Force to cause one opponent's character just 'hit' to be immediately placed in Lost Pile.",
         "icons": [
           "Cloud City"
@@ -13655,9 +13654,6 @@
           "set": "11"
         }
       ],
-      "pulledBy": [
-        "Sith Fury (V)"
-      ],
       "rarity": "R",
       "rulings": [
         "The loser of the duel is the character with the lower total.",
@@ -13757,9 +13753,6 @@
           "set": "14"
         }
       ],
-      "pulledBy": [
-        "Sith Fury (V)"
-      ],
       "rarity": "R",
       "set": "14",
       "side": "Dark"
@@ -13781,7 +13774,7 @@
         ],
         "deploy": "6",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Dark Jedi"
         ],
@@ -13815,9 +13808,6 @@
         {
           "set": "203"
         }
-      ],
-      "pulledBy": [
-        "Sith Fury (V)"
       ],
       "rarity": "U",
       "rulings": [
@@ -13870,9 +13860,6 @@
         {
           "set": "12"
         }
-      ],
-      "pulledBy": [
-        "Sith Fury (V)"
       ],
       "rarity": "R",
       "set": "12",
@@ -13952,9 +13939,6 @@
           "set": "14"
         }
       ],
-      "pulledBy": [
-        "Sith Fury (V)"
-      ],
       "rarity": "R",
       "set": "14",
       "side": "Dark"
@@ -14008,7 +13992,7 @@
         "ability": "6",
         "deploy": "6",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Dark Jedi"
         ],
@@ -14047,7 +14031,6 @@
       ],
       "pulledBy": [
         "Blizzard 4",
-        "Sith Fury (V)",
         "The Empire's Back"
       ],
       "rarity": "R1",
@@ -14077,7 +14060,7 @@
         "ability": "6",
         "deploy": "6",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Dark Jedi"
         ],
@@ -14117,7 +14100,6 @@
       ],
       "pulledBy": [
         "Blizzard 4",
-        "Sith Fury (V)",
         "The Empire's Back"
       ],
       "rarity": "R1",
@@ -14181,7 +14163,6 @@
       ],
       "pulledBy": [
         "Blizzard 4",
-        "Sith Fury (V)",
         "The Empire's Back"
       ],
       "rarity": "PM",
@@ -14241,7 +14222,6 @@
       ],
       "pulledBy": [
         "Blizzard 4",
-        "Sith Fury (V)",
         "The Empire's Back"
       ],
       "rarity": "R",
@@ -14296,7 +14276,6 @@
       ],
       "pulledBy": [
         "Blizzard 4",
-        "Sith Fury (V)",
         "The Empire's Back"
       ],
       "rarity": "R1",
@@ -14354,7 +14333,7 @@
           "lightsaber"
         ],
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on Vader. May not be stolen. If present during battle, may 'throw' (place in Lost Pile) to add a destiny to attrition. May target a character for free. Draw two destiny. Target hit, and its forfeit = 0, if total destiny > defense value.",
         "icons": [
           "Set 8"
@@ -14615,7 +14594,7 @@
       ],
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on any system. Adds X to your total at that system, where X = number of your starships present. Your troopers and combat vehicles may shuttle to related sites for free.",
         "icons": [
           "Hoth"
@@ -14873,7 +14852,7 @@
       "front": {
         "darkSideIcons": 1,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Dark:  Deploys only if Coolant Shaft on table. While That Thing's Operational on table, you may add one battle destiny during battles at Death Star II system and system it orbits.  Light:  When your starship moves from here, draw movement destiny. Add maneuver (if any). If total destiny < 2, starship is lost.",
         "icons": [
           "Mobile",
@@ -14905,7 +14884,7 @@
       "front": {
         "darkSideIcons": 1,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Dark:  Deploys only if Death Star II system on table. Your TIEs at Death Star II locations may not Tallon Roll. Your non-Objective cards with 'Occupation' in title are canceled.  Light:  When your starship moves from here, draw movement destiny. Add maneuver (if any). If total destiny < 1, starship is lost.",
         "icons": [
           "Mobile",
@@ -15139,7 +15118,7 @@
       ],
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 2 Force to deploy on Docking Bay 327. At the end of a battle at Death Star system, may target an opponent's starship present (except a Mon Calamari star cruiser) using 2 Force. Draw two destiny. Target captured if total destiny > defense value.",
         "icons": [
           "A New Hope"
@@ -15395,7 +15374,7 @@
       "front": {
         "darkSideIcons": 1,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Dark:  If you control, may deploy a docking bay directly from your Reserve Deck. Reshuffle deck.  Light:  If you control, with a Rebel with ability > 2 present, Force drain +2 here.",
         "icons": [
           "Interior",
@@ -15861,7 +15840,7 @@
         ],
         "deploy": "4",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Adds 2 to power of anything he pilots. Power +1 for each opponent's character present. While present, may reduce Han's forfeit to zero.",
         "icons": [
@@ -16013,7 +15992,7 @@
         ],
         "deploy": "5",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Adds 2 to the power of anything he pilots. Permanent weapon is •Dengar's Blaster Carbine (may target a character, creature or vehicle for free; draw destiny; target hit, and its forfeit = 0, if destiny +1 > defense value; may be fired twice per battle).",
         "icons": [
@@ -16064,7 +16043,7 @@
         ],
         "deploy": "4",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "While opponent's [Reflections 2] objective on table, adds one battle destiny.  Permanent weapon is •Dengar's Blaster Carbine (twice per battle, may target a character or vehicle for free; draw destiny; target 'hit,' and its forfeit = 0, if destiny +1 > defense value).",
         "icons": [
@@ -16108,7 +16087,7 @@
           "blaster"
         ],
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to deploy on Dengar, 3 on your other warrior. May target a character, creature or vehicle using 1 Force. Draw destiny. Target hit if destiny +1 > defense value. If hit by Dengar, target's forfeit = 0.",
         "icons": [
           "Dagobah"
@@ -16143,7 +16122,7 @@
     {
       "front": {
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 2 Force to deploy on Dengar, or 5 on your other bounty hunter. May target a non-droid character using 3 Force. Draw destiny. Character immediately captured if destiny +3 > defense value.",
         "icons": [
           "Jabba's Palace"
@@ -16274,7 +16253,7 @@
     {
       "front": {
         "destiny": "6",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on table. My Favorite Decoration may not be placed out of play. At same site as Jabba's Prize, opponent's characters deploy +1 and your Force drains are +1. While Jabba's Prize with Scum And Villainy, your total power in all battles is +3. (Immune to Alter.)",
         "icons": [
           "Cloud City",
@@ -16500,7 +16479,7 @@
         ],
         "deploy": "1",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "No Hyperdrive"
         ],
@@ -16804,7 +16783,7 @@
       "counterpart": "Disarmed",
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If both players have a character with a weapon present at same site, deploy on that opponent's character during any control phase. Character loses all weapons, is power -1 and may no longer carry weapons. (Immune to Alter.)",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/disarmed.gif",
         "lore": "C-3PO's arm was pulled off by attacking Tusken Raiders. 'I don't think I can make it. You go on, Master Luke...I'm done for.'",
@@ -17287,7 +17266,7 @@
           "laser cannon"
         ],
         "destiny": "7",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 4 Force to deploy on Jabba's Sail Barge or your sandcrawler; it is power +3 and immune to attrition < 5. If your warrior aboard here, may target a vehicle using 2 Force. Draw destiny. Target hit if destiny +2 > defense value.",
         "icons": [
           "Jabba's Palace"
@@ -17468,7 +17447,7 @@
         ],
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Adds 2 to power of anything he pilots. The not-so-good doctor may 'operate' on any other character present that was just 'hit' or just Disarmed; 'patient' is lost.",
         "icons": [
@@ -17700,7 +17679,7 @@
     {
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy at any interior site. Cannot be moved. Droids may not deploy to same site. Following the turn this device is deployed, all droids present are lost at end of any turn.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/droiddetector.gif",
         "lore": "To keep out the mechanicals he so detested, Wuher installed an automatic droid detector at the entrance to the Mos Eisley Cantina.",
@@ -18083,7 +18062,7 @@
         "ability": "2",
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "Adds 3 to power of anything he pilots. When piloting Black 2, also adds 1 to maneuver and may draw one battle destiny if not able to otherwise.",
         "icons": [
@@ -18125,7 +18104,7 @@
         ],
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Adds 3 to power of anything he pilots. When piloting Black 3, also adds 1 to maneuver and may draw one battle destiny if not able to otherwise.",
         "icons": [
@@ -18163,7 +18142,7 @@
         "ability": "2",
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Adds 3 to power of anything he pilots. When piloting Black 4, also may draw one battle destiny if not able to otherwise. May use 1 Force to take one Lone Pilot into hand from Reserve Deck; reshuffle.",
         "icons": [
@@ -18452,7 +18431,7 @@
         ],
         "deploy": "3",
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "1",
         "gametext": "Deploy on any site. May be moved with two warriors for 1 additional Force. Your warrior present may target a starfighter (use 5 as defense value), character, creature or vehicle using 2 Force. Draw destiny. Target hit if destiny +1 > defense value.",
         "icons": [
@@ -18607,7 +18586,7 @@
         "destinyValues": [
           0
         ],
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Power Droid"
         ],
@@ -18675,7 +18654,7 @@
       "counterpart": "Nabrun Leids",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "At any time (except during battle), target any or all of your characters at one site to 'transport' (relocate) to any one other site. Draw destiny. Use that much Force to 'transport,' or place Interrupt in Lost Pile.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/elishelrot.gif",
         "lore": "A Givin pilot who can seal his joints to withstand the vacuum of space. Makes slaving and spike runs to Kala'uun. Has made many special modifications to his ship, the Hinthra.",
@@ -18707,7 +18686,7 @@
         ],
         "deploy": "4",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "5",
         "gametext": "May add 1 pilot and 3 passengers. Permanent pilot is •Elis, who provides ability of 2. Once per game, may use 1 Force to deploy a smuggler aboard from Reserve Deck; reshuffle. Immune to attrition < 5.",
         "hyperspeed": "4",
@@ -18805,7 +18784,7 @@
       "counterpart": "Panic",
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If opponent just initiated a battle where opponent has more than double your power, reveal up to 3 cards from your Reserve Deck. Of those 3, deploy anywhere (for free) any characters, starships, vehicles, devices or weapons. Any others are lost.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/emergencydeployment.gif",
         "lore": "TIE fighters are stored in large racks far above the hangar deck. Catapulted into space by powerful tractor beam generators, TIEs can quickly scramble to engage the enemy.",
@@ -18872,8 +18851,7 @@
         }
       ],
       "pulledBy": [
-        "According To My Design (V)",
-        "Sith Fury (V)"
+        "According To My Design (V)"
       ],
       "pulls": [
         "Force Lightning"
@@ -18928,8 +18906,7 @@
         }
       ],
       "pulledBy": [
-        "According To My Design (V)",
-        "Sith Fury (V)"
+        "According To My Design (V)"
       ],
       "rarity": "U",
       "set": "205",
@@ -19057,7 +19034,7 @@
       "counterpart": "Higher Ground",
       "front": {
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "USED: During a battle at a site, instead of firing one character weapon, cause one opponent's character present to be power -4 until end of turn.  LOST: During a battle at a site, use 3 Force to cancel one battle destiny just drawn.",
         "icons": [
           "Cloud City"
@@ -19657,7 +19634,7 @@
           "laser cannon"
         ],
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to deploy on your TIE. May target a starship using 1 Force. Draw destiny. Subtract 2 if targeting a capital starship. Target hit if destiny > defense value.",
         "icons": [
           "A New Hope"
@@ -19973,7 +19950,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on Bunker if you control that site. Your Force generation at Endor system may not be canceled. Once per turn, may deploy an Endor site from your reserve deck; reshuffle. Place Effect in Used Pile if opponent controls this site. (Immune to Alter.)",
         "icons": [
           "Set 7"
@@ -20046,7 +20023,7 @@
     {
       "front": {
         "destiny": "6",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If your capital starship is about to be lost, unless Tarkin aboard, relocate your characters aboard to any one planet site or to one of your capital starships.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/evacuate.gif",
         "lore": "Escape pods are on many starships allowing those in peril to flee, an act considered cowardly by Imperial officers. 'We've analyzed their attack, sir, and there is a danger.'",
@@ -20078,7 +20055,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "USED: Cancel all Revolutions in play (owner loses 1 Force for each).  LOST: If Vader or Vader's Custom TIE was just lost, relocate that card to Used Pile. OR Relocate to Used Pile one Imperial just lost from any Death Star location.",
         "icons": [
           "A New Hope"
@@ -20472,7 +20449,7 @@
     {
       "front": {
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use X Force during your control phase, where X = the total number of characters present or missing at exterior marker sites under 'nighttime conditions.' Those characters are lost.",
         "icons": [
           "Hoth"
@@ -20502,7 +20479,7 @@
           "rifle"
         ],
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your First Order warrior. May target a character or vehicle for free. Draw destiny. Add 1 if fired by a stormtrooper. Target hit, and may not be used to satisfy attrition, if total destiny > defense value.",
         "icons": [
           "Episode VII",
@@ -20538,7 +20515,7 @@
       ],
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on Dagobah: Cave. Target an apprentice on Dagobah. All Jedi Test game text is suspended. If target present during any battle phase, opponent draws destiny. If destiny < 4, you retrieve 2 Force (also, if destiny = 0, target is lost). Otherwise, Utinni Effect canceled.",
         "icons": [
           "Dagobah"
@@ -20760,7 +20737,7 @@
       "counterpart": "Don't Do That Again (V) - Defensive Shield",
       "front": {
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Plays on table. Ice Storm, Lost In The Wilderness, Order To Engage, Sandwhirl, and Scramble are canceled. Once per game, may take an Immediate Effect into hand from Reserve Deck; reshuffle. Unless opponent occupies a battleground system, Staging Areas is suspended.",
         "icons": [
           "Defensive Shield",
@@ -20880,7 +20857,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on any capital starship. When that starship is at a system or sector you control, your total power is +1 in battles at related sites.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/fearwillkeeptheminline.gif",
         "lore": "'The regional governors now have direct control over their territories. Fear will keep the local systems in line. Fear of this battle station.'",
@@ -20916,7 +20893,7 @@
         ],
         "deploy": "2",
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "While no droid present with Trevagg, to initiate battles at same location as Trevagg, player must use X Force, where X = total number of [Dark Side Force] and [Light Side Force] present with him.",
         "icons": [
@@ -20991,7 +20968,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on an Imperial of ability < 5 present with Vader, Emperor or one of your admirals, generals, or moffs. Imperial gains {leader} skill, is power +1, and is immune to Demotion, Report to Lord Vader, and What is Thy Bidding, My Master? (Immune to Alter.)",
         "icons": [
           "Dagobah"
@@ -21277,7 +21254,7 @@
         ],
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Deploys -1 to same site as a First Order leader. Opponent's characters here are cumulatively defense value -1 (limit -3).",
         "icons": [
@@ -21346,7 +21323,7 @@
       ],
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 2 Force to deploy on your Star Destroyer. Your other starships may move as a 'react' to same system or sector (for free). If starship lost, you lose X Force, where X = starship's armor. (Immune to your Alter.)",
         "icons": [
           "Dagobah"
@@ -21554,7 +21531,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on a cloud sector (limit one per sector). Force you activate may be drawn into hand (one per turn for each of your Floating Refineries on table). Each cloud sector or gas miner drawn in this way by this device may be revealed to retrieve 1 Force.",
         "icons": [
           "Special Edition"
@@ -21728,7 +21705,7 @@
       "counterpart": "Blaster Deflection",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "USED: Cancel an attempt to target a Dark Jedi with a character weapon.  LOST: If one of your characters was just targeted by a weapon during a battle, use 3 Force to cancel the targeting.",
         "icons": [
           "Cloud City"
@@ -22038,7 +22015,7 @@
         ],
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "2",
         "gametext": "Adds 2 to power of anything he pilots. While at a site you control, Imperials are immune to Ke Chu Ke Kukuta? at that site.",
         "icons": [
@@ -22127,7 +22104,7 @@
     {
       "front": {
         "destiny": "6",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on opponent's character alone at Wampa Cave. Character is power = 0 and may not move. May be canceled if opponent has a lightsaber or total ability > 4 present. If character eaten by a creature, cumulatively adds 2 to ferocity.",
         "icons": [
           "Hoth"
@@ -22163,7 +22140,7 @@
       ],
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "During your control phase, peek at opponent's hand and target one non-Interrupt card you find there that has a deploy cost < total number of [Light Side] icons on table. Opponent must deploy a card of that title by the end of your next turn, or lose a card of that title from hand (if possible).",
         "icons": [
           "Dagobah"
@@ -22249,7 +22226,7 @@
       "counterpart": "Fusion Generator Supply Tanks",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your starship at a system or sector where a related docking bay is on table. Adds 1 to hyperspeed, power and maneuver.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/fusiongeneratorsupplytanks.gif",
         "lore": "Installed at many facilities throughout the Empire to provide power to the Imperial spacefleet. Supplies starships with energy necessary for sublight and hyperspace travel.",
@@ -22273,7 +22250,7 @@
       "front": {
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Medical Droid"
         ],
@@ -22304,7 +22281,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 2 Force to deploy on any Tusken Raider. If a battle has just been initiated where present, target a character for free; draw two destiny. If total destiny > 5, target's weapons are 'knocked away' (may not be used this battle).",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/gaderffiistick.gif",
         "lore": "Notorious 'gaffi' weapon favored by Tusken Raiders. Built from scavenged metal. Intimidates and evokes fear.",
@@ -22339,7 +22316,7 @@
         ],
         "deploy": "3",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "2",
         "gametext": "Deploys free to same site as Mosep. Adds 2 to power of anything he pilots. While at Audience Chamber, adds 1 to your Force drains at Jabba's Palace sites.",
         "icons": [
@@ -22439,7 +22416,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to deploy on your Gamorrean. Adds 1 to power. When present at a site, Gamorrean draws one battle destiny if not able to otherwise. May target a character or creature for free. Draw destiny. Target hit if destiny > defense value.",
         "icons": [
           "Jabba's Palace"
@@ -22772,7 +22749,7 @@
         ],
         "deploy": "3",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Attuned"
         ],
@@ -22913,7 +22890,7 @@
         ],
         "deploy": "3",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Attuned"
         ],
@@ -23053,7 +23030,7 @@
           "dejarik"
         ],
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "During the damage segment of a battle you lost, if you have no cards left that can be forfeited, cancel all remaining battle damage. (Immune to Sense.) OR Cancel Nightfall.",
         "icons": [
           "A New Hope"
@@ -23094,7 +23071,7 @@
       "counterpart": "Houjix & Out Of Nowhere",
       "front": {
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "USED: Cancel Nabrun Leids.  LOST: If you just forfeited all your cards that participated in a battle you lost, cancel all remaining battle damage (Immune to Sense). OR Cancel Hyper Escape, Closer!?, or one 'react.' OR During your move phase, cancel Landing Claw.",
         "icons": [
           "Reflections 2"
@@ -23277,7 +23254,7 @@
         ],
         "deploy": "4",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Sensitive"
         ],
@@ -23334,7 +23311,7 @@
         ],
         "deploy": "4",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Attuned"
         ],
@@ -23423,7 +23400,7 @@
     {
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Strikes at Dune Sea, Jundland Wastes, Beggar's Canyon, Lars' Moisture Farm, Jawa Camp, or Mos Eisley. Target opponent's character present at that site. Draw destiny. Target lost if destiny > ability.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/gravelstorm.gif",
         "lore": "Tatooine's twin suns cause turbulent storms that strike with little or no warning. Strong winds whip rocks through the air with enormous force.",
@@ -23728,7 +23705,7 @@
       ],
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploys for 1 Force to an unoccupied site. Deploys and moves like an undercover spy. When present with Han (or alien) of ability < 3, choose one to be immediately lost (treat as an 'all cards' situation). Seeker is also lost.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/hanseeker.gif",
         "lore": "Military version of a 'remote.' Programmed to stalk specific targets or secondary targets. Heat and light sensors track with fatal accuracy. Can stow away on starships.",
@@ -24112,7 +24089,7 @@
     {
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If an opponent's character with ability > 2 has just become missing, deploy on a Rebel with ability > 2 on same planet. Rebel may not participate in battle. Immediate Effect canceled if missing character is found or lost.",
         "icons": [
           "Hoth"
@@ -24320,7 +24297,7 @@
         ],
         "deploy": "3",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "5",
         "gametext": "Draws one battle destiny in not able to otherwise. While at Audience Chamber (or stacked on your Objective), your other Weequays are deploy -1, power +1, and forfeit +2. Once per game, may deploy Aurra, Slave I, or a Kowakian from Reserve Deck; reshuffle.",
         "icons": [
@@ -24792,7 +24769,7 @@
     {
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "USED: If an opponent's weapon is about to 'hit' an Imperial present with a captive being escorted, the captive is 'hit' instead.  LOST: During the damage segment of a battle at a site, you may forfeit any captives present (once per battle per captive).",
         "icons": [
           "Cloud City"
@@ -24928,7 +24905,7 @@
     {
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on an opponent's smuggler, gambler, or thief. If subsequently captured, seized by a bounty hunter and then transfered to Jabba's Palace Dungeon, retrieve Force equal to character's forfeit (+6 if Han) and lose effect. (Immune to Alter.)",
         "icons": [
           "Jabba's Palace"
@@ -25074,7 +25051,7 @@
       ],
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your IT-O. Once during each of your control phases, if present with a captive: You may ask one yes-or-no question about cards in opponent's hand. Opponent must answer truthfully or lose 1 Force. OR May add 1 to Force drain where present.",
         "icons": [
           "A New Hope"
@@ -25267,7 +25244,7 @@
       "counterpart": "Affect Mind",
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to deploy on one of your Dark Jedi. Opponent's total ability at same location is reduced by 2, unless an opponent's Jedi is also present.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/ifindyourlackoffaithdisturbing.gif",
         "lore": "Darth Vader ruthlessly used the Force to strike down enemies and soldiers who displeased him. He could choke victims from afar without touching them.",
@@ -25330,7 +25307,7 @@
       ],
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on an opponent's gambler. Cancels gambler's game text. If a battle was just initiated, you may use X Force to exclude gambler from that battle, where X = gambler's ability.",
         "icons": [
           "Cloud City"
@@ -25435,7 +25412,7 @@
       },
       "front": {
         "destiny": "0",
-        "errataVersion": "E2",
+        "errataSymbol": "E2",
         "gametext": "I Want That Map:Deploy Tuanul Village, any other [Episode VII] location, and I Will Finish What You Started. Opponent may reveal a unique (•) Resistance character from Reserve Deck; that card is a Resistance Agent. Otherwise, Luke is a Resistance Agent and loses immunity to attrition.{For} remainder of game, non-[Episode VII] Dark Jedi are lost and Resistance Agents are immune to Set For Stun.{Flip} this card if your First Order characters control two battlegrounds and a Resistance Agent is not present at a battleground site.And Now You'll Give It To Me:{While} this side up, where you have a First Order leader, opponent must first use or lose 1 Force to draw a card for battle destiny. Unless BB-8 on table, opponent's Force retrieval is canceled. If Kylo on table: During your turn, may stack an Interrupt from your Lost Pile face up on I Will Finish What You Started; and once per turn, may play an Interrupt stacked there as if from hand (then place that card out of play).{Flip} this card if you do not occupy two battlegrounds or if a Resistance Agent is present at a battleground site.",
         "icons": [
           "Episode VII",
@@ -25497,7 +25474,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on table. Opponent may deploy Amidala from Reserve Deck; reshuffle. If Maul present with Amidala and opponent has no Jedi there, she is captured. Once per game may take If The Trace Was Correct into hand from Reserve Deck; reshuffle. (Immune to Alter.)",
         "icons": [
           "Episode I",
@@ -25660,7 +25637,7 @@
       "counterpart": "It Can Wait",
       "front": {
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 3 Force to place an opponent's just deployed character, starship, vehicle, weapon, or device in opponent's hand. On opponent's next turn, that card (or one card of same title) may deploy for free.",
         "icons": [
           "Hoth"
@@ -25769,7 +25746,7 @@
         ],
         "deploy": "4",
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "May add 1 pilot (must be a smuggler or bounty hunter) and 2 passengers. Maneuver +3 and immune to attrition < 3 if IG-88 piloting. Ion Cannon may deploy aboard.",
         "hyperspeed": "3",
@@ -25818,7 +25795,7 @@
         ],
         "deploy": "5",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Assassin Droid"
         ],
@@ -26055,7 +26032,7 @@
           "cannon"
         ],
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to deploy on IG-88, 4 on your other warrior. Adds 2 to power. May target X non-droid characters or creatures using X Force. Draw destiny for each. If destiny = 0, character is power -1 and forfeit -1 until end of turn. If destiny -1 > defense value, target hit.",
         "icons": [
           "Dagobah"
@@ -26094,7 +26071,7 @@
       ],
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Target opponent's starfighter making an Attack Run. Draw destiny. Add 1 for each of your TIEs in Death Star: Trench. If total destiny > maneuver, starfighter is lost. OR Add 1 to weapon destiny draws of any starfighter for remainder of this turn.",
         "icons": [
           "A New Hope"
@@ -26543,7 +26520,7 @@
           "DH-17 blaster"
         ],
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to deploy on your warrior. May target a character, creature or vehicle using 1 Force. Draw destiny. Target hit if destiny > defense value.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/imperialblaster.gif",
         "lore": "A BlasTech DH-17 blaster pistol. Uses power packs and high-energy blaster gases. Shoots bolts of explosive coherent light energy.",
@@ -26686,7 +26663,7 @@
       "counterpart": "Menace Fades",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your side of table. Whenever you control any two Rebel Base locations, or any one planet site and two systems, the effects of Revolution and all opponent's Force drain bonuses are canceled. (Immune to Alter.)",
         "icons": [
           "Cloud City"
@@ -26720,7 +26697,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on table. Whenever you lose Force (except from Force drains, battle damage, or your card), may reduce loss (to a minimum of 1) by the number of battlegrounds you occupy. During battle, may place this Effect out of play to draw one battle destiny if unable to otherwise. (Immune to Alter.)",
         "icons": [
           "Cloud City",
@@ -26818,7 +26795,10 @@
     {
       "front": {
         "destiny": "5",
-        "gametext": "Deploy on table. Lost if your non-Imperial character (or starship) on table. Unless you occupy fewer locations than opponent: if you win a battle, retrieve an Imperial; and, during battle, may take an Imperial just drawn for destiny into hand to cancel and redraw that destiny. (Immune to Alter.)",
+        "errataDate": "2022-12-12",
+        "errataNotes": "E1 Text: Deploy on table. Lost if your non-Imperial character (or starship) on table. Unless you occupy fewer locations than opponent: if you win a battle, retrieve an Imperial; and, during battle, may take an Imperial just drawn for destiny into hand to cancel and redraw that destiny. [Immune to Alter.]",
+        "errataSymbol": "E2",
+        "gametext": "Deploy on table. You may initiate battles for free. Once per turn, if you just drew a character for destiny, may take that card into hand to cancel and redraw that destiny. Canceled if your non-Imperial character (or starship) on table. [Immune to Alter.]",
         "icons": [
           "Set 1"
         ],
@@ -26831,6 +26811,7 @@
       "gempId": "201_30",
       "id": 1271,
       "legacy": false,
+      "previousId": 20004,
       "printings": [
         {
           "set": "201"
@@ -26842,8 +26823,8 @@
       ],
       "rarity": "U1",
       "rulings": [
-        "Mara Jade, The Emperor's Hand (for example) does not make this card lost.",
-        "<u>Both</u> of the bonuses (Dark retrieving an Imperial, and Dark taking a just drawn Imperial into hand) require Dark to occupy at least as many locations as opponent."
+        "Mara Jade, The Emperor's Hand (for example) does not make this Effect canceled.",
+        "Imperial starships (Dark starships with no allegiance icon such as Independent, Republic, etc) do not make this Effect canceled."
       ],
       "set": "201",
       "side": "Dark"
@@ -26854,7 +26835,7 @@
       ],
       "back": {
         "destiny": "7",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Imperial Entanglements:Deploy Tatooine system (with Devastator there) and a Tatooine battleground site.{For} remainder of game, you may not deploy Sandwhirl, Admiral's Orders, Jabba's Palace sites, non-Imperial characters, non-Imperial starships, or systems.{While} this side up, opponent loses no Force to Tatooine Occupation or your Force drains at Tatooine system. Once per turn, may deploy a Tatooine battleground site from Reserve Deck; reshuffle.{Flip} this card if you control three Tatooine sites and opponent controls fewer than three Tatooine sites. No One To Stop Us This Time: {While} this side up, once during your control phase, may peek at up to X cards from the top of your Reserve Deck, where X = number of Tatooine locations you occupy; take one into hand and shuffle your Reserve Deck. Once per turn, may deploy a Tatooine battleground site from Reserve Deck; reshuffle. Opponent's characters require +1 Force to move from Tatooine sites using their landspeed. During your draw phase, you may retrieve one trooper.{Flip} this card if opponent controls more Tatooine sites than you.",
         "icons": [
           "Set 1"
@@ -26865,7 +26846,7 @@
       },
       "front": {
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Imperial Entanglements:Deploy Tatooine system (with Devastator there) and a Tatooine battleground site.{For} remainder of game, you may not deploy Sandwhirl, Admiral's Orders, Jabba's Palace sites, non-Imperial characters, non-Imperial starships, or systems. {While} this side up, opponent loses no Force to Tatooine Occupation or your Force drains at Tatooine system. Once per turn, may deploy a Tatooine battleground site from Reserve Deck; reshuffle.{Flip} this card if you control three Tatooine sites and opponent controls fewer than three Tatooine sites. No One To Stop Us This Time:{While} this side up, once during your control phase, may peek at up to X cards from the top of your Reserve Deck, where X = number of Tatooine locations you occupy; take one into hand and shuffle your Reserve Deck. Once per turn, may deploy a Tatooine battleground site from Reserve Deck; reshuffle. Opponent's characters require +1 Force to move from Tatooine sites using their landspeed. During your draw phase, you may retrieve one trooper.{Flip} this card if opponent controls more Tatooine sites than you.",
         "icons": [
           "Set 1"
@@ -26897,7 +26878,7 @@
         ],
         "deploy": "1",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "1",
         "gametext": "Adds 1 to weapon destiny draws of anything he is aboard as a passenger.",
         "icons": [
@@ -26931,7 +26912,7 @@
         "ability": "1",
         "deploy": "3",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "2",
         "gametext": "Adds 2 to power of anything he pilots. When piloting a Star Destroyer, also draws one battle destiny if not able to otherwise.",
         "icons": [
@@ -27115,7 +27096,7 @@
         "ability": "2",
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "2",
         "gametext": "Adds 2 to power of anything he pilots.",
         "icons": [
@@ -27181,7 +27162,7 @@
       "counterpart": "Rebel Reinforcements",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If opponent has more total characters and starships on table than you have, use 1 Force to draw destiny. Retrieve that number of Stormtroopers and/or TIE/lns.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/imperialreinforcements.gif",
         "lore": "Imperial stormtroopers deploy in 8-10 trooper squads. Reinforcements are typically held in reserve according to standard Imperial operating procedures.",
@@ -27213,7 +27194,7 @@
         ],
         "deploy": "2",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Adds 1 to forfeit of your other troopers at same site. When moving with a 'squad' of exactly three other troopers, all four move for 1 Force. Imperial Trooper Guards at same site may move.",
         "icons": [
@@ -27285,7 +27266,7 @@
         ],
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "1",
         "gametext": "Power +4 when defending a battle. Cannot move.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/imperialtrooperguard.gif",
@@ -27322,7 +27303,7 @@
         ],
         "deploy": "2",
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "2",
         "gametext": "Deploys only aboard Executor or on any Death Star Site. Cannot move. May cancel opponent's Force Drains at adjacent Death Star or Executor sites.",
         "icons": [
@@ -27468,7 +27449,7 @@
       ],
       "front": {
         "destiny": "6",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If you have a Star Destroyer in a battle, during the weapons segment use its tractor beam for free. Add 2 to tractor beam destiny if targeting a unique (•) starship. If not captured, target is power and maneuver -3 for remainder of turn.",
         "icons": [
           "Special Edition"
@@ -27581,7 +27562,7 @@
       "counterpart": "Infantry Mine",
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy at same exterior site as your mining droid. 'Explodes' if a character deploys or moves (without using a vehicle or starfighter) to or across same site. Draw destiny. Character lost if destiny +2 > ability. Infantry Mine is also lost.",
         "icons": [
           "Hoth"
@@ -27614,7 +27595,7 @@
       ],
       "front": {
         "destiny": "6",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If a battle was just initiated at same site as your Undercover spy, your characters at adjacent sites may move there as a 'react' (for free). OR Cancel Sabotage.",
         "icons": [
           "A New Hope"
@@ -28062,7 +28043,7 @@
           "ion cannon"
         ],
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 2 Force to deploy on your Star Destroyer. May target a starship using 1 Force. Draw destiny. If destiny +2 > defense value, all starship weapons deployed on target are lost, armor or maneuver = 0 and hyperspeed = 0.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/ioncannon.gif",
         "lore": "Fires blasts of ionized energy. Causes massive disruptions in weapon, engine and computer systems aboard a target. Disables starship defenses against tractor beams.",
@@ -28132,7 +28113,7 @@
       "front": {
         "deploy": "3",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Interrogator Droid"
         ],
@@ -28234,7 +28215,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to target opponent's starfighter with maneuver at a system or sector where a battle just finished. Draw destiny. Starfighter lost if destiny > maneuver.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/ivegotaproblemhere.gif",
         "lore": "Debris fragments damaged Jek Porkins' X-wing, causing a cascade of computer and flight control failures.",
@@ -28260,7 +28241,7 @@
       ],
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to target a starship's [Nav Computer] or astromech. Draw destiny. If destiny > 1, [Nav Computer] or astromech is lost. If starship's [Nav Computer] is lost, place Effect on starship (may add 1 astromech); otherwise, Effect lost.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/ivelostartoo.gif",
         "lore": "'WHAAAAAAAAAOOOOW!'",
@@ -28390,7 +28371,7 @@
         ],
         "deploy": "6",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Sensitive"
         ],
@@ -28866,7 +28847,7 @@
         "armor": "5",
         "deploy": "5",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "7",
         "gametext": "Deploys only on Tatooine; you may immediately deploy Passenger Deck from your Reserve Deck and reshuffle. May add 1 driver and 7 passengers. Your aliens deploy -1 aboard.",
         "icons": [
@@ -29034,7 +29015,7 @@
         "armor": "5",
         "deploy": "4",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "6",
         "gametext": "May add 1 alien pilot and 6 passengers. Permanent pilot provides ability of 2. When deployed, you may deploy an alien leader aboard from Reserve Deck; reshuffle. Immune to attrition < 5.",
         "hyperspeed": "4",
@@ -29578,7 +29559,7 @@
           "blaster"
         ],
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your Jawa. May target a character or creature for free. Draw destiny. If destiny -1 > defense value, target hit. If destiny = 0, Jawa Blaster 'explodes' (weapon and character firing it are lost).",
         "icons": [
           "A New Hope"
@@ -30124,7 +30105,7 @@
       "front": {
         "darkSideIcons": 2,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Dark:  Your starships deploy -1 here, -2 if Tarkin is aboard a starship here. If you control, Kessel Run is canceled.  Light:  Total ability of 6 or more required for you to draw battle destiny here.",
         "icons": [
           "Planet"
@@ -30200,7 +30181,7 @@
       "counterpart": "Sai'torr Kal Fas",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your non-warrior character (except droids) to give that character [Warrior] skill. OR Deploy on your warrior. That character is power +1. (Immune to Alter.)",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/ketmaliss.gif",
         "lore": "Assassins are highly valued by Jabba the Hutt and other gangsters. Prince Xizor's 'shadow killer,' has unknown but undoubtably lethal business in Mos Eisley.",
@@ -30336,7 +30317,7 @@
           "dejarik"
         ],
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If opponent just forfeited or lost a character, use 1 Force to regenerate one of your own characters. Retrieve the character closest to the top of your Lost Pile into your hand.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/kintanstrider.gif",
         "lore": "A dejarik of a ferocious creature with incredible healing abilities. Extinct on the homeworld of Kintan, but used as a guard beasts by many Hutt gangsters.",
@@ -30409,7 +30390,7 @@
         ],
         "deploy": "3",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Attuned"
         ],
@@ -30459,7 +30440,7 @@
         ],
         "deploy": "4",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "2",
         "gametext": "Deploys only on Tatooine. Adds 1 to power of anything he pilots. Power = 1 + ability of opponent's highest-ability character present.",
         "icons": [
@@ -30563,7 +30544,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Insert in opponent's Reserve Deck. When Effect reaches top it is lost, but opponent may not initiate any battles for remainder of turn. (Immune to Alter.)",
         "icons": [
           "Dagobah"
@@ -30594,7 +30575,7 @@
       "counterpart": "Anger, Fear, Aggression (V)",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on table with up to any number of Defensive Shields from outside your deck face-down under here. Four times per game, may play a Defensive Shield from here (as if from hand). Unless canceling your Interrupt, opponent may not play Recoil In Fear until the end of your first turn.",
         "icons": [
           "Dagobah",
@@ -31275,7 +31256,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If your character is about to be hit, use 1 Force (free if by a [Permanent Weapon] weapon); for remainder of turn, its forfeit may not be reduced and it may not be used to satisfy attrition. OR Cancel Disarmed. (Immune to Sense.) OR Cancel a 'react'. OR During your move phase, target any or all of your characters at one site to 'transport' (relocate) to an exterior or battleground site. Draw destiny. Use that much Force to 'transport,' or place Interrupt in Lost Pile.",
         "icons": [
           "Episode I",
@@ -31315,7 +31296,7 @@
         ],
         "deploy": "2",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Attuned"
         ],
@@ -31414,7 +31395,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy between any two interior mobile sites. To pass, a character must have (power + ability) > 4 or use a Lift Tube (all other vehicles are blocked). Laser Gate defense value = 3; may be targeted (as if a character) by a character weapon from either site.",
         "icons": [
           "A New Hope"
@@ -31443,7 +31424,7 @@
     {
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 2 Force to deploy on an interior site. May target a seeker (use defense value = 1), character or creature for free. Draw destiny. Target hit if destiny -1 > defense value. Laser Projector may be targeted by any weapon (use defense value = 1).",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/laserprojector.gif",
         "lore": "Laser system activated by distress signal from guards. Used at security checkpoints and detention block control rooms. Targeting guided by centralized droid controller.",
@@ -31608,7 +31589,7 @@
       ],
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploys for 1 Force to an unoccupied site. Deploys and moves like an undercover spy. When present with Leia (or warrior) of ability < 3, choose one to be immediately lost (treat as an 'all cards' situation). Seeker is also lost.",
         "icons": [
           "A New Hope"
@@ -31754,7 +31735,7 @@
         "ability": "2",
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "Adds 2 to power of any starship he pilots. On Tyrant, also adds one to Armor. When in battle with an Imperial leader, subtracts 1 from opponent's total battle destiny.",
         "icons": [
@@ -31869,7 +31850,7 @@
         "ability": "2",
         "deploy": "0",
         "destiny": "6",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "When drawn for destiny, use 1 Force or this card is lost. Adds 2 to power of anything he pilots. During your deploy phase, may use 3 Force to relocate Kylo from here to same site as a Resistance Agent.",
         "icons": [
@@ -32058,7 +32039,7 @@
         "ability": "2",
         "deploy": "3",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "During your control phase, may use 1 Force to search your Reserve Deck, take one Human Shield into hand and reshuffle. When escorting a captive, captive is forfeit +2 and Sheckil is immune to attrition < 4.",
         "icons": [
@@ -32133,7 +32114,7 @@
         "ability": "2",
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Deploy -1 for starship weapons of any starship he pilots. Adds 2 to power of anything he pilots. Subtracts 1 from maneuver of any starfighter he pilots.",
         "icons": [
@@ -32201,7 +32182,7 @@
         "ability": "2",
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Deploys -1 to Executor. While aboard a capital starship, adds 1 to armor and its defense value may not be reduced. If Fear Will Keep Them In Line here and your Imperial just won a battle at a related site, opponent loses 2 Force.",
         "icons": [
@@ -32317,7 +32298,7 @@
           "rifle"
         ],
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 2 Force to deploy on your warrior. If your power droid or fusion generator present, may target a character, creature or vehicle using 2 Force. Draw destiny. Target hit if destiny +1 > defense value. May fire repeatedly for 2 Force each time.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/lightrepeatingblasterrifle.gif",
         "lore": "BlasTech model T-21 light repeating blaster. Excellent power, good range. Carries energy for 25 shots. Unlimited firepower when attached to a power generator.",
@@ -32411,7 +32392,7 @@
       ],
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If the opponent has two cards or less in hand, opponent must immediately lose 2 Force (4 Force if it is your turn). If the opponent has Fusion Generator Supply Tanks aboard a starship, loss is reduced by 2.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/limitedresources.gif",
         "lore": "The Empire dominates consumption of resources. Despite being efficient, Rebel logistical and maintenance officers often are compelled to expend emergency reserves.",
@@ -32440,7 +32421,7 @@
       "front": {
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Mining Droid"
         ],
@@ -32477,7 +32458,7 @@
         ],
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "For each other musician present, adds a 'cover charge' of 1 to the Force required to move or deploy each character to same site.",
         "icons": [
@@ -32610,7 +32591,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force at the beginning of your battle phase to allow any two of your Stormtroopers in the Cantina to battle any one opponent's character (your choice). You may add one battle destiny. No other battles may occur in Cantina this turn.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/localtrouble.gif",
         "lore": "'Look like somebody's beginning to take an interest in your handiwork.' Imperial stormtroopers coerce local residents to assist them in the apprehension of Rebel scum.",
@@ -32636,7 +32617,7 @@
       ],
       "front": {
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on table. At the end of each player's deploy phase, if they did not deploy a location, they lose 1 Force. Effect canceled if any player deploys three or more locations in a single turn.",
         "icons": [
           "Dagobah"
@@ -32674,7 +32655,7 @@
       "counterpart": "Full Throttle",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If your pilot (or permanent pilot) is defending a battle alone at a system or sector, add one battle destiny. OR If Motti is defending a battle alone at a system or sector, add two battle destiny.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/lonepilot.gif",
         "lore": "One lone TIE fighter, acting as a scout near the Death Star, suddenly encountered the Millennium Falcon.",
@@ -32702,7 +32683,7 @@
       "counterpart": "Warrior's Courage",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If any warrior is defending a battle alone at a site, add one battle destiny. OR If Tagge is defending a battle alone at a site, add two battle destiny.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/lonewarrior.gif",
         "lore": "Though generally deployed in squads, all Imperial warriors are trained in the close combat techniques and have a reputation for ferocity when cornered.",
@@ -32759,7 +32740,7 @@
         ],
         "deploy": "8",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Dark Jedi"
         ],
@@ -32794,9 +32775,6 @@
           "set": "13"
         }
       ],
-      "pulledBy": [
-        "Sith Fury (V)"
-      ],
       "rarity": "PM",
       "set": "13",
       "side": "Dark"
@@ -32810,7 +32788,7 @@
         ],
         "deploy": "6",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Dark Jedi"
         ],
@@ -32841,9 +32819,6 @@
         {
           "set": "208"
         }
-      ],
-      "pulledBy": [
-        "Sith Fury (V)"
       ],
       "rarity": "R",
       "set": "208",
@@ -32883,9 +32858,6 @@
         {
           "set": "208"
         }
-      ],
-      "pulledBy": [
-        "Sith Fury (V)"
       ],
       "pulls": [
         "Always Two There Are",
@@ -32960,7 +32932,6 @@
       ],
       "pulledBy": [
         "Blizzard 4",
-        "Sith Fury (V)",
         "The Empire's Back"
       ],
       "rarity": "R",
@@ -32970,7 +32941,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If a pilot was just lost from a system or sector, deploy on that location and stack pilot here. Pilot may be rescued or captured by any capital starship present here during any move phase, and may be targeted by weapons (except during battle) as if present (treat as a starfighter with defense value = 0). Lost if no pilot here.",
         "icons": [
           "Dagobah"
@@ -33065,7 +33036,7 @@
         ],
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "5",
         "gametext": "While at Docking Control Room 327, adds 2 to your total power at Docking Bay 327. Once during each of your control phases, if at same site as an Undercover spy, may draw destiny. Spy's 'cover is broken' if destiny = spy's ability.",
         "icons": [
@@ -33206,7 +33177,7 @@
       ],
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploys for 1 Force to an unoccupied site. Deploys and moves like an undercover spy. When present with Luke of ability < 4 or pilot of ability < 3, choose one to be immediately lost (treat as an 'all cards' situation). Seeker is also lost.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/lukeseeker.gif",
         "lore": "Military version of a 'remote.' Programmed to stalk specific targets or secondary targets. Heat and light sensors track with fatal accuracy. Can stow away on starships.",
@@ -33428,34 +33399,10 @@
       "side": "Dark"
     },
     {
-      "front": {
-        "destiny": "3",
-        "gametext": "Deploy on a site. Once per game, you may re-circulate. Once per turn, may cancel and redraw your destiny to power (or a Dark Hours destiny) here, or use X Force to reveal top X cards of your Reserve Deck; may place one in Used Pile (replace other cards in same order).",
-        "icons": [
-          "Set 10"
-        ],
-        "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Dark/large/macroscan.gif",
-        "lore": "Electrobinocular view. Readouts list object's true and relative azimuth, elevation and range. Built-in night vision.",
-        "title": "Macroscan (V)",
-        "type": "Effect"
-      },
-      "gempId": "210_37",
-      "id": 6505,
-      "legacy": false,
-      "printings": [
-        {
-          "set": "210"
-        }
-      ],
-      "rarity": "C2",
-      "set": "210",
-      "side": "Dark"
-    },
-    {
       "counterpart": "Magnetic Suction Tube",
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your Sandcrawler. Once during each of your control phases, may target one character present. Draw destiny. If destiny > character's ability, 'suck up' character (relocate to related interior Sandcrawler site or owner's Used Pile).",
         "icons": [
           "A New Hope"
@@ -34299,7 +34246,7 @@
           "lightsaber"
         ],
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on Maul. Adds 1 to Maul's lightsaber combat total. May lose 1 Force to add 2 to Force drain where present. Twice per battle, may target a character. Draw two destiny. Target hit, and its forfeit = 0, if total > defense value. While on Maul, may not be stolen.",
         "icons": [
           "Episode I",
@@ -34318,10 +34265,8 @@
       "matchingWeapon": [
         "Darth Maul",
         "Darth Maul With Lightsaber",
-        "Darth Maul",
-        "Lone Hunter",
-        "Darth Maul",
-        "Young Apprentice",
+        "Darth Maul, Lone Hunter",
+        "Darth Maul, Young Apprentice",
         "Lord Maul",
         "Lord Maul With Lightsaber"
       ],
@@ -34393,10 +34338,8 @@
       "matchingWeapon": [
         "Darth Maul",
         "Darth Maul With Lightsaber",
-        "Darth Maul",
-        "Lone Hunter",
-        "Darth Maul",
-        "Young Apprentice",
+        "Darth Maul, Lone Hunter",
+        "Darth Maul, Young Apprentice",
         "Lord Maul",
         "Lord Maul With Lightsaber"
       ],
@@ -34449,10 +34392,8 @@
       "matching": [
         "Darth Maul",
         "Darth Maul With Lightsaber",
-        "Darth Maul",
-        "Lone Hunter",
-        "Darth Maul",
-        "Young Apprentice",
+        "Darth Maul, Lone Hunter",
+        "Darth Maul, Young Apprentice",
         "Lord Maul",
         "Lord Maul With Lightsaber"
       ],
@@ -34510,7 +34451,7 @@
         ],
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Adds 2 to power of anything he pilots or drives. When driving a transport vehicle, adds one battle destiny. When piloting at a cloud sector, once per turn adds one battle destiny during battle at a related exterior site.",
         "icons": [
@@ -34676,7 +34617,7 @@
         ],
         "deploy": "3",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Once during each of your control phases, may reveal opponent's hand by using X Force, where X = number of cards in opponent's hand. All unique (•) male Rebels and unique (•) male aliens there are lost.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/miiyoomonith.gif",
@@ -34703,7 +34644,7 @@
       "counterpart": "We're Leaving",
       "front": {
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 3 Force to deploy on table. During the damage segment of a battle your opponent initiated, if you have no cards left that can be forfeited, you may place this Effect out of play to cancel all remaining battle damage. (Immune to Alter.)",
         "icons": [
           "Episode I",
@@ -34870,7 +34811,7 @@
         ],
         "deploy": "2",
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "5",
         "gametext": "May add 1 driver and 1 passenger. Moves free if Jabba or any bounty hunter aboard. May move for free as a 'react' to a battle where your thief, smuggler or bounty hunter is participating.",
         "icons": [
@@ -34989,7 +34930,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If Tarkin is defending a battle alone, add two battle destiny. OR If any alien is defending a battle alone, add one battle destiny.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/momentoftriumph.gif",
         "lore": "A ruthless ruler of Outer Rim Territories. Grand Moff Tarkin used the Death Star to destroy Alderaan, creating the doctrine of rule by fear.",
@@ -35055,7 +34996,7 @@
           "dejarik"
         ],
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "USED: If opponent has 13 or more cards in hand, place all but 8 (random selection) in Used Pile.  LOST: Use 4 Force to reveal opponent's hand. All cards opponent has two or more of in hand are lost.",
         "icons": [
           "A New Hope"
@@ -35092,7 +35033,7 @@
           "blaster"
         ],
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to deploy on your alien warrior (free if on Tatooine). May target a character for free. Draw destiny. Target is forfeit -2 for remainder of turn if destiny +2 > defense value.",
         "icons": [
           "Jabba's Palace"
@@ -35130,7 +35071,7 @@
         ],
         "deploy": "3",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "5",
         "gametext": "When opponent is losing Force from Force drains at the same or an adjacent site, lost Force must come from Reserve Deck if possible.",
         "icons": [
@@ -35282,7 +35223,7 @@
       ],
       "front": {
         "destiny": "7",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on Chewie if Han was just lost or just became missing. Opponent cannot play Let The Wookiee Win or Wookiee Roar. Opponent must also lose 1 Force at end of every player's turn. If Han on table, Effect canceled.",
         "icons": [
           "Hoth"
@@ -35317,7 +35258,7 @@
       "front": {
         "deploy": "0",
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Messenger Droid"
         ],
@@ -35493,7 +35434,7 @@
       "front": {
         "darkSideIcons": 2,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Dark:  While Anakin or Vader here, gains one [Dark Side] icon and one [Light Side] icon.  Light:  If Vader on table, unless Amidala at a Mustafar location, Force drain -1 here.",
         "icons": [
           "Planet",
@@ -35606,7 +35547,7 @@
       },
       "front": {
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "My Kind Of Scum:Deploy Desert Heart and a Jabba's Palace site. May deploy Well Guarded. Reveal one unique (•) alien from your deck whose lore specifies its species. This card is your Rep.{For} remainder of game, your Rep is a leader. Well Guarded is immune to Alter. You may not deploy 'insert' cards or operatives. While frozen Han on table, Rebels are immune to No Bargain and Bad Feeling Have I.{Flip} this card if you occupy two battleground sites (must occupy a third with a non-unique alien of your Rep's species if a non-Tatooine location is on table).Fearless And Inventive:{While} this side up, once per turn you may cancel a Force drain or a just-drawn battle destiny by placing here from hand a copy of your Rep. Once during each of your control phases, you may retrieve a non-unique alien of your Rep's species. While Jabba and Bib on table, your battle destiny draws are each +2. Wounded Wookiee is destiny +3. Unless a non-Tatooine location is on table, your aliens are forfeit +2. For remainder of game, your Rep may deploy from here as if from hand.{Flip} this card if you do not occupy 2 battleground sites.",
         "icons": [
           "Premium"
@@ -35759,7 +35700,7 @@
         ],
         "deploy": "3",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "SWARM: 3"
         ],
@@ -35965,7 +35906,7 @@
       "front": {
         "darkSideIcons": 2,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Dark:  Unless Gungan Energy Shield on table, your AATs are each power +2 here.  Light:  Once per game may take Gungan Energy Shield into hand from Reserve Deck; reshuffle.",
         "icons": [
           "Exterior",
@@ -36142,7 +36083,7 @@
       "front": {
         "darkSideIcons": 3,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Dark:  Any characters of ability < 5 'hit' here (and all cards on them) are placed in owner's Used Pile.  Light:  Any characters of ability < 5 'hit' here (and all cards on them) are placed in owner's Used Pile.",
         "icons": [
           "Interior",
@@ -36689,7 +36630,7 @@
       "counterpart": "Double Agent",
       "front": {
         "destiny": "6",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If both players have a spy at same site, draw destiny. Add 2 if opponent's spy is Undercover. Opponent's spy is lost if destiny > 2.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/nevaryalnal.gif",
         "lore": "Immense Ranat scavenger from Aralia. Slyly spies for anyone willing to pay his price. Outcast. Works as a laborer for Hrchek, the Saurin droid trader.",
@@ -36719,7 +36660,7 @@
           "dejarik"
         ],
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If opponent just deployed four or more characters to same location this turn, prevent all of those characters from battling this turn. OR if opponent just 'reacted' to a battle, cancel the battle.",
         "icons": [
           "A New Hope"
@@ -36757,7 +36698,7 @@
           "dejarik"
         ],
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on table. If your character, starship, or vehicle in battle is about to be lost before the damage segment, it is instead lost at end of battle (if forfeited, forfeit for 0). (Immune to Alter.)",
         "icons": [
           "Set 1"
@@ -37365,7 +37306,7 @@
     {
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on a site. Adds 1 to the total weapon destiny of each of your automated weapons at same and adjacent sites. During battle, may add the power of one of your characters at an adjacent site you control to your total.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/observationholocam.gif",
         "lore": "Remote surveillance viewers with droid controllers supplement security. Can activate alarms and automated weapons when needed, bringing help to endangered locations.",
@@ -37518,7 +37459,7 @@
         ],
         "deploy": "4",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "No Hyperdrive"
         ],
@@ -37563,7 +37504,7 @@
         ],
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "5",
         "gametext": "Adds 2 to power of anything he pilots. When at a Death Star site, Imperial starships may move to the Death Star system as a 'react.'",
         "icons": [
@@ -37599,7 +37540,7 @@
       ],
       "front": {
         "destiny": "6",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Cancel an attempt by opponent to target your droid to be stolen, 'hit' or lost. Droid is protected from all such attempts for remainder of turn. OR Switch OFF any binary droid for remainder of turn.",
         "icons": [
           "Hoth"
@@ -38661,7 +38602,7 @@
       "counterpart": "Firefight",
       "front": {
         "destiny": "6",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "During a battle, if you have weapons at at least 2 sites adjacent to that battle, add 3 to your total power and add one battle destiny. OR For remainder of turn, your biker scout at an exterior site is power +1 and adds 1 to each of that character's weapon destiny draws.",
         "icons": [
           "Endor"
@@ -38763,7 +38704,7 @@
       "counterpart": "Leia Of Alderaan (V)",
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your leader. Opponent may not cancel or reduce Force drains at same battleground. If on Emperor, may place Effect in Lost Pile to retrieve an Imperial leader.",
         "icons": [
           "Set 5"
@@ -39357,7 +39298,7 @@
         ],
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Power +3 when battling at same site as Dr. Evazan, unless opponent has a lightsaber present. Adds 2 to power of anything he pilots.",
         "icons": [
@@ -39397,7 +39338,7 @@
         ],
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E2",
+        "errataSymbol": "E2",
         "forfeit": "3",
         "gametext": "Adds 2 to power of anything he pilots.  At same site, non-Jedi Luke may not swing a lightsaber at aliens (or return aliens to hand using his game text). During battle, if with a smuggler, may add one destiny to attrition or make that smuggler forfeit = 0.",
         "icons": [
@@ -39619,7 +39560,7 @@
       "counterpart": "Combined Attack",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "During a battle, target opponent's character or vehicle present with two (or more) of your weapons. Add all weapon destiny draws together. Apply that total separately for each weapon in an order of your choosing.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/preciseattack.gif",
         "lore": "'Only Imperial stormtroopers are so precise.'",
@@ -39830,7 +39771,7 @@
       "counterpart": "Legendary Starfighter",
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If opponent just lost a starship in a battle you won, deploy on your participating starfighter. Once during each of opponent's move phases, opponent loses 1 Force (2 if starfighter is a TIE/ln). Also, that starfighter is power +2. (Immune to Control.)",
         "icons": [
           "Special Edition"
@@ -39943,7 +39884,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your Probe Droid. Adds 2 to X for that droid. OR Use 1 Force to deploy on one of your other droids. When at a site you control, once during each of your control phases, you may peek at one card randomly selected from opponent's hand.",
         "icons": [
           "Hoth"
@@ -39977,7 +39918,7 @@
         ],
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Probe Droid"
         ],
@@ -40015,7 +39956,7 @@
           "laser cannon"
         ],
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your probe droid. May target an artillery weapon (use 5 as defense value), character or creature for free. Draw destiny. Artillery weapon lost if destiny > defense value. Character or creature hit if destiny > defense value.",
         "icons": [
           "Hoth"
@@ -40120,7 +40061,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 2 Force to deploy on an opponent's droid (except R2-D2 and C- 3PO), 1 on your droid. When either player draws a destiny matching the number of characters at same site, droid 'explodes' (all characters present are lost).",
         "icons": [
           "A New Hope"
@@ -40155,7 +40096,7 @@
       ],
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Cancel Anger, Fear, Aggression when it is inserted or revealed. OR If your opponent just initiated a battle or Force drain, opponent must choose to use 2 Force, or cancel that battle or Force drain.",
         "icons": [
           "Cloud City"
@@ -40491,7 +40432,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on table. Aurra, Bossk, and Cad are destiny +2. Once per game, may reveal up to two unique (•) aliens from hand and/or Reserve Deck (reshuffle); for remainder of game, those cards are assassins and Black Sun agents. (Immune to Alter.)",
         "icons": [
           "Tatooine",
@@ -40632,7 +40573,7 @@
         ],
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Astromech Droid"
         ],
@@ -40674,7 +40615,7 @@
         ],
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Astromech Droid"
         ],
@@ -40712,7 +40653,7 @@
         ],
         "deploy": "1",
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Vehicle Repair Droid"
         ],
@@ -40745,7 +40686,7 @@
         ],
         "deploy": "2",
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Astromech Droid"
         ],
@@ -40987,8 +40928,8 @@
       ],
       "back": {
         "destiny": "7",
-        "errataVersion": "E1",
-        "gametext": "Ralltiir Operations:Deploy Ralltiir system.{For} remainder of game, spaceport sites are immune to Always Thinking With Your Stomach, He Hasn't Come Back Yet, and Ounee Ta. Your Force generation is +1 at each Ralltiir location. {While} this side up, once per turn, may deploy a site (or non-unique Imperial) to Ralltiir from Reserve Deck; reshuffle.{Flip} this card if Imperials control at least three Ralltiir sites and opponent controls no Ralltiir locations.In The Hands Of The Empire:{While} this side up, opponent's Force drains are -1 at their locations. Your total battle destiny is +X, where X = number of Ralltiir locations your Imperials occupy. {Flip} this card if opponent controls at least two Ralltiir locations.",
+        "errataSymbol": "E1",
+        "gametext": "Ralltiir Operations:Deploy [Set 20] Ralltiir system.{For} remainder of game, spaceport sites are immune to Always Thinking With Your Stomach, He Hasn't Come Back Yet, and non-[Set 18] Ounee Ta. You may not play [Coruscant] Do They Have A Code Clearance?. Your Force generation is +1 at each Ralltiir site. {While} this side up, once per turn, may deploy a site (or non-unique Imperial) to Ralltiir from Reserve Deck; reshuffle.{Flip} this card if Imperials control at least three Ralltiir sites and opponent controls no Ralltiir locations.In The Hands Of The Empire:{While} this side up, opponent's Force drains are -1 at their locations. Your total battle destiny is +X, where X = number of Ralltiir locations your Imperials occupy. {Flip} this card if opponent controls at least two Ralltiir locations.",
         "icons": [
           "Set 10"
         ],
@@ -40998,8 +40939,10 @@
       },
       "front": {
         "destiny": "0",
-        "errataVersion": "E1",
-        "gametext": "Ralltiir Operations:Deploy Ralltiir system.{For} remainder of game, spaceport sites are immune to Always Thinking With Your Stomach, He Hasn't Come Back Yet, and Ounee Ta. Your Force generation is +1 at each Ralltiir location. {While} this side up, once per turn, may deploy a site (or non-unique Imperial) to Ralltiir from Reserve Deck; reshuffle.{Flip} this card if Imperials control at least three Ralltiir sites and opponent controls no Ralltiir locations.In The Hands Of The Empire:{While} this side up, opponent's Force drains are -1 at their locations. Your total battle destiny is +X, where X = number of Ralltiir locations your Imperials occupy. {Flip} this card if opponent controls at least two Ralltiir locations.",
+        "errataDate": "2022-12-12",
+        "errataNotes": "Original card deployed any Ralltiir system, affected all versions of Ounee Ta, gave Force generations +1 at all Ralltiir locations, and did not mention Code Clearance. Note that Insignificant Rebellion (V) used to negate Code Clearance instead.",
+        "errataSymbol": "E1",
+        "gametext": "Ralltiir Operations:Deploy [Set 20] Ralltiir system.{For} remainder of game, spaceport sites are immune to Always Thinking With Your Stomach, He Hasn't Come Back Yet, and non-[Set 18] Ounee Ta. You may not play [Coruscant] Do They Have A Code Clearance?. Your Force generation is +1 at each Ralltiir site. {While} this side up, once per turn, may deploy a site (or non-unique Imperial) to Ralltiir from Reserve Deck; reshuffle.{Flip} this card if Imperials control at least three Ralltiir sites and opponent controls no Ralltiir locations.In The Hands Of The Empire:{While} this side up, opponent's Force drains are -1 at their locations. Your total battle destiny is +X, where X = number of Ralltiir locations your Imperials occupy. {Flip} this card if opponent controls at least two Ralltiir locations.",
         "icons": [
           "Set 10"
         ],
@@ -41010,6 +40953,7 @@
       "gempId": "210_42",
       "id": 6590,
       "legacy": false,
+      "previousId": 20010,
       "printings": [
         {
           "set": "210"
@@ -41460,7 +41404,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If any bounty hunter is defending a battle alone, add one battle destiny. OR If Bossk, Greedo or Boba Fett is defending a battle alone, add two battle destiny.",
         "icons": [
           "Dagobah"
@@ -41492,7 +41436,7 @@
         "ability": "1",
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "Adds 1 to power of anything he pilots. When piloting Black 2, Black 3 or Black 4, also adds 1 to maneuver and draws one battle destiny if not able to otherwise.",
         "icons": [
@@ -41589,7 +41533,7 @@
       ],
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 2 Force to deploy on any war room at a Rebel Base. Target a Rebel with forfeit > 4 or an opponent's leader. Opponent may not initiate a battle or a Force drain at same location as target. Utinni Effect canceled when reached by target.",
         "icons": [
           "Hoth"
@@ -41658,7 +41602,7 @@
       "counterpart": "Access Denied",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Insert face up in your Reserve Deck. When Effect reaches top it is lost, along with all opponent's 'insert' cards there. Reshuffle. (Immune to Alter.) OR Deploy between two mobile sites. Opponent's characters may pass only if aboard a Lift Tube or opponent uses +1 Force each.",
         "icons": [
           "Cloud City"
@@ -41850,7 +41794,7 @@
         ],
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "2",
         "gametext": "Adds 1 to power of each of your bounty hunters and smugglers (but subtracts 1 from Greedo's power) at same site. Adds 1 to power of anything he pilots.",
         "icons": [
@@ -42093,7 +42037,7 @@
         ],
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Once per game, may take Jawa Blaster or a card with 'sandcrawler' in title or game text into hand from Reserve Deck; reshuffle. During opponent's turn, if present at a Tatooine battleground and there is more than 1 Force in opponent's Force Pile, you may use 1 Force in opponent's Force Pile.",
         "icons": [
@@ -42438,7 +42382,7 @@
         ],
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "No Hyperdrive"
         ],
@@ -42556,7 +42500,7 @@
         ],
         "deploy": "3",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "5",
         "gametext": "Deploys only to a Tatooine site. May add 1 driver and 7 passengers. Cannot move to mobile sites. Adds 1 to forfeit of each Jawa at same exterior site.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/sandcrawler.gif",
@@ -42584,7 +42528,7 @@
       "front": {
         "darkSideIcons": 0,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Dark:  Deploy on your sandcrawler. Each Jawa is forfeit +2 here. 'Nighttime conditions' here.  Light:  Your characters may enter/exit here for 1 Force each. 'Nighttime conditions' here.",
         "icons": [
           "Interior",
@@ -42770,7 +42714,7 @@
         ],
         "deploy": "6",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "5",
         "gametext": "Deploys -1 for each other Sith character here (limit - 4). Once per game, may exchange a card in hand with a Sith character in Lost Pile. Immune to attrition < 3.",
         "icons": [
@@ -43675,7 +43619,7 @@
       "counterpart": "This Is All Your Fault",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Lose a droid to cancel all attrition against you at same site this turn. OR Re-target an opponent's weapon to one of your droids at same site. If droid is 'hit', use original target's forfeit number.",
         "icons": [
           "Hoth"
@@ -43851,7 +43795,7 @@
       "counterpart": "Sense & Recoil In Fear",
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "USED: Target your highest-ability character and one just-played Interrupt. Draw destiny. If destiny < ability of target character, cancel target Interrupt.  LOST: Use 3 Force. Each player places hand onto Reserve Deck (if possible), then places Used Pile onto Reserve Deck; reshuffle. Each player then draws cards from Reserve Deck equal to the number of cards just placed from hand onto Reserve Deck (if any).",
         "icons": [
           "Reflections 2"
@@ -44525,7 +44469,7 @@
     {
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If Agents Of Black Sun on table, deploy on table. May use 1 Force to deploy Imperial Square from Reserve Deck; reshuffle. Once per turn, if Emperor on Coruscant, may draw top card of Force Pile (if during your turn and you occupy three battlegrounds, opponent also loses 1 Force). (Immune to Alter.)",
         "icons": [
           "Set 9"
@@ -44551,7 +44495,7 @@
     {
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If a battle you won just ended at an interior site and you have a character of ability > 3 present there, relocate one opponent's character present to an adjacent site. (If on Cloud City, may relocate that character to Weather Vane instead.)",
         "icons": [
           "Cloud City"
@@ -44697,7 +44641,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your side of table. Once per turn, you may lose 1 Force to draw the top card of your Reserve Deck into your hand. If that card is a space creature, you may immediately deploy it for free.",
         "icons": [
           "Dagobah"
@@ -44810,7 +44754,7 @@
       ],
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on Wakeelmui system. Retrieve 1 Force each time you deploy a TIE. Also, once per turn you may relocate a TIE just lost from table to Used Pile. (Immune to Alter while you occupy Wakeelmui.)",
         "icons": [
           "Special Edition"
@@ -44916,7 +44860,10 @@
     {
       "front": {
         "destiny": "3",
-        "gametext": "Deploy on table. Your droids are destiny +1. Once per turn, if you just drew a non-[Presence] droid for destiny, may take that droid into hand. Once per turn, may deploy Droid Workshop, Forced Servitude, Incinerator, or Wuher from Reserve Deck; reshuffle. (Immune to Alter.)",
+        "errataDate": "2022-12-12",
+        "errataNotes": "Original card could also deploy Forced Servitude (and did not cancel it). Original card was not immune to Levitation.",
+        "errataSymbol": "E1",
+        "gametext": "Deploy on table. Your droids are destiny +1. Once per turn, if you just drew a non-[Presence] droid for destiny, may take that droid into hand. Once per turn, may deploy Droid Workshop, Incinerator, or Wuher from Reserve Deck; reshuffle. Forced Servitude is canceled. Immune to Levitation. [Immune to Alter.]",
         "icons": [
           "Set 10"
         ],
@@ -44928,10 +44875,16 @@
       "gempId": "210_45",
       "id": 6642,
       "legacy": false,
+      "previousId": 20011,
       "printings": [
         {
           "set": "210"
         }
+      ],
+      "pulls": [
+        "Cloud City: Incinerator",
+        "Jabba's Palace: Droid Workshop",
+        "Wuher"
       ],
       "rarity": "U2",
       "set": "210",
@@ -45078,8 +45031,10 @@
       "counterpart": "Jedi Levitation (V)",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
-        "gametext": "USED: If you just drew a character for destiny, take that card into hand to cancel and redraw that destiny.  LOST: Once per game, exchange a Dark Jedi in hand with a Dark Jedi in Lost Pile.",
+        "errataDate": "2022-12-12",
+        "errataNotes": "E1 Text: USED: If you just drew a character for destiny, take that card into hand to cancel and redraw that destiny.  LOST: Once per game, exchange a Dark Jedi in hand with a Dark Jedi in Lost Pile.",
+        "errataSymbol": "E2",
+        "gametext": "USED: If you just drew a character for destiny, choose: Take that card into hand. OR Cancel and redraw that destiny. LOST: Once per game, use 4 Force to take a character into hand from Lost Pile.",
         "icons": [
           "Tatooine",
           "Set 0"
@@ -45094,35 +45049,16 @@
       "gempId": "200_123",
       "id": 4003,
       "legacy": false,
+      "previousId": 20012,
       "printings": [
         {
           "set": "200"
         }
       ],
-      "pulls": [
-        "Count Dooku",
-        "Darth Maul",
-        "Darth Maul With Lightsaber",
-        "Darth Maul",
-        "Lone Hunter",
-        "Darth Maul",
-        "Young Apprentice",
-        "Darth Sidious",
-        "Darth Vader",
-        "Darth Vader (V)",
-        "Darth Vader With Lightsaber",
-        "Darth Vader, Dark Lord Of The Sith",
-        "Darth Vader, Emperor's Enforcer",
-        "Emperor Palpatine",
-        "Emperor Palpatine, Foreseer",
-        "Lord Maul",
-        "Lord Maul With Lightsaber",
-        "Lord Sidious",
-        "Lord Vader",
-        "The Emperor",
-        "Vader"
-      ],
       "rarity": "C",
+      "rulings": [
+        "The Lost function is not retrieval."
+      ],
       "set": "200",
       "side": "Dark"
     },
@@ -45223,7 +45159,7 @@
         ],
         "deploy": "3",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Deploy -1 to a Tatooine site. May add 1 driver and 5 passengers. May move as a 'react.' If lost, any characters aboard may 'jump off' (disembark).",
         "icons": [
@@ -45429,7 +45365,7 @@
         ],
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "CLAWS: 2"
         ],
@@ -45558,7 +45494,7 @@
       "counterpart": "Sorry About The Mess",
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "During your control phase, fire one of your weapons. If URoRRuR'R'R firing, may add 2 to each weapon destiny draw. (A seeker may be targeted by a character weapon, as if a character with defense value of 4.) Any 'hit' targets are immediately lost.",
         "icons": [
           "A New Hope"
@@ -45632,7 +45568,7 @@
         ],
         "deploy": "5",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "Deploys -3 to same site as any smuggler or bounty. During your deploy phase, a Vibro-Ax may deploy for free on Snoova from Reserve Deck; reshuffle. When Snoova excludes a target with a Vibro-Ax, he may capture target instead.",
         "icons": [
@@ -45675,7 +45611,7 @@
         ],
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Deploys only on Hoth. Power -1 when not at a Hoth site.",
         "icons": [
@@ -46082,7 +46018,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on a prison. When one of your troopers 'delivers' (imprisons) a captive here, you may search your Lost Pile, take any one card into hand and then lose effect. (Each captive may be 'delivered' only once until they are released or leave table)",
         "icons": [
           "Cloud City"
@@ -46124,7 +46060,7 @@
           "hologram"
         ],
         "destiny": "7",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on table. The Phantom Menace is canceled. You lose no Force to Kylo or Kylo's Lightsaber. if Kylo (or Kylo's Lightsaber) just lost, may place this Effect in Lost Pile to take that card into hand. (Immune to Alter.)",
         "icons": [
           "Episode VII",
@@ -46227,7 +46163,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on Kessel system (may not be moved). Target one captive and one trooper to escort captive. When targets reach Utinni Effect, retrieve Force equal to captive's forfeit (captive and Utinni Effect lost). If trooper lost en route, captive released.",
         "icons": [
           "A New Hope"
@@ -46993,7 +46929,7 @@
       "counterpart": "Echo Trooper Backpack",
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your trooper. May use any number of weapons and devices. Trooper is immune to attrition < 3 when at a planet site.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/stormtrooperbackpack.gif",
         "lore": "Standard-issue Imperial equipment with full survival and encampment gear, plus ammunition and food for an extended deployment. Makes each trooper self-sufficient.",
@@ -47024,7 +46960,7 @@
         ],
         "deploy": "1",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "1",
         "gametext": "Deploys free to same site as an Imperial leader.  Once per turn, may target a non-unique Imperial warrior present; target is power +1 for remainder of turn. When forfeited at same site as an Imperial leader or (non-cadet trooper), also satisfies all remaining attrition against you.",
         "icons": [
@@ -47231,7 +47167,7 @@
       "counterpart": "Blast The Door, Kid!",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If a battle was just initiated at an interior site, use 1 Force; for remainder of battle all characters of ability > 2 and all leaders (on both sides) are simultaneously excluded from that battle.",
         "icons": [
           "A New Hope"
@@ -47383,7 +47319,7 @@
     {
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on Death Star system at parsec 0. May target a capital starship at Death Star system, or at a system it orbits, using 4 Force. Draw two destiny. Target hit if total destiny > defense value.",
         "icons": [
           "A New Hope"
@@ -47745,7 +47681,7 @@
       "counterpart": "Merc Sunlet",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your non-thief to give that character thief skill. Once during each of your control phases, may target one device at same site. Draw destiny. If destiny < target's destiny number, it is stolen. OR Deploy on a weapon to prevent theft. (Immune to Alter.)",
         "icons": [
           "A New Hope"
@@ -48005,7 +47941,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Target two starfighters (your TIE/ln and any Rebel starfighter) present at same system or sector. Each player draws destiny. Opponent totals destiny and starship's power. You total destiny, TIE's power and TIE's maneuver. Lowest total loses starfighter.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/tallonroll.gif",
         "lore": "Maneuver named after Adar Tallon, tactician of the Old Republic who revolutionized starfighter combat. Pursuing fighter rolls and turns, maintaining speed and target lock.",
@@ -48147,7 +48083,7 @@
         ],
         "deploy": "4",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Attuned"
         ],
@@ -48186,7 +48122,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on Death Star. During your control phase, for each battleground system controlled by your Star Destroyer within 2 parsecs of Death Star, opponent loses 1 Force. Canceled if opponent controls this system.",
         "icons": [
           "Set 0"
@@ -48217,7 +48153,7 @@
     {
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on opponent's spy or Rebel leader. If subsequently captured, seized by a bounty hunter or Imperial and then transferred to Detention Block Corridor, retrieve Force equal to character's forfeit (+4 if Leia) and lose Effect. (Immune to Alter.)",
         "icons": [
           "Special Edition"
@@ -49011,7 +48947,7 @@
       "front": {
         "darkSideIcons": 2,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Dark:  Your characters here and at Watto's Junkyard are immune to opponent's Sandwhirl.  Light:  For remainder of game, sites may not deploy between this site and Watto's Junkyard.",
         "icons": [
           "Exterior",
@@ -49232,7 +49168,7 @@
         "ability": "1",
         "deploy": "1",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "2",
         "gametext": "When on Tatooine, may cancel any result of Krayt Dragon Bones. While at Audience Chamber, all your Tusken Raiders are power = 3 and forfeit +2.",
         "icons": [
@@ -49513,7 +49449,7 @@
         ],
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "May add 2 pilots or passengers. May move as a 'react' for free. When Arnet piloting, immune to attrition < 4 and adds 1 to attrition against opponent here.",
         "icons": [
@@ -49813,7 +49749,7 @@
       "counterpart": "Grappling Hook",
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If opponent just played an Interrupt, use 1 Force to deploy on table. That Interrupt is played out but is then 'grabbed' (played here but is out of play). Any new Interrupts of the same name are unique (•). (Immune to Control.)",
         "icons": [
           "Grabber",
@@ -49922,7 +49858,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If you have a probe droid at a site during your control phase, move one of your starships to the related system. That starship cannot move again this turn.",
         "icons": [
           "Hoth"
@@ -49954,7 +49890,7 @@
       ],
       "front": {
         "destiny": "6",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If Vader and Obi-Wan are present at same site, use 1 Force to initiate a duel between them.  Compare their power, and add 2 if that character is armed with a lightsaber.  Loser (lowest total) of duel is placed out of play.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/thecircleisnowcomplete.gif",
         "lore": "Vader and Obi-Wan Kenobi fought a final lightsaber duel near Hangar Bay 327 on the Death Star. 'When I left you I was but the learner; now I am the master.'",
@@ -50131,8 +50067,7 @@
         }
       ],
       "pulledBy": [
-        "According To My Design (V)",
-        "Sith Fury (V)"
+        "According To My Design (V)"
       ],
       "rarity": "PM",
       "set": "10",
@@ -50144,7 +50079,7 @@
       ],
       "front": {
         "destiny": "6",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If Luke was just 'frozen,' deploy on Emperor or Detention Block Corridor. Target Luke and Vader. When reached by targets, place Utinni Effect on Luke and opponent must lose Force from Life Force equal to half their Life Force (round down). If Luke released, lose Utinni Effect. (Immune to Alter.)",
         "icons": [
           "Cloud City"
@@ -50506,7 +50441,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "USED: If your Imperial of ability > 2 just won a battle, randomly take into hand one card stacked on I Feel The Conflict. (Immune to Sense.)  LOST: If Vader in battle, subtract 2 from each of opponent's battle destiny draws.",
         "icons": [
           "Tatooine"
@@ -50666,7 +50601,7 @@
       "counterpart": "What're You Tryin' To Push On Us?",
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 3 Force to deploy on table and stack one just-played Interrupt here. To play any new Interrupt of the same name, player must first stack it here and use +1 Force for each Interrupt in stack, even if Interrupt is normally free. (Immune to Control.)",
         "icons": [
           "Grabber",
@@ -51128,7 +51063,7 @@
         ],
         "deploy": "7",
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "5",
         "gametext": "Deploys -2 to a Jabba's Palace site.  If opponent just initiated battle at same site, may use X Force (limit 2) to add twice X to power. Your alien leaders present may not be targeted by weapons. End of your turn: Use 2 Force to maintain OR Lose 1 Force to place in Used Pile OR Place out of play.",
         "icons": [
@@ -51224,7 +51159,7 @@
         ],
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Deploys free to your [Independent Starship] starship. Adds 2 to power of anything he pilots. When with Lieutenant Tanbris in a battle at a system, adds 2 to each of your battle destiny draws.",
         "icons": [
@@ -51425,7 +51360,7 @@
         ],
         "deploy": "3",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "2",
         "gametext": "Deploy -1 to same system as any Imperial capital starship. May add 1 pilot. Boosted TIE Cannon may deploy aboard.",
         "hyperspeed": "2",
@@ -51739,7 +51674,7 @@
         ],
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "No Hyperdrive"
         ],
@@ -51859,7 +51794,7 @@
         ],
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "2",
         "gametext": "Twice during each of your control phases, may use 2 Force to draw 2 destiny for 2 chances at a destiny = 2. If successful, may steal or destroy up to 2 weapons or 2 devices present.",
         "icons": [
@@ -52012,7 +51947,7 @@
       ],
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 2 Force to deploy on your Star Destroyer. At the end of a battle at same system or sector, may target an opponent's starship present (except Mon Calamari Star Cruiser) using 2 Force. Draw destiny. Target captured if destiny > defense value.",
         "icons": [
           "A New Hope"
@@ -52235,7 +52170,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If you have a piloted AT-AT or AT-ST present at a site, target opponent's character, 'crashed' vehicle or unpiloted vehicle without armor present. Draw destiny. Character lost if destiny > ability. Vehicle lost if destiny < 7.",
         "icons": [
           "Hoth"
@@ -52450,7 +52385,7 @@
         ],
         "deploy": "0",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Deploys only on Cloud City, but may move elsewhere. Power +2 when participating in a battle you initiate. Opponent may use 2 Force to 'bribe' (exclude) Blendin from battle.",
         "icons": [
@@ -52607,7 +52542,7 @@
           "turbolaser battery"
         ],
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 3 Force to deploy on your Star Destroyer or any mobile system. May target a starship using 2 Force. Draw two destiny. Subtract 2 if targeting a capital starship. Otherwise, subtract 5. Target hit if total destiny > defense value.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/turbolaserbattery.gif",
         "lore": "High-powered blasters. Require power generators, cryogenic cooling units and large crews. More effective against capital starships than starfighters.",
@@ -52844,9 +52779,14 @@
       ],
       "back": {
         "destiny": "7",
-        "gametext": "Twin Suns Of Tatooine:Deploy Tatooine system and a non-Jabba's Palace Tatooine battleground site. {For} remainder of game, you may not deploy Jabba's Palace sites or Sandwhirl. {While} this side up, once per turn, may use 1 Force to deploy a Tatooine battleground site from Reserve Deck; reshuffle. {Flip} this card if you control two Tatooine battleground sites (at least one with a Dark Jedi) and occupy Tatooine system, and opponent controls no Tatooine sites.Well Trained In The Jedi Arts:{While} this side up, once per game, may deploy Tatooine Occupation from Reserve Deck; reshuffle. Once during your control phase, may peek at the top two cards of your Reserve Deck; take one into hand and shuffle Reserve Deck. For opponent to move a character or vehicle from same site as your Dark Jedi requires +1 Force. {Flip} this card if opponent controls more Tatooine sites than you.",
+        "errataDate": "2022-12-12",
+        "errataNotes": "Original card had Premium icon instead of Episode I and Tatooine icons, and the underlying card was I Will Find Them Quickly, Master.",
+        "errataSymbol": "E1",
+        "gametext": "Twin Suns Of Tatooine:Deploy Tatooine system and a non-Jabba's Palace Tatooine site. {For} remainder of game, you may not deploy Jabba's Palace sites or Sandwhirl. {While} this side up, once per turn, may use 1 Force to deploy a Tatooine battleground site from Reserve Deck; reshuffle. {Flip} this card if you control two Tatooine battleground sites (at least one with a Dark Jedi) and occupy Tatooine system, and opponent controls no Tatooine sites.Well Trained In The Jedi Arts:{While} this side up, once per game, may deploy Tatooine Occupation from Reserve Deck; reshuffle. Once during your control phase, may peek at the top two cards of your Reserve Deck; take one into hand and shuffle Reserve Deck. For opponent to move a character or vehicle from same site as your Dark Jedi requires +1 Force. {Flip} this card if opponent controls more Tatooine sites than you.",
         "icons": [
-          "Set P"
+          "Episode I",
+          "Set P",
+          "Tatooine"
         ],
         "imageUrl": "https://res.starwarsccg.org/cards/DemoDeck-Dark/large/welltrainedinthejediarts.gif",
         "title": "Twin Suns Of Tatooine / Well Trained In The Jedi Arts",
@@ -52854,9 +52794,14 @@
       },
       "front": {
         "destiny": "0",
-        "gametext": "Twin Suns Of Tatooine:Deploy Tatooine system and a non-Jabba's Palace Tatooine battleground site. {For} remainder of game, you may not deploy Jabba's Palace sites or Sandwhirl. {While} this side up, once per turn, may use 1 Force to deploy a Tatooine battleground site from Reserve Deck; reshuffle. {Flip} this card if you control two Tatooine battleground sites (at least one with a Dark Jedi) and occupy Tatooine system, and opponent controls no Tatooine sites.Well Trained In The Jedi Arts:{While} this side up, once per game, may deploy Tatooine Occupation from Reserve Deck; reshuffle. Once during your control phase, may peek at the top two cards of your Reserve Deck; take one into hand and shuffle Reserve Deck. For opponent to move a character or vehicle from same site as your Dark Jedi requires +1 Force. {Flip} this card if opponent controls more Tatooine sites than you.",
+        "errataDate": "2022-12-12",
+        "errataNotes": "Original card required the started Tatooine site to be a battleground. Original card had Premium icon instead of Episode I and Tatooine icons.",
+        "errataSymbol": "E1",
+        "gametext": "Twin Suns Of Tatooine:Deploy Tatooine system and a non-Jabba's Palace Tatooine site. {For} remainder of game, you may not deploy Jabba's Palace sites or Sandwhirl. {While} this side up, once per turn, may use 1 Force to deploy a Tatooine battleground site from Reserve Deck; reshuffle. {Flip} this card if you control two Tatooine battleground sites (at least one with a Dark Jedi) and occupy Tatooine system, and opponent controls no Tatooine sites.Well Trained In The Jedi Arts:{While} this side up, once per game, may deploy Tatooine Occupation from Reserve Deck; reshuffle. Once during your control phase, may peek at the top two cards of your Reserve Deck; take one into hand and shuffle Reserve Deck. For opponent to move a character or vehicle from same site as your Dark Jedi requires +1 Force. {Flip} this card if opponent controls more Tatooine sites than you.",
         "icons": [
-          "Set P"
+          "Episode I",
+          "Set P",
+          "Tatooine"
         ],
         "imageUrl": "https://res.starwarsccg.org/cards/DemoDeck-Dark/large/twinsunsoftatooine.gif",
         "title": "Twin Suns Of Tatooine / Well Trained In The Jedi Arts",
@@ -52865,6 +52810,7 @@
       "gempId": "301_4",
       "id": 6716,
       "legacy": false,
+      "previousId": 20013,
       "printings": [
         {
           "set": "301"
@@ -52970,7 +52916,7 @@
         ],
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "May add 1 driver and 2 passengers. May move as a 'react.'",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/ubrikkian9000z001.gif",
@@ -53119,7 +53065,7 @@
     {
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 3 Force. Each player places hand onto Reserve Deck (if possible), then places Used Pile onto Reserve Deck; reshuffle. Each player then draws cards from Reserve Deck equal to the number of cards just placed from hand onto Reserve Deck (if any).",
         "icons": [
           "Dagobah"
@@ -53146,7 +53092,7 @@
       "counterpart": "Undercover",
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your spy at a site and cross spy to opponent's side. Spy is now Undercover. During your deploy phase, may voluntarily 'break cover' (lose Effect) if at a site. (Immune to Alter.)",
         "icons": [
           "A New Hope"
@@ -53323,7 +53269,7 @@
           "rifle"
         ],
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to deploy on URoRRuR'R'R or Chief Bast, 3 on your non-droid character. May target a character or creature using 1 Force. Draw destiny. Subtract 1 if targeting a character. Add 2 if targeting a creature. Target hit if total destiny > defense value.",
         "icons": [
           "A New Hope"
@@ -53466,7 +53412,6 @@
       ],
       "pulledBy": [
         "Blizzard 4",
-        "Sith Fury (V)",
         "The Empire's Back"
       ],
       "rarity": "PM",
@@ -53510,7 +53455,7 @@
       ],
       "front": {
         "destiny": "5",
-        "errataVersion": "E2",
+        "errataSymbol": "E2",
         "gametext": "Vader follows (using landspeed for free) an opponent's character that just moved from same site. OR If Vader in battle alone, your total battle destiny is +1 for each character in battle. OR If Vader in battle, cancel Dodge, It's A Trap!, or Obi-Wan's Journal.",
         "icons": [
           "Tatooine",
@@ -53546,7 +53491,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on a Rebel of ability > 2. If subsequently captured, seized by a bounty hunter and then transferred to a prison where Vader is present, retrieve Force equal to character's forfeit (+4 if Luke) and lose Effect. (Immune to Alter.)",
         "icons": [
           "Cloud City"
@@ -53656,7 +53601,7 @@
         ],
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "5",
         "gametext": "May add 1 pilot. Vader deploys -2 aboard. While Vader piloting, immune to attrition < 5, and during battle, may cancel game text of a passenger (or pilot of ability < 4) here.",
         "hyperspeed": "3",
@@ -53730,7 +53675,7 @@
           "lightsaber"
         ],
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on Vader. May add 1 to Force drain where present. May target a character or creature for free. Draw two destiny. Target hit, and its forfeit = 0, if total destiny > defense value.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Dark/large/vaderslightsaber.gif",
         "lore": "Custom-built by Darth Vader. After the Clone Wars, he wielded this weapon while hunting down the last of the Jedi. Cuts through almost anything except another lightsaber blade.",
@@ -54013,7 +53958,7 @@
         ],
         "deploy": "3",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Attuned"
         ],
@@ -54056,7 +54001,7 @@
       "counterpart": "Vehicle Mine",
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy at same exterior site as your mining droid. 'Explodes' if starfighter (use 5 as defense value) or non-creature vehicle deploys or moves to or across same site. Draw destiny. Target lost if destiny +2 > defense value. Vehicle Mine is also lost.",
         "icons": [
           "Hoth"
@@ -54234,7 +54179,7 @@
       "counterpart": "Vibro-Ax",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 3 Force to deploy on any alien warrior. Adds 1 to power. May target a character using 1 Force. Both players draw destiny. Target immediately excluded from battle if warrior's power + your destiny > target's power + opponent's destiny.",
         "icons": [
           "Jabba's Palace"
@@ -54400,7 +54345,7 @@
         ],
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "SLITHER: 3"
         ],
@@ -54726,7 +54671,7 @@
     {
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If you have a piloted AT-AT present at a site, target opponent's artillery weapon at same or adjacent exterior site. Draw destiny. Target lost if destiny +1 > forfeit. Also, one opponent's character at same site as target (random selection) lost if destiny +1 > 6.",
         "icons": [
           "Hoth"
@@ -54780,7 +54725,7 @@
     {
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If you have a piloted AT-AT present at a site, target any number of opponent's troopers present at same or adjacent exterior site. Draw destiny. If destiny > number of troopers targeted, they are lost.",
         "icons": [
           "Hoth"
@@ -54846,7 +54791,7 @@
         "ability": "2",
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Adds 2 to power of anything he pilots. May use 1 Force to take one tractor beam, Our First Catch Of The Day or Besieged into hand from Reserve Deck; reshuffle.",
         "icons": [
@@ -55050,7 +54995,7 @@
       ],
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force if opponent's character is about to be lost or forfeited from battle. It is captured instead (character is first restored to normal). OR Use X Force to capture all characters on board a captured starship, where X = twice the number of characters.",
         "icons": [
           "A New Hope"
@@ -55313,7 +55258,7 @@
       "front": {
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Maintenance Droid"
         ],
@@ -55446,7 +55391,7 @@
         ],
         "deploy": "4",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Deploys only on Tatooine. May fire one weapon during your control phase (at double use of Force). May use 2 Force to 'assassinate' any character just 'hit' by Weequay Marksman (victim is immediately lost).",
         "icons": [
@@ -55574,7 +55519,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your general or commander. When battling, adds 1 to your total battle destiny (or 2 if Igar). Once during each of your control phases, may take one Imperial Propaganda into hand from Reserve Deck; reshuffle. Your Force drains are +1 at holosites.",
         "icons": [
           "Endor"
@@ -56070,7 +56015,7 @@
         ],
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "Adds 3 to power of anything he pilots. May deploy with any cruiser using Combat Response. While aboard a piloted [Independent] starship, opponent's battle and weapon destiny draws here are -1.",
         "icons": [
@@ -56275,7 +56220,7 @@
       "front": {
         "darkSideIcons": 2,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Dark:  Once per game, may exchange an alien in hand with a non-spy Black Sun agent in Lost Pile.  Light:  Once per game, if you control, may retrieve a Corellian.",
         "icons": [
           "Underground",
@@ -56859,7 +56804,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "USED: Use 1 Force to take a [First Order] shuttle into hand from Reserve Deck; reshuffle.  STARTING: Deploy Jakku: Landing Site, Bow To The First Order, and one Effect that deploys on table and is always immune to Alter. Place this Interrupt in hand.",
         "icons": [
           "Episode VII",
@@ -57409,11 +57354,12 @@
         "characteristics": [
           "Black Sun agent",
           "bounty hunter",
+          "Gand",
           "scout"
         ],
         "deploy": "4",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Sensitive"
         ],
@@ -57467,7 +57413,7 @@
         ],
         "deploy": "6",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "5",
         "gametext": "May add 1 pilot and 3 passengers. Permanent pilot is •Zuckuss, who provides ability of 4 and adds 2 to power. Unless opponent has total ability > 6 piloting here, may reset opponent's total battle destiny here to 0.",
         "hyperspeed": "5",
@@ -57505,7 +57451,7 @@
           "rifle"
         ],
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on Zuckuss, or use 1 Force to deploy on any other bounty hunter. May target a character or creature using 2 Force. Draw destiny. Character captured if destiny -1 > defense value. Creature lost if destiny +1 > defense value.",
         "icons": [
           "Dagobah"
@@ -57590,7 +57536,7 @@
         ],
         "deploy": "3",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Attuned"
         ],
@@ -57719,7 +57665,7 @@
         ],
         "deploy": "4",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Sensitive"
         ],
@@ -57786,7 +57732,7 @@
     {
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If you have deployed a site (except Imperial Square) with exactly two [Dark Side] (and no other locations), deploy a related (or mobile) battleground site and up to three Effects that deploy for free and are always immune to Alter. Place Interrupt in Lost Pile.",
         "icons": [
           "Cloud City",
@@ -57821,7 +57767,10 @@
     {
       "front": {
         "destiny": "4",
-        "gametext": "If Ralltiir Operations on table, deploy on table. Forfeit values are not modified by Do They Have A Code Clearance?. Once per battle, when you draw battle destiny, may exchange a card in hand with a card of same card type in Lost Pile. (Immune to Alter.)",
+        "errataDate": "2022-12-12",
+        "errataNotes": "Original prevented Code Clearance from increasing forfeit, and didn't place Lost Interrupts out of play.",
+        "errataSymbol": "E1",
+        "gametext": "If Ralltiir Operations on table, deploy on table. Once per battle, when you draw battle destiny, may exchange a card in hand with a card of same card type in Lost Pile. If your Lost Interrupt (except Ghhhk) just resolved, place it out of play. [Immune to Alter.]",
         "icons": [
           "Death Star II",
           "Set 10"
@@ -57835,6 +57784,7 @@
       "gempId": "210_47",
       "id": 6788,
       "legacy": false,
+      "previousId": 20005,
       "printings": [
         {
           "set": "210"
@@ -57844,6 +57794,11 @@
         "Moment Of Triumph (V)"
       ],
       "rarity": "U",
+      "rulings": [
+        "A 'Used Or Lost' Interrupt only goes out of play if the Lost function is played.",
+        "If a Lost Interrupt is canceled, it does not resolve and therefore does not go out of play.",
+        "A Lost Interrupt with a failed outcome (such as a failed destiny draw on Set For Stun) has resolved, and goes out of play."
+      ],
       "set": "210",
       "side": "Dark"
     },
@@ -58287,11 +58242,14 @@
         "destinyValues": [
           0.5
         ],
+        "errataDate": "2022-12-12",
+        "errataNotes": "Original Text: Never deploys to a battleground. Opponent may not cancel your destiny draws. Once per turn, may add 1 to a just drawn battle or weapon destiny. Once per turn, may subtract 1 from a just drawn battle or weapon destiny. Immune to attrition < 5.",
+        "errataSymbol": "E1",
         "extraText": [
           "Dark Jedi"
         ],
         "forfeit": "8",
-        "gametext": "Never deploys to a battleground. Opponent may not cancel your destiny draws. Once per turn, may add 1 to a just drawn battle or weapon destiny. Once per turn, may subtract 1 from a just drawn battle or weapon destiny. Immune to attrition < 5.",
+        "gametext": "Never deploys to a battleground. Once per turn, may add or subtract 1 from a just drawn battle destiny or blaster weapon destiny. Battle destiny draws may not be canceled where you have a non-unique blaster. Immune to attrition < 5.",
         "icons": [
           "Warrior",
           "Set 13"
@@ -58307,6 +58265,7 @@
       "gempId": "213_10",
       "id": 6800,
       "legacy": false,
+      "previousId": 20008,
       "printings": [
         {
           "set": "213"
@@ -58928,7 +58887,7 @@
       ],
       "back": {
         "destiny": "7",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Hunt Down And Destroy The Jedi: Deploy Vader's Castle, [Set 13] Visage Of The Emperor, and a [Cloud City] site with exactly one [Dark Side]. {For} remainder of game, you may not deploy characters except bounty hunters, droids, and Imperials. Where you have an Inquisitor, your total battle destiny is +1 (+2 if with a 'Hatred' card). Inquisitors are destiny +1. {While} this side up, once per turn, may deploy a [Cloud City] or Malachor battleground site from Reserve Deck; reshuffle. {Flip} this card if Vader is at a battleground site unless Luke, a Jedi, or a Padawan at a battleground site. Their Fire Has Gone Out Of The Universe: {While} this side up, you lose no Force from Visage Of The Emperor. While Vader armed with a lightsaber, opponent's Force drain bonuses are canceled. {Flip} this card if Vader not on table or if Luke, a Jedi, or a Padawan at a battleground site; once per game, may take Vader and your cards on him into hand from a site you control.",
         "icons": [
           "Set 13"
@@ -58939,7 +58898,7 @@
       },
       "front": {
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Hunt Down And Destroy The Jedi: Deploy Vader's Castle, [Set 13] Visage Of The Emperor, and a [Cloud City] site with exactly one [Dark Side]. {For} remainder of game, you may not deploy characters except bounty hunters, droids, and Imperials. Where you have an Inquisitor, your total battle destiny is +1 (+2 if with a 'Hatred' card). Inquisitors are destiny +1. {While} this side up, once per turn, may deploy a [Cloud City] or Malachor battleground site from Reserve Deck; reshuffle. {Flip} this card if Vader is at a battleground site unless Luke, a Jedi, or a Padawan at a battleground site. Their Fire Has Gone Out Of The Universe: {While} this side up, you lose no Force from Visage Of The Emperor. While Vader armed with a lightsaber, opponent's Force drain bonuses are canceled. {Flip} this card if Vader not on table or if Luke, a Jedi, or a Padawan at a battleground site; once per game, may take Vader and your cards on him into hand from a site you control.",
         "icons": [
           "Set 13"
@@ -58972,7 +58931,7 @@
       ],
       "back": {
         "destiny": "7",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Shadow Collective: Deploy Maul's Chambers. If Massassi Throne Room on table, may deploy [Set 13] Maul to Maul's Chambers. {For} remainder of game, you may not deploy cards with ability (or [Episode I] droids) except characters with 'Black Sun,' 'Crimson Dawn,' or 'Hutt' in lore, assassins, gangsters, [Episode I] bounty hunters, and [Independent] starships. Once per turn, may deploy a non-unique blaster (or a card with 'First Light' in title) from Reserve Deck; reshuffle. {Flip} this card if you just 'hit' a character (or during your battle phase if your gangsters control two battlegrounds). You Know Who I Answer To: {May immediately} re-circulate and shuffle your Reserve Deck. {While} this side up, if your gangster leader in battle at same site as your non-unique blaster, may add one destiny to total power. During your draw phase, if Maul alone, may peek at the cards in your Force Pile. {Flip} this card at end of turn. If you are about to flip this card and you occupy three battlegrounds, opponent loses 1 Force.",
         "icons": [
           "Set 13"
@@ -59001,7 +58960,8 @@
       ],
       "rarity": "C",
       "rulings": [
-        "Dark cannot use persona replacement to play characters that aren't normally allowed (for example, cannot persona replace Set 13 Maul with Darth Maul Young Apprentice)."
+        "Dark cannot use persona replacement to play characters that aren't normally allowed (for example, cannot persona replace Set 13 Maul with Darth Maul Young Apprentice).",
+        "(7-side) An empty Used Pile does not prevent Dark from performing the 're-circulate and shuffle Reserve Deck' action."
       ],
       "set": "213",
       "side": "Dark"
@@ -59093,8 +59053,11 @@
         ],
         "deploy": "4",
         "destiny": "4",
+        "errataDate": "2022-12-12",
+        "errataNotes": "Original card did not require an Episode VII icon on his deploy location.",
+        "errataSymbol": "E1",
         "forfeit": "9",
-        "gametext": "Never deploys or moves (even if carried) to a location with a [Light Side] icon. Once per turn, may draw bottom card of your Force Pile. Once per game, if about to be lost, may take him into hand. Immune to attrition.",
+        "gametext": "Never deploys or moves (even if carried) except to an [Episode VII] location without a [Light Side] icon. Once per turn, may draw bottom card of your Force Pile. Once per game, if about to be lost, may take him into hand. Immune to attrition.",
         "icons": [
           "Episode VII",
           "Set 14"
@@ -59110,6 +59073,7 @@
       "gempId": "214_8",
       "id": 6851,
       "legacy": false,
+      "previousId": 20009,
       "printings": [
         {
           "set": "214"
@@ -59158,7 +59122,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If I Will Finish What You Started on table, deploy on table. While [Episode VII] Emperor on Exegol, attrition against opponent is +2 at same location as Kylo, Rey, or Snoke and, once per game, may deploy an [Episode VII] battleground system from Reserve Deck; reshuffle. (Immune to Alter.)",
         "icons": [
           "Episode VII",
@@ -59397,7 +59361,7 @@
         "armor": "6",
         "deploy": "7",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "8",
         "gametext": "May add 6 pilots, 8 passengers, and 2 starfighters. Permanent pilot provides ability of 2. While alone at an [Episode VII] system, adds Force icons to equalize them for both sides here. Immune to attrition < 4.",
         "hyperspeed": "3",
@@ -59470,7 +59434,7 @@
         ],
         "deploy": "4",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Attuned"
         ],
@@ -59829,7 +59793,7 @@
       "front": {
         "darkSideIcons": 2,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Dark:  May deploy non-[Theed Palace] Sidious here from Reserve Deck; reshuffle. If your [Special Edition] objective on table, gains one [Light Side] icon and opponent's Force drains are +2 here.  Light:  -",
         "icons": [
           "Exterior",
@@ -59977,7 +59941,6 @@
         }
       ],
       "pulledBy": [
-        "Sith Fury (V)",
         "Mustafar: Vader's Castle",
         "Vaneé"
       ],
@@ -60489,7 +60452,10 @@
       ],
       "front": {
         "destiny": "2",
-        "gametext": "Deploy on table. Attempts to 'blow away' Alderaan are +5. If Alderaan has been 'blown away,' adds one [Light Side] icon at Death Star system and opponent's total battle destiny is -1. Once per game, may take Superlaser into hand from Reserve Deck; reshuffle. (Immune to Alter.)",
+        "errataDate": "2022-12-12",
+        "errataNotes": "Original also made opponent's total battle destiny -1 after Alderaan was blown away.",
+        "errataSymbol": "E1",
+        "gametext": "Deploy on table. Attempts to 'blow away' Alderaan are +5. If Alderaan has been 'blown away,' adds one [Light Side] icon at Death Star system. Once per game, may take Superlaser into hand from Reserve Deck; reshuffle. (Immune to Alter.)",
         "icons": [
           "Set 17"
         ],
@@ -60502,6 +60468,7 @@
       "gempId": "217_1",
       "id": 6953,
       "legacy": false,
+      "previousId": 20002,
       "printings": [
         {
           "set": "217"
@@ -60517,7 +60484,6 @@
       ],
       "rarity": "U",
       "rulings": [
-        "The opponent's total battle destiny -1 applies everywhere.",
         "Cannot pull Superlaser Mark II."
       ],
       "set": "217",
@@ -60526,17 +60492,15 @@
     {
       "front": {
         "deploy": "2",
-        "destiny": "½ or 5½",
-        "destinyValues": [
-          0.5,
-          5.5
-        ],
-        "errataVersion": "E1",
+        "destiny": "4½",
+        "errataDate": "2022-12-12",
+        "errataNotes": "E1 Text: Deploys -1 to same site as BB-8. Cancels game text of BB-8 and/or Rose at same site. During your move phase, may place in Used Pile; 'break cover' of all Undercover spies here (if any). Immune to Restraining Bolt and Sorry About The Mess.",
+        "errataSymbol": "E2",
         "extraText": [
           "Astromech Droid"
         ],
         "forfeit": "4",
-        "gametext": "Deploys -1 to same site as BB-8. Cancels game text of BB-8 and/or Rose at same site. During your move phase, may place in Used Pile; 'break cover' of all Undercover spies here (if any). Immune to Restraining Bolt and Sorry About The Mess.",
+        "gametext": "If with a First Order leader at a battleground site, Force drain +1 here. During your move phase, may place in Used Pile; 'break cover' of all Undercover spies here (if any). Nabrun Leids may not transport cards to or from here. Immune to Restraining Bolt.",
         "icons": [
           "Nav Computer",
           "Episode VII",
@@ -60553,6 +60517,7 @@
       "gempId": "217_2",
       "id": 6954,
       "legacy": false,
+      "previousId": 20003,
       "printings": [
         {
           "set": "217"
@@ -60560,11 +60525,7 @@
       ],
       "rarity": "C2",
       "rulings": [
-        "BB-9E cannot cancel game text if BB-9E is at a system or sector.",
-        "BB-9E does not cancel the game text of captives.",
-        "BB-9E automatically cancels game text whenever applicable (it is not optional).",
-        "BB-9E may be placed in Used Pile even if there are no Undercover spies there.",
-        "'Immune to Sorry About The Mess' prevents the control phase firing function and prevents the place in Lost Pile function of the combo card. It does not prevent the 3 being added to weapon destiny function of the combo card."
+        "BB-9E may be placed in Used Pile even if there are no Undercover spies there."
       ],
       "set": "217",
       "side": "Dark"
@@ -61464,7 +61425,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on table. If Revenge Of The Sith on table, your Sidious may be targeted by Force Lightning and Lord Sidious may use his game text as if alone. Once per game, if Sidious with a Dark Jedi, may retrieve a character into hand. [Immune to Alter.]",
         "icons": [
           "Episode I",
@@ -61697,7 +61658,10 @@
       ],
       "front": {
         "destiny": "5",
-        "gametext": "For remainder of turn, opponent's Force retrieval using Resistance characters' game text is canceled. OR For remainder of turn, opponent may not cancel your battle destiny draws. OR Search opponent's Lost Pile; place one device you find there out of play. OR Cancel It Could Be Worse. OR Cancel Projection Of A Skywalker at an opponent's planet site.",
+        "errataDate": "2022-12-12",
+        "errataNotes": "Original Text: For remainder of turn, opponent's Force retrieval using Resistance characters' game text is canceled. OR For remainder of turn, opponent may not cancel your battle destiny draws. OR Search opponent's Lost Pile; place one device you find there out of play. OR Cancel It Could Be Worse. OR Cancel Projection Of A Skywalker at an opponent's planet site.",
+        "errataSymbol": "E1",
+        "gametext": "For remainder of turn, opponent may not cancel your battle destiny draws or character weapon destiny draws. OR If you have two battlegrounds on table (and opponent does not), for remainder of turn, your total power in battles is +1 for each opponent’s non-battleground location on table. OR Cancel It Could Be Worse or Nabrun Leids. OR If opponent does not occupy a battleground site (or if Menace Fades on table), cancel Projection Of A Skywalker.",
         "icons": [
           "Set 18"
         ],
@@ -61710,6 +61674,7 @@
       "gempId": "218_7",
       "id": 7047,
       "legacy": false,
+      "previousId": 20000,
       "printings": [
         {
           "set": "218"
@@ -61717,8 +61682,10 @@
       ],
       "rarity": "C1",
       "rulings": [
-        "First function: Rey, All Of The Jedi may perform her action that places a card out of play. Only the retrieval is canceled.",
-        "Second function: The number of battle destiny draws may still be limited."
+        "First function: The number of destiny draws may still be limited, and/or the draws may be prevented from being added.",
+        "Second function: Count the number of opponent's non-battlegrounds at the time the Interrupt was played. That is the power bonus for remainder of turn.",
+        "Third function: Plays after the opponent pays the cost (using Force for ICBW or Nabrun).",
+        "Fourth function: Targets and cancels a specific POAS on table (not both, if there are two copies on table)."
       ],
       "set": "218",
       "side": "Dark"
@@ -62031,7 +61998,7 @@
       ],
       "back": {
         "destiny": "7",
-        "gametext": "A Great Tactician Creates Plans: Deploy Lothal system, Advanced Projects Laboratory, Imperial Complex, and Thrawn’s Art Collection. For remainder of game, you may not deploy [Episode I] (or [Episode VII]) cards with ability or [Presence], or any admiral (except Thrawn). While this side up, Imperial Star Destroyers deploy -1 (-3 if Chimaera). Once per turn, may deploy a battleground system (or a site to Lothal) from Reserve Deck; reshuffle. Flip this card during any deploy phase if Thrawn at a battleground and two or more artwork cards on table. The Result Is Often Resentment: While this side up, if a battle was just initiated involving an Imperial leader or piloted TIE defender, may ‘study’ one artwork card. If it is a weapon, cancel the battle. Otherwise, if possible, if its printed destiny number is: (0-2) opponent’s immunity to attrition is canceled; (3-4) opponent excludes their character from battle; (5+) add 3 to your total power. Place artwork card in owner's Lost Pile. Flip this card if Thrawn not on table or (except during battle) if no artwork cards on table.",
+        "gametext": "A Great Tactician Creates Plans: Deploy Lothal system, Advanced Projects Laboratory, Imperial Complex, and Thrawn’s Art Collection. For remainder of game, you may not deploy Chiraneau or [Episode I] (or [Episode VII]) cards with ability or [Presence]. Once per turn, may deploy a battleground system (or a site to Lothal) from Reserve Deck; reshuffle. While this side up, Imperial Star Destroyers deploy -1 (-3 if Chimaera). Flip this card during any deploy phase if Thrawn at a battleground and two artwork cards on table. The Result Is Often Resentment: While this side up, if a battle was just initiated involving an Imperial leader or piloted TIE defender, may ‘study’ one artwork card. If it is a weapon, cancel the battle. Otherwise, if possible, if its printed destiny number is: (0-2) opponent’s immunity to attrition is canceled; (3-4) opponent excludes their character from battle; (5+) add 3 to your total power. Place artwork card in owner's Lost Pile. Flip this card if Thrawn not on table or (except during battle) if no artwork cards on table.",
         "icons": [
           "Set 19"
         ],
@@ -62041,7 +62008,10 @@
       },
       "front": {
         "destiny": "0",
-        "gametext": "A Great Tactician Creates Plans: Deploy Lothal system, Advanced Projects Laboratory, Imperial Complex, and Thrawn’s Art Collection. For remainder of game, you may not deploy [Episode I] (or [Episode VII]) cards with ability or [Presence], or any admiral (except Thrawn). While this side up, Imperial Star Destroyers deploy -1 (-3 if Chimaera). Once per turn, may deploy a battleground system (or a site to Lothal) from Reserve Deck; reshuffle. Flip this card during any deploy phase if Thrawn at a battleground and two or more artwork cards on table. The Result Is Often Resentment: While this side up, if a battle was just initiated involving an Imperial leader or piloted TIE defender, may ‘study’ one artwork card. If it is a weapon, cancel the battle. Otherwise, if possible, if its printed destiny number is: (0-2) opponent’s immunity to attrition is canceled; (3-4) opponent excludes their character from battle; (5+) add 3 to your total power. Place artwork card in owner's Lost Pile. Flip this card if Thrawn not on table or (except during battle) if no artwork cards on table.",
+        "errataDate": "2022-12-12",
+        "errataNotes": "Original could not deploy any admirals except Thrawn, and pulling sites/systems was only while on the 0-side.",
+        "errataSymbol": "E1",
+        "gametext": "A Great Tactician Creates Plans: Deploy Lothal system, Advanced Projects Laboratory, Imperial Complex, and Thrawn’s Art Collection. For remainder of game, you may not deploy Chiraneau or [Episode I] (or [Episode VII]) cards with ability or [Presence]. Once per turn, may deploy a battleground system (or a site to Lothal) from Reserve Deck; reshuffle. While this side up, Imperial Star Destroyers deploy -1 (-3 if Chimaera). Flip this card during any deploy phase if Thrawn at a battleground and two artwork cards on table. The Result Is Often Resentment: While this side up, if a battle was just initiated involving an Imperial leader or piloted TIE defender, may ‘study’ one artwork card. If it is a weapon, cancel the battle. Otherwise, if possible, if its printed destiny number is: (0-2) opponent’s immunity to attrition is canceled; (3-4) opponent excludes their character from battle; (5+) add 3 to your total power. Place artwork card in owner's Lost Pile. Flip this card if Thrawn not on table or (except during battle) if no artwork cards on table.",
         "icons": [
           "Set 19"
         ],
@@ -62052,6 +62022,7 @@
       "gempId": "219_1",
       "id": 7073,
       "legacy": false,
+      "previousId": 20001,
       "printings": [
         {
           "set": "219"
@@ -62364,13 +62335,16 @@
       "front": {
         "darkSideIcons": 2,
         "destiny": "0",
-        "gametext": "Dark: While you control, at related battleground sites you control with an Imperial leader, your Force drains are +1. Light: If Ghost and Phantom piloted here, Force drain +1 here. If no Rebel starships piloted here, Force drain -1 here.",
+        "errataDate": "2022-12-12",
+        "errataNotes": "Original was a 2/1 system instead of 2/0. Original Text: Dark: While you control, at related battleground sites you control with an Imperial leader, your Force drains are +1. Light: If Ghost and Phantom piloted here, Force drain +1 here. If no Rebel starships piloted here, Force drain -1 here.",
+        "errataSymbol": "E1",
+        "gametext": "Dark: While you occupy with an admiral, gains one [Dark Side] icon. Light: While you control, opponent occupies with an admiral, or Lothal converted, gains one [Light Side] icon.",
         "icons": [
           "Planet",
           "Set 19"
         ],
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual19-Dark/large/lothal.gif",
-        "lightSideIcons": 1,
+        "lightSideIcons": 0,
         "parsec": "6",
         "subType": "System",
         "title": "•Lothal",
@@ -62380,12 +62354,17 @@
       "gempId": "219_10",
       "id": 7082,
       "legacy": false,
+      "previousId": 20006,
       "printings": [
         {
           "set": "219"
         }
       ],
       "rarity": "U2",
+      "rulings": [
+        "Only follow the 'While Lothal converted' text of the topmost (active) Lothal system card.  It is applicable if there exists one (or more) converted copies of Lothal underneath.",
+        "Disregard the text of the copies of Lothal underneath."
+      ],
       "set": "219",
       "side": "Dark"
     },
@@ -62396,7 +62375,10 @@
       "front": {
         "darkSideIcons": 1,
         "destiny": "0",
-        "gametext": "Dark: Once per game, may deploy TIE Defender Project or Thrawn here from Reserve Deck; reshuffle. Light: If you control with a Rebel, Force drain +1 here.",
+        "errataDate": "2022-12-12",
+        "errataNotes": "Original Dark Text could not pull Pryce. Original Light Text: Opponent may not reduce or cancel your Force drains here.",
+        "errataSymbol": "E1",
+        "gametext": "Dark: Once per game, may deploy TIE Defender Project, Pryce, or Thrawn here from Reserve Deck; reshuffle. Light: Opponent may not reduce or cancel your Force drains here.",
         "icons": [
           "Exterior",
           "Planet",
@@ -62413,6 +62395,7 @@
       "gempId": "219_11",
       "id": 7083,
       "legacy": false,
+      "previousId": 20007,
       "printings": [
         {
           "set": "219"
@@ -63057,6 +63040,546 @@
       ],
       "rarity": "PM",
       "set": "207",
+      "side": "Dark"
+    },
+    {
+      "abbr": [
+        "BFHTTP"
+      ],
+      "front": {
+        "ability": "1",
+        "characteristics": [
+          "gangster",
+          "leader",
+          "Twi'lek"
+        ],
+        "deploy": "4",
+        "destiny": "1",
+        "forfeit": "3",
+        "gametext": "Jabba's game text is canceled. While with two aliens, adds one destiny to attrition. While at Audience Chamber, your Force drains at other Tatooine battlegrounds are +1 and, if opponent just deployed a character here, may activate 1 Force.",
+        "icons": [
+          "Set 20"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual20-Dark/large/bibfortunaheirtothepalace.gif",
+        "lore": "Twi'lek gangster. Leader. Plotted to kill Jabba.",
+        "power": "2",
+        "subType": "Alien",
+        "title": "•Bib Fortuna, Heir To The Palace",
+        "type": "Character",
+        "uniqueness": "*"
+      },
+      "gempId": "220_1",
+      "id": 7123,
+      "legacy": false,
+      "printings": [
+        {
+          "set": "220"
+        }
+      ],
+      "rarity": "U",
+      "rulings": [
+        "The 'two aliens' can be both Dark, both Light, or one of each. Bib does not count as one of the aliens.",
+        "The phrase 'may activate 1 Force' means Dark may activate, not the opponent."
+      ],
+      "set": "220",
+      "side": "Dark"
+    },
+    {
+      "front": {
+        "destiny": "0",
+        "gametext": "Plays on table. At end of a turn, if opponent has 15 or more cards in hand, may use 2 Force to shuffle all but 9 (random selection) into Used Pile. If Grimtaash or Thrown Back just targeted your hand, may reveal 2 cards from hand; they cannot be removed or checked for duplicates.",
+        "icons": [
+          "Episode I",
+          "Set D"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual20-Dark/large/drop.gif",
+        "lore": "Anakin had to heed Qui-Gon's advice to avoid the rapidly approaching storm.",
+        "title": "•Drop! (V)",
+        "type": "Defensive Shield",
+        "uniqueness": "*"
+      },
+      "gempId": "220_2",
+      "id": 7124,
+      "legacy": false,
+      "printings": [
+        {
+          "set": "220"
+        }
+      ],
+      "rarity": "U",
+      "rulings": [
+        "A player may view cards that are being removed from their own hand.",
+        "When 2 cards are revealed to prevent them from being placed in Used Pile, the hand will still be reduced to the size required by Grimtaash or Thrown Back.",
+        "If a player has 2 of the same card and reveals 1 to prevent it from being checked for duplicates, the other copy is not lost. If a player has 3 of the same card and reveals 2 of them, the other copy is not lost. If a player has 3 of the same card and reveals only 1 of them, the other 2 are duplicates of each other and are lost."
+      ],
+      "set": "220",
+      "side": "Dark"
+    },
+    {
+      "front": {
+        "darkSideIcons": 2,
+        "destiny": "0",
+        "gametext": "Dark: If you control, your total power is +1 at Ralltiir sites. Light: Your characters shuttle to and from here for free.",
+        "icons": [
+          "A New Hope",
+          "Planet",
+          "Set 20"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual20-Dark/large/ralltiir.gif",
+        "lightSideIcons": 0,
+        "parsec": "3",
+        "subType": "System",
+        "title": "•Ralltiir",
+        "type": "Location",
+        "uniqueness": "*"
+      },
+      "gempId": "220_3",
+      "id": 7125,
+      "legacy": false,
+      "printings": [
+        {
+          "set": "220"
+        }
+      ],
+      "rarity": "C1",
+      "set": "220",
+      "side": "Dark"
+    },
+    {
+      "abbr": [
+        "TS"
+      ],
+      "front": {
+        "ability": "4",
+        "characteristics": [
+          "female",
+          "Inquisitor"
+        ],
+        "deploy": "3",
+        "destiny": "3",
+        "extraText": [
+          "Force-Sensitive"
+        ],
+        "forfeit": "5",
+        "gametext": "Deploys +3 to your location. Obi-Wan is not a general. Once per turn, if opponent's card just moved from here, opponent loses 1 Force. Your characters here move (using landspeed) to sites opponent occupies for free. Immune to attrition < 4.",
+        "icons": [
+          "Pilot",
+          "Warrior",
+          "Set 20"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual20-Dark/large/thirdsister.gif",
+        "lore": "Female Inquisitor.",
+        "power": "4",
+        "subType": "Imperial",
+        "title": "•Third Sister",
+        "type": "Character",
+        "uniqueness": "*"
+      },
+      "gempId": "220_4",
+      "id": 7126,
+      "legacy": false,
+      "printings": [
+        {
+          "set": "220"
+        }
+      ],
+      "rarity": "U",
+      "rulings": [
+        "Third Sister only checks for movement of characters, vehicles, and starships.",
+        "Third Sister affects the Obi-Wan persona globally. This prevents Rebel Leadership (V) from taking General Kenobi into hand from Reserve Deck."
+      ],
+      "set": "220",
+      "side": "Dark"
+    },
+    {
+      "front": {
+        "ability": "4",
+        "characteristics": [
+          "Black Sun agent",
+          "bounty hunter",
+          "Gand",
+          "scout"
+        ],
+        "deploy": "3",
+        "destiny": "1",
+        "extraText": [
+          "Force-Sensitive"
+        ],
+        "forfeit": "4",
+        "gametext": "Adds 2 to power of anything he pilots. Power and defense value +2 with 4-LOM. Once during battle, if opponent just drew weapon or battle destiny, may draw destiny; reset opponent's destiny number to your drawn destiny number. Immune to attrition < 3.",
+        "icons": [
+          "Dagobah",
+          "Pilot",
+          "Warrior",
+          "Set 20"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual20-Dark/large/zuckuss.gif",
+        "lore": "Male Gand. Practitioner of ancient religious findsman vocation. Bounty hunter and scout. Gains surprisingly accurate information through mystical visions during meditation.",
+        "power": "3",
+        "subType": "Alien",
+        "title": "•Zuckuss (V)",
+        "type": "Character",
+        "uniqueness": "*"
+      },
+      "gempId": "220_5",
+      "id": 7127,
+      "legacy": false,
+      "matching": [
+        "Mist Hunter"
+      ],
+      "matchingWeapon": [
+        "Zuckuss' Snare Rifle"
+      ],
+      "printings": [
+        {
+          "set": "220"
+        }
+      ],
+      "rarity": "R",
+      "set": "220",
+      "side": "Dark"
+    },
+    {
+      "combo": [
+        "4-LOM With Concussion Rifle + Boba Fett, Bounty Hunter Two battle destinies."
+      ],
+      "front": {
+        "armor": "3",
+        "characteristics": [
+          "Black Sun agent",
+          "bounty hunter",
+          "information broker",
+          "thief"
+        ],
+        "deploy": "3",
+        "destiny": "3",
+        "extraText": [
+          "Protocol Droid"
+        ],
+        "forfeit": "3",
+        "gametext": "Permanent weapon is •4-LOM's Concussion Rifle (may target a character for free; target is power -1 until end of turn).  Once per turn, may place a card from hand on bottom of Used Pile to draw top card from Reserve Deck.",
+        "icons": [
+          "Warrior",
+          "Permanent weapon",
+          "Premium",
+          "Set 0"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/VirtualAlternateImage-Dark/large/4lomwithconcussionrifle_ai.gif",
+        "lore": "Accomplished thief and information broker. Modified by Jabba to be an effective bounty hunter. The Hutt often teams 4-LOM with other hired killers.",
+        "power": "2",
+        "subType": "Droid",
+        "title": "•4-LOM With Concussion Rifle (V) (AI)",
+        "type": "Character",
+        "uniqueness": "*"
+      },
+      "gempId": "200_71",
+      "id": 7133,
+      "legacy": false,
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
+      "pulledBy": [
+        "Double Back",
+        "Double Back (V)"
+      ],
+      "rarity": "PM",
+      "rulings": [
+        "This weapon is not a blaster."
+      ],
+      "set": "200",
+      "side": "Dark"
+    },
+    {
+      "front": {
+        "armor": "5",
+        "characteristics": [
+          "battle droid",
+          "Trade Federation"
+        ],
+        "deploy": "4",
+        "destiny": "2",
+        "extraText": [
+          "Battle Droid"
+        ],
+        "forfeit": "4",
+        "gametext": "Draws one battle destiny if unable to otherwise. Attrition against opponent is +1 here.",
+        "icons": [
+          "Presence",
+          "Separatist",
+          "Episode I",
+          "Set 4"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/VirtualAlternateImage-Dark/large/b2battledroid_ai.gif",
+        "lore": "Blank.",
+        "power": "4",
+        "subType": "Droid",
+        "title": "•••B2 Battle Droid (AI)",
+        "type": "Character",
+        "uniqueness": "***"
+      },
+      "gempId": "204_36",
+      "id": 7134,
+      "legacy": false,
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
+      "pulledBy": [
+        "Naboo: Theed Palace Hallway",
+        "There They Are!"
+      ],
+      "rarity": "C2",
+      "set": "204",
+      "side": "Dark"
+    },
+    {
+      "cancels": [
+        "A (non-Immune to Sense) Interrupt (during battle)"
+      ],
+      "front": {
+        "armor": "5",
+        "characteristics": [
+          "Imperial (starship)",
+          "ship-docking capability"
+        ],
+        "deploy": "8",
+        "destiny": "1",
+        "forfeit": "8",
+        "gametext": "May add 6 pilots, 8 passengers, 2 vehicles, and 4 TIEs. Permanent pilot provides ability of 2. During battle, may lose 1 Force to cancel a non-[Immune to Sense] Interrupt.",
+        "hyperspeed": "3",
+        "icons": [
+          "Pilot",
+          "Nav Computer",
+          "Scomp Link",
+          "A New Hope",
+          "Set 0"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/VirtualAlternateImage-Dark/large/conquest_ai.gif",
+        "lore": "One of the Imperial cruisers that chased the Millennium Falcon from Tatooine. It scanned the Falcon just before Han punched his starship to lightspeed.",
+        "power": "8",
+        "subType": "Capital: Imperial-Class Star Destroyer",
+        "title": "•Conquest (V) (AI)",
+        "type": "Starship",
+        "uniqueness": "*"
+      },
+      "gempId": "200_133",
+      "id": 7135,
+      "legacy": false,
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
+      "pulledBy": [
+        "Commander Nemet (V)",
+        "Kuat Drive Yards"
+      ],
+      "rarity": "R1",
+      "rulings": [
+        "May only cancel one Interrupt per battle.",
+        "Only check if the currently played Interrupt function is immune to Sense. If not, it may be canceled."
+      ],
+      "set": "200",
+      "side": "Dark"
+    },
+    {
+      "front": {
+        "ability": "7",
+        "characteristics": [
+          "leader",
+          "Trade Federation"
+        ],
+        "deploy": "6",
+        "destiny": "1",
+        "extraText": [
+          "Dark Jedi Master"
+        ],
+        "forfeit": "8",
+        "gametext": "Deploys -1 if Sidious (or Insidious Prisoner) on table. Power +1 for each Jedi here. May be targeted by Force Lightning. Once per game, if opponent just initiated battle here, may take Force Lightning or Force Push into hand from Reserve Deck; reshuffle. Immune to attrition < 6 (< 8 if with a Jedi).",
+        "icons": [
+          "Warrior",
+          "Pilot",
+          "Separatist",
+          "Episode I",
+          "Set 0"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/VirtualAlternateImage-Dark/large/countdooku_ai.gif",
+        "lore": "Serrennoian leader. Trade Federation.",
+        "power": "5",
+        "subType": "Dark Jedi Master",
+        "title": "•Count Dooku (AI)",
+        "type": "Character",
+        "uniqueness": "*"
+      },
+      "gempId": "200_76",
+      "id": 7136,
+      "legacy": false,
+      "matchingWeapon": [
+        "Dooku's Lightsaber"
+      ],
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
+      "pulledBy": [
+        "Always Two There Are"
+      ],
+      "pulls": [
+        "Force Lightning or Force Push"
+      ],
+      "rarity": "C",
+      "rulings": [
+        "When using this text, treat all instances of the word 'Emperor' on Force Lightning as 'Dooku' instead."
+      ],
+      "set": "200",
+      "side": "Dark"
+    },
+    {
+      "cancels": [
+        "Amidala's game text"
+      ],
+      "combo": [
+        "Darth Maul, Lone Hunter + Maul Strikes",
+        "Darth Maul, Lone Hunter + The Phantom Menace While present with an opponent's Jedi, Maul is defense value +2 and immune to attrition.",
+        "Darth Maul, Lone Hunter + I Have You Now Add one battle destiny (two if Rebel is Luke) if a Dark Jedi and a Rebel with ability > 2 are involved in the same battle.",
+        "Darth Maul, Lone Hunter + Force Field Cancels an attempt to target a Dark Jedi with a character weapon."
+      ],
+      "front": {
+        "ability": "6",
+        "characteristics": [
+          "Trade Federation"
+        ],
+        "deploy": "6",
+        "destiny": "1",
+        "errataSymbol": "E1",
+        "extraText": [
+          "Dark Jedi"
+        ],
+        "forfeit": "8",
+        "gametext": "If drawn for destiny, may take into hand to cancel and redraw that destiny. Cancels Blaster Deflection (and Amidala's game text) here. Maul's weapon destiny draws may not be modified or canceled by opponent. Immune to attrition < 5.",
+        "icons": [
+          "Pilot",
+          "Warrior",
+          "Episode I",
+          "Set 3"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/VirtualAlternateImage-Dark/large/darthmaullonehunter_ai.gif",
+        "lore": "Trade Federation.",
+        "power": "7",
+        "subType": "Sith",
+        "title": "•Darth Maul, Lone Hunter (AI)",
+        "type": "Character",
+        "uniqueness": "*"
+      },
+      "gempId": "203_26",
+      "id": 7137,
+      "legacy": false,
+      "matching": [
+        "Maul's Sith Infiltrator"
+      ],
+      "matchingWeapon": [
+        "Maul's Double-Bladed Lightsaber",
+        "Maul's Lightsaber"
+      ],
+      "printings": [
+        {
+          "set": "203"
+        }
+      ],
+      "rarity": "U",
+      "rulings": [
+        "Cancels game text of any version of the Amidala persona, including Padme."
+      ],
+      "set": "203",
+      "side": "Dark"
+    },
+    {
+      "front": {
+        "characteristics": [
+          "lightsaber"
+        ],
+        "destiny": "1",
+        "gametext": "Deploy on Dooku or a [Separatist] character of ability > 4. Adds 1 to this character's duel and lightsaber combat totals. May add 1 to Force drain where present. May target a character for free. Draw two destiny. Target hit, and its forfeit = 0, if total destiny > defense value.",
+        "icons": [
+          "Episode I",
+          "Set 0"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/VirtualAlternateImage-Dark/large/dookuslightsaber_ai.gif",
+        "lore": "Blank.",
+        "subType": "Character",
+        "title": "•Dooku's Lightsaber (AI)",
+        "type": "Weapon",
+        "uniqueness": "*"
+      },
+      "gempId": "200_142",
+      "id": 7138,
+      "legacy": false,
+      "matching": [
+        "Count Dooku"
+      ],
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
+      "pulledBy": [
+        "I Will Finish What You Started",
+        "Maul Strikes",
+        "Blaster Rack (V)",
+        "Evil Is Everywhere"
+      ],
+      "rarity": "U",
+      "set": "200",
+      "side": "Dark"
+    },
+    {
+      "front": {
+        "ability": "3",
+        "characteristics": [
+          "admiral",
+          "Harch",
+          "leader",
+          "commander",
+          "Trade Federation"
+        ],
+        "deploy": "3",
+        "destiny": "2",
+        "extraText": [
+          "Force-Attuned"
+        ],
+        "forfeit": "5",
+        "gametext": "Adds 2 to power of anything he pilots. Unless alone, may place Trench in Used Pile to make an [Episode I] starship here immune to attrition for remainder of turn. While at opponent's system, their starships deploy +1 here.",
+        "icons": [
+          "Pilot",
+          "Separatist",
+          "Episode I",
+          "Set 12"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/VirtualAlternateImage-Dark/large/admiraltrenchholo_ai.gif",
+        "lore": "Harch commander. Leader. Trade Federation.",
+        "power": "3",
+        "subType": "Republic",
+        "title": "•Admiral Trench (AI)",
+        "type": "Character",
+        "uniqueness": "*"
+      },
+      "gempId": "212_5",
+      "id": 7148,
+      "legacy": false,
+      "printings": [
+        {
+          "set": "212"
+        }
+      ],
+      "pulledBy": [
+        "Imperial Command"
+      ],
+      "rarity": "C2",
+      "set": "212",
       "side": "Dark"
     }
   ]

--- a/DarkPreErrata.json
+++ b/DarkPreErrata.json
@@ -1,0 +1,559 @@
+{
+  "cards": [
+    {
+      "abbr": [
+        "ADTFTR&TO",
+        "A Dark Time combo"
+      ],
+      "cancels": [
+        "It Could Be Worse",
+        "Projection Of A Skywalker (sometimes)",
+        "Force retrieval from General Leia Organa, Rey With Lightsaber, Rey All Of The Jedi, and Rose Tico."
+      ],
+      "front": {
+        "destiny": "5",
+        "gametext": "For remainder of turn, opponent's Force retrieval using Resistance characters' game text is canceled. OR For remainder of turn, opponent may not cancel your battle destiny draws. OR Search opponent's Lost Pile; place one device you find there out of play. OR Cancel It Could Be Worse. OR Cancel Projection Of A Skywalker at an opponent's planet site.",
+        "icons": [
+          "Set 18"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual18-Dark/large/adarktimefortherebelliontarkinsorders.gif",
+        "subType": "Used",
+        "title": "•A Dark Time For The Rebellion & •Tarkin's Orders",
+        "type": "Interrupt",
+        "uniqueness": "*"
+      },
+      "gempId": "218_7",
+      "id": 20000,
+      "legacy": false,
+      "nextId": 7047,
+      "printings": [
+        {
+          "set": "218"
+        }
+      ],
+      "rarity": "C1",
+      "rulings": [
+        "First function: Rey, All Of The Jedi may perform her action that places a card out of play. Only the retrieval is canceled.",
+        "Second function: The number of battle destiny draws may still be limited."
+      ],
+      "set": "218",
+      "side": "Dark"
+    },
+    {
+      "abbr": [
+        "AGTCP/TRIOR",
+        "Thrawn"
+      ],
+      "back": {
+        "destiny": "7",
+        "gametext": "A Great Tactician Creates Plans: Deploy Lothal system, Advanced Projects Laboratory, Imperial Complex, and Thrawn’s Art Collection. For remainder of game, you may not deploy [Episode I] (or [Episode VII]) cards with ability or [Presence], or any admiral (except Thrawn). While this side up, Imperial Star Destroyers deploy -1 (-3 if Chimaera). Once per turn, may deploy a battleground system (or a site to Lothal) from Reserve Deck; reshuffle. Flip this card during any deploy phase if Thrawn at a battleground and two or more artwork cards on table. The Result Is Often Resentment: While this side up, if a battle was just initiated involving an Imperial leader or piloted TIE defender, may ‘study’ one artwork card. If it is a weapon, cancel the battle. Otherwise, if possible, if its printed destiny number is: (0-2) opponent’s immunity to attrition is canceled; (3-4) opponent excludes their character from battle; (5+) add 3 to your total power. Place artwork card in owner's Lost Pile. Flip this card if Thrawn not on table or (except during battle) if no artwork cards on table.",
+        "icons": [
+          "Set 19"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual19-Dark/large/theresultisoftenresentment.gif",
+        "title": "A Great Tactician Creates Plans / The Result Is Often Resentment",
+        "type": "Objective"
+      },
+      "front": {
+        "destiny": "0",
+        "gametext": "A Great Tactician Creates Plans: Deploy Lothal system, Advanced Projects Laboratory, Imperial Complex, and Thrawn’s Art Collection. For remainder of game, you may not deploy [Episode I] (or [Episode VII]) cards with ability or [Presence], or any admiral (except Thrawn). While this side up, Imperial Star Destroyers deploy -1 (-3 if Chimaera). Once per turn, may deploy a battleground system (or a site to Lothal) from Reserve Deck; reshuffle. Flip this card during any deploy phase if Thrawn at a battleground and two or more artwork cards on table. The Result Is Often Resentment: While this side up, if a battle was just initiated involving an Imperial leader or piloted TIE defender, may ‘study’ one artwork card. If it is a weapon, cancel the battle. Otherwise, if possible, if its printed destiny number is: (0-2) opponent’s immunity to attrition is canceled; (3-4) opponent excludes their character from battle; (5+) add 3 to your total power. Place artwork card in owner's Lost Pile. Flip this card if Thrawn not on table or (except during battle) if no artwork cards on table.",
+        "icons": [
+          "Set 19"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual19-Dark/large/agreattacticiancreatesplans.gif",
+        "title": "A Great Tactician Creates Plans / The Result Is Often Resentment",
+        "type": "Objective"
+      },
+      "gempId": "219_1",
+      "id": 20001,
+      "legacy": false,
+      "nextId": 7073,
+      "printings": [
+        {
+          "set": "219"
+        }
+      ],
+      "rarity": "U",
+      "rulings": [
+        "(Both sides) This Objective must flip as an automatic action as soon as the flip conditions are met.",
+        "(0-side) 'Flip this card during any deploy phase' means it will flip during either player's deploy phase.",
+        "(0-side) 'Imperial Star Destroyers' refers to Imperial affiliation (not First Order, Rebel, Independent, etc).  It does not refer to Imperial-class. Thus Dominator and Executor are deploy -1.",
+        "(7-side) After studying an artwork card, place it in Lost Pile even if it was not possible to perform the specified action (e.g., even if there was no character to exclude from battle or no immunity to attrition to cancel).",
+        "(7-side) For a multi-destiny artwork card such as R2-D2, the destiny value is chosen by the card owner (typically Light) <u>after</u> Dark chooses it to be studied."
+      ],
+      "set": "219",
+      "side": "Dark"
+    },
+    {
+      "abbr": [
+        "AED"
+      ],
+      "front": {
+        "destiny": "2",
+        "gametext": "Deploy on table. Attempts to 'blow away' Alderaan are +5. If Alderaan has been 'blown away,' adds one [Light Side] icon at Death Star system and opponent's total battle destiny is -1. Once per game, may take Superlaser into hand from Reserve Deck; reshuffle. (Immune to Alter.)",
+        "icons": [
+          "Set 17"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual17-Dark/large/aneffectivedemonstration.gif",
+        "lore": "Blank.",
+        "title": "•An Effective Demonstration",
+        "type": "Effect",
+        "uniqueness": "*"
+      },
+      "gempId": "217_1",
+      "id": 20002,
+      "legacy": false,
+      "nextId": 6953,
+      "printings": [
+        {
+          "set": "217"
+        }
+      ],
+      "pulledBy": [
+        "Twi'lek Advisor",
+        "We Must Accelerate Our Plans"
+      ],
+      "pulls": [
+        "Superlaser",
+        "Superlaser (V)"
+      ],
+      "rarity": "U",
+      "rulings": [
+        "The opponent's total battle destiny -1 applies everywhere.",
+        "Cannot pull Superlaser Mark II."
+      ],
+      "set": "217",
+      "side": "Dark"
+    },
+    {
+      "front": {
+        "deploy": "2",
+        "destiny": "½ or 5½",
+        "destinyValues": [
+          0.5,
+          5.5
+        ],
+        "errataSymbol": "E1",
+        "extraText": [
+          "Astromech Droid"
+        ],
+        "forfeit": "4",
+        "gametext": "Deploys -1 to same site as BB-8. Cancels game text of BB-8 and/or Rose at same site. During your move phase, may place in Used Pile; 'break cover' of all Undercover spies here (if any). Immune to Restraining Bolt and Sorry About The Mess.",
+        "icons": [
+          "Nav Computer",
+          "Episode VII",
+          "Set 17"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual17-Dark/large/bb9e.gif",
+        "lore": "Blank.",
+        "power": "2",
+        "subType": "Droid",
+        "title": "•BB-9E",
+        "type": "Character",
+        "uniqueness": "*"
+      },
+      "gempId": "217_2",
+      "id": 20003,
+      "legacy": false,
+      "nextId": 6954,
+      "printings": [
+        {
+          "set": "217"
+        }
+      ],
+      "rarity": "C2",
+      "rulings": [
+        "BB-9E cannot cancel game text if BB-9E is at a system or sector.",
+        "BB-9E does not cancel the game text of captives.",
+        "BB-9E automatically cancels game text whenever applicable (it is not optional).",
+        "BB-9E may be placed in Used Pile even if there are no Undercover spies there.",
+        "'Immune to Sorry About The Mess' prevents the control phase firing function and prevents the place in Lost Pile function of the combo card. It does not prevent the 3 being added to weapon destiny function of the combo card."
+      ],
+      "set": "217",
+      "side": "Dark"
+    },
+    {
+      "front": {
+        "destiny": "5",
+        "gametext": "Deploy on table. Lost if your non-Imperial character (or starship) on table. Unless you occupy fewer locations than opponent: if you win a battle, retrieve an Imperial; and, during battle, may take an Imperial just drawn for destiny into hand to cancel and redraw that destiny. [Immune to Alter.]",
+        "icons": [
+          "Set 1"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual1-Dark/large/imperialenforcement.gif",
+        "lore": "When Vader's forces impose the New Order upon a region, Rebel resources and lifelines are quickly eliminated.",
+        "title": "•Imperial Enforcement",
+        "type": "Effect",
+        "uniqueness": "*"
+      },
+      "gempId": "201_30",
+      "id": 20004,
+      "legacy": false,
+      "nextId": 1271,
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
+      "pulledBy": [
+        "Twi'lek Advisor",
+        "We Must Accelerate Our Plans"
+      ],
+      "rarity": "U1",
+      "rulings": [
+        "Mara Jade, The Emperor's Hand (for example) does not make this Effect lost.",
+        "Imperial starships (Dark starships with no allegiance icon such as Independent, Republic, etc) do not make this Effect lost.",
+        "<u>Both</u> of the bonuses (Dark retrieving an Imperial, and Dark taking a just drawn Imperial into hand) require Dark to occupy at least as many locations as opponent."
+      ],
+      "set": "201",
+      "side": "Dark"
+    },
+    {
+      "front": {
+        "destiny": "4",
+        "gametext": "If Ralltiir Operations on table, deploy on table. Forfeit values are not modified by Do They Have A Code Clearance?. Once per battle, when you draw battle destiny, may exchange a card in hand with a card of same card type in Lost Pile. [Immune to Alter.]",
+        "icons": [
+          "Death Star II",
+          "Set 10"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Dark/large/insignificantrebellion.gif",
+        "lore": "'Your fleet is lost. And your friends on the Endor moon will not survive. There is no escape, my young apprentice.'",
+        "title": "•Insignificant Rebellion (V)",
+        "type": "Effect",
+        "uniqueness": "*"
+      },
+      "gempId": "210_47",
+      "id": 20005,
+      "legacy": false,
+      "nextId": 6788,
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
+      "pulledBy": [
+        "Moment Of Triumph (V)"
+      ],
+      "rarity": "U",
+      "set": "210",
+      "side": "Dark"
+    },
+    {
+      "front": {
+        "darkSideIcons": 2,
+        "destiny": "0",
+        "gametext": "Dark: While you control, at related battleground sites you control with an Imperial leader, your Force drains are +1. Light: If Ghost and Phantom piloted here, Force drain +1 here. If no Rebel starships piloted here, Force drain -1 here.",
+        "icons": [
+          "Planet",
+          "Set 19"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual19-Dark/large/lothal.gif",
+        "lightSideIcons": 1,
+        "parsec": "6",
+        "subType": "System",
+        "title": "•Lothal",
+        "type": "Location",
+        "uniqueness": "*"
+      },
+      "gempId": "219_10",
+      "id": 20006,
+      "legacy": false,
+      "nextId": 7082,
+      "printings": [
+        {
+          "set": "219"
+        }
+      ],
+      "rarity": "U2",
+      "set": "219",
+      "side": "Dark"
+    },
+    {
+      "abbr": [
+        "LAPL"
+      ],
+      "front": {
+        "darkSideIcons": 1,
+        "destiny": "0",
+        "gametext": "Dark: Once per game, may deploy TIE Defender Project or Thrawn here from Reserve Deck; reshuffle. Light: If you control with a Rebel, Force drain +1 here.",
+        "icons": [
+          "Exterior",
+          "Planet",
+          "Scomp Link",
+          "Set 19"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual19-Dark/large/lothaladvancedprojectslaboratory.gif",
+        "lightSideIcons": 1,
+        "subType": "Site",
+        "title": "•Lothal: Advanced Projects Laboratory",
+        "type": "Location",
+        "uniqueness": "*"
+      },
+      "gempId": "219_11",
+      "id": 20007,
+      "legacy": false,
+      "nextId": 7083,
+      "printings": [
+        {
+          "set": "219"
+        }
+      ],
+      "rarity": "U",
+      "set": "219",
+      "side": "Dark"
+    },
+    {
+      "front": {
+        "ability": "6",
+        "characteristics": [
+          "Crimson Dawn",
+          "leader",
+          "gangster"
+        ],
+        "deploy": "4",
+        "destiny": "½",
+        "destinyValues": [
+          0.5
+        ],
+        "extraText": [
+          "Dark Jedi"
+        ],
+        "forfeit": "8",
+        "gametext": "Never deploys to a battleground. Opponent may not cancel your destiny draws. Once per turn, may add 1 to a just drawn battle or weapon destiny. Once per turn, may subtract 1 from a just drawn battle or weapon destiny. Immune to attrition < 5.",
+        "icons": [
+          "Warrior",
+          "Set 13"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual13-Dark/large/maul.gif",
+        "lore": "Crimson Dawn leader. Gangster.",
+        "power": "4",
+        "subType": "Sith",
+        "title": "•Maul",
+        "type": "Character",
+        "uniqueness": "*"
+      },
+      "gempId": "213_10",
+      "id": 20008,
+      "legacy": false,
+      "nextId": 6800,
+      "printings": [
+        {
+          "set": "213"
+        }
+      ],
+      "rarity": "C",
+      "rulings": [
+        "Does not need to be at the battle location to add or subtract 1 from a just drawn destiny.",
+        "However, if Maul does happen to be at the battle location, then he must be participating in the battle (not excluded) in order to add or subtract 1."
+      ],
+      "set": "213",
+      "side": "Dark"
+    },
+    {
+      "abbr": [
+        "PER"
+      ],
+      "front": {
+        "ability": "7",
+        "characteristics": [
+          "Leader",
+          "Dark Jedi Master"
+        ],
+        "deploy": "4",
+        "destiny": "4",
+        "forfeit": "9",
+        "gametext": "Never deploys or moves (even if carried) to a location with a [Light Side] icon. Once per turn, may draw bottom card of your Force Pile. Once per game, if about to be lost, may take him into hand. Immune to attrition.",
+        "icons": [
+          "Episode VII",
+          "Set 14"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual14-Dark/large/palpatineemperorreturned.gif",
+        "lore": "Leader.",
+        "power": "2",
+        "subType": "Dark Jedi Master/First Order",
+        "title": "•Palpatine, Emperor Returned",
+        "type": "Character",
+        "uniqueness": "*"
+      },
+      "gempId": "214_8",
+      "id": 20009,
+      "legacy": false,
+      "nextId": 6851,  
+      "printings": [
+        {
+          "set": "214"
+        }
+      ],
+      "rarity": "U1",
+      "rulings": [
+        "This card qualifies as Emperor, as Palpatine, and as Sidious.",
+        "If his game text is canceled, the text cannot be used to take him into hand when about to be lost.",
+        "If he is hit during battle and then excluded from the battle (e.g. by Clash Of Sabers) he is inactive and so cannot use his text to be taken into hand. He is immediately lost due to being hit while outside of a battle.",
+        "A Light Side Force icon could be added to the same location as Palpatine, Emperor Returned (e.g. due to Presence Of The Force). This does not violate Palpatine's text or cause him to be removed from table."
+      ],
+      "set": "214",
+      "side": "Dark"
+    },
+    {
+      "abbr": [
+        "RO/ITHOTEV",
+        "ROPSV"
+      ],
+      "back": {
+        "destiny": "7",
+        "errataSymbol": "E1",
+        "gametext": "Ralltiir Operations:Deploy Ralltiir system.{For} remainder of game, spaceport sites are immune to Always Thinking With Your Stomach, He Hasn't Come Back Yet, and Ounee Ta. Your Force generation is +1 at each Ralltiir location. {While} this side up, once per turn, may deploy a site (or non-unique Imperial) to Ralltiir from Reserve Deck; reshuffle.{Flip} this card if Imperials control at least three Ralltiir sites and opponent controls no Ralltiir locations.In The Hands Of The Empire:{While} this side up, opponent's Force drains are -1 at their locations. Your total battle destiny is +X, where X = number of Ralltiir locations your Imperials occupy. {Flip} this card if opponent controls at least two Ralltiir locations.",
+        "icons": [
+          "Set 10"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Dark/large/inthehandsoftheempire.gif",
+        "title": "Ralltiir Operations / In The Hands Of The Empire (V)",
+        "type": "Objective"
+      },
+      "front": {
+        "destiny": "0",
+        "errataSymbol": "E1",
+        "gametext": "Ralltiir Operations:Deploy Ralltiir system.{For} remainder of game, spaceport sites are immune to Always Thinking With Your Stomach, He Hasn't Come Back Yet, and Ounee Ta. Your Force generation is +1 at each Ralltiir location. {While} this side up, once per turn, may deploy a site (or non-unique Imperial) to Ralltiir from Reserve Deck; reshuffle.{Flip} this card if Imperials control at least three Ralltiir sites and opponent controls no Ralltiir locations.In The Hands Of The Empire:{While} this side up, opponent's Force drains are -1 at their locations. Your total battle destiny is +X, where X = number of Ralltiir locations your Imperials occupy. {Flip} this card if opponent controls at least two Ralltiir locations.",
+        "icons": [
+          "Set 10"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Dark/large/ralltiiroperations.gif",
+        "title": "Ralltiir Operations / In The Hands Of The Empire (V)",
+        "type": "Objective"
+      },
+      "gempId": "210_42",
+      "id": 20010,
+      "legacy": false,
+      "nextId": 6590,
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
+      "rarity": "R",
+      "set": "210",
+      "side": "Dark"
+    },
+    {
+      "front": {
+        "destiny": "3",
+        "gametext": "Deploy on table. Your droids are destiny +1. Once per turn, if you just drew a non-[Presence] droid for destiny, may take that droid into hand. Once per turn, may deploy Droid Workshop, Forced Servitude, Incinerator, or Wuher from Reserve Deck; reshuffle. (Immune to Alter.)",
+        "icons": [
+          "Set 10"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual10-Dark/large/silenceisgolden.gif",
+        "lore": "'Excuse me, sir, might I in--'",
+        "title": "Silence Is Golden (V)",
+        "type": "Effect"
+      },
+      "gempId": "210_45",
+      "id": 20011,
+      "legacy": false,
+      "nextId": 6642,
+      "printings": [
+        {
+          "set": "210"
+        }
+      ],
+      "pulls": [
+        "Cloud City: Incinerator",
+        "Forced Servitude",
+        "Jabba's Palace: Droid Workshop",
+        "Wuher"
+      ],
+      "rarity": "U2",
+      "set": "210",
+      "side": "Dark"
+    },
+    {
+      "counterpart": "Jedi Levitation (V)",
+      "front": {
+        "destiny": "4",
+        "errataSymbol": "E1",
+        "gametext": "USED: If you just drew a character for destiny, take that card into hand to cancel and redraw that destiny.  LOST: Once per game, exchange a Dark Jedi in hand with a Dark Jedi in Lost Pile.",
+        "icons": [
+          "Tatooine",
+          "Set 0"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Dark/large/sithfury.gif",
+        "lore": "At his peak, no one could stand up to the Dark Lord of the Sith. His superior tactics devastated those who opposed him.",
+        "subType": "Used Or Lost",
+        "title": "•Sith Fury (V)",
+        "type": "Interrupt",
+        "uniqueness": "*"
+      },
+      "gempId": "200_123",
+      "id": 20012,
+      "legacy": false,
+      "nextId": 4003,
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
+      "pulls": [
+        "Count Dooku",
+        "Darth Maul",
+        "Darth Maul With Lightsaber",
+        "Darth Maul, Lone Hunter",
+        "Darth Maul, Young Apprentice",
+        "Darth Sidious",
+        "Darth Vader",
+        "Darth Vader (V)",
+        "Darth Vader With Lightsaber",
+        "Darth Vader, Dark Lord Of The Sith",
+        "Darth Vader, Emperor's Enforcer",
+        "Emperor Palpatine",
+        "Emperor Palpatine, Foreseer",
+        "Lord Maul",
+        "Lord Maul With Lightsaber",
+        "Lord Sidious",
+        "Lord Vader",
+        "The Emperor",
+        "Vader"
+      ],
+      "rarity": "C",
+      "set": "200",
+      "side": "Dark"
+    },
+    {
+      "abbr": [
+        "TSOT/WTITJA",
+        "DS Demo Deck"
+      ],
+      "back": {
+        "destiny": "7",
+        "gametext": "Twin Suns Of Tatooine:Deploy Tatooine system and a non-Jabba's Palace Tatooine battleground site. {For} remainder of game, you may not deploy Jabba's Palace sites or Sandwhirl. {While} this side up, once per turn, may use 1 Force to deploy a Tatooine battleground site from Reserve Deck; reshuffle. {Flip} this card if you control two Tatooine battleground sites (at least one with a Dark Jedi) and occupy Tatooine system, and opponent controls no Tatooine sites.Well Trained In The Jedi Arts:{While} this side up, once per game, may deploy Tatooine Occupation from Reserve Deck; reshuffle. Once during your control phase, may peek at the top two cards of your Reserve Deck; take one into hand and shuffle Reserve Deck. For opponent to move a character or vehicle from same site as your Dark Jedi requires +1 Force. {Flip} this card if opponent controls more Tatooine sites than you.",
+        "icons": [
+          "Premium",
+          "Set P"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/DemoDeck-Dark/large/welltrainedinthejediarts.gif",
+        "title": "Twin Suns Of Tatooine / Well Trained In The Jedi Arts",
+        "type": "Objective"
+      },
+      "front": {
+        "destiny": "0",
+        "gametext": "Twin Suns Of Tatooine:Deploy Tatooine system and a non-Jabba's Palace Tatooine battleground site. {For} remainder of game, you may not deploy Jabba's Palace sites or Sandwhirl. {While} this side up, once per turn, may use 1 Force to deploy a Tatooine battleground site from Reserve Deck; reshuffle. {Flip} this card if you control two Tatooine battleground sites (at least one with a Dark Jedi) and occupy Tatooine system, and opponent controls no Tatooine sites.Well Trained In The Jedi Arts:{While} this side up, once per game, may deploy Tatooine Occupation from Reserve Deck; reshuffle. Once during your control phase, may peek at the top two cards of your Reserve Deck; take one into hand and shuffle Reserve Deck. For opponent to move a character or vehicle from same site as your Dark Jedi requires +1 Force. {Flip} this card if opponent controls more Tatooine sites than you.",
+        "icons": [
+          "Premium",
+          "Set P"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/DemoDeck-Dark/large/twinsunsoftatooine.gif",
+        "title": "Twin Suns Of Tatooine / Well Trained In The Jedi Arts",
+        "type": "Objective"
+      },
+      "gempId": "301_4",
+      "id": 20013,
+      "legacy": false,
+      "nextId": 6716,
+      "printings": [
+        {
+          "set": "301"
+        }
+      ],
+      "rarity": "R",
+      "set": "301",
+      "side": "Dark"
+    }
+  ]
+}

--- a/Light.json
+++ b/Light.json
@@ -4,7 +4,7 @@
       "front": {
         "deploy": "2",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Medical Droid"
         ],
@@ -87,7 +87,7 @@
       "front": {
         "deploy": "1",
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Maintenance Droid"
         ],
@@ -122,7 +122,7 @@
     {
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If Jakku on table, deploy on table. Your Force generation is +1 at Jakku battlegrounds you occupy. During your deploy phase, may place a Resistance character from hand on top of Used Pile to take a Resistance character of equal or lesser ability into hand from Reserve Deck; reshuffle. (Immune to Alter.)",
         "icons": [
           "Set 9"
@@ -369,7 +369,7 @@
       ],
       "front": {
         "destiny": "6",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If you just lost a duel opponent initiated (before duel has any result) lose 1 Force to cancel the duel and return Interrupt (if any) used to initiate duel to owner's hand. OR If you just lost a character armed with a lightsaber, take that character into hand.",
         "icons": [
           "Tatooine"
@@ -710,7 +710,7 @@
       "counterpart": "A Disturbance In The Force",
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Once per game, during your deploy phase, 'insert' (face down) into opponent's Reserve Deck; reshuffle. When effect reaches top it is immediately lost, but opponent may not activate any more Force that turn. (Immune to Alter.)",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/atremorintheforce.gif",
         "lore": "'Stand By...'",
@@ -893,7 +893,7 @@
         ],
         "deploy": "5",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Jedi Knight"
         ],
@@ -982,7 +982,7 @@
       "counterpart": "Restricted Access",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Insert face up in your Reserve Deck. When Effect reaches top it is lost, along with all opponent's 'insert' cards there. Reshuffle. (Immune to Alter.) OR Deploy between two mobile sites. Opponent's characters may pass only if aboard a Lift Tube or opponent uses +1 Force each.",
         "icons": [
           "Cloud City"
@@ -1279,7 +1279,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If an opponent's character of ability > 3 was just lost in a battle or duel you won, deploy on one of your warriors involved. Warrior is power +2. During each of opponent's move phases, opponent loses 1 Force (2 if character was a Dark Jedi). (Immune to Control.)",
         "icons": [
           "Cloud City"
@@ -1317,7 +1317,7 @@
       "counterpart": "I Find Your Lack Of Faith Disturbing",
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to deploy on one of your Jedi. Unless a Dark Jedi is also present, opponent's total ability at same location is reduced by 2.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/affectmind.gif",
         "lore": "'What was that?' The Jedi power known as 'affect mind' is often used to create minor distractions, allowing Jedi to elude enemies rather than engage them in battle.",
@@ -1388,7 +1388,7 @@
       },
       "front": {
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Agents In The Court:Deploy Hutt Trade Route and a Jabba's Palace site. May deploy Yarna d'al' Gargan. Reveal one unique (•) alien from your deck whose lore specifies its species. This card is your Rep.{For} remainder of game, your Rep is a leader. Yarna d'al' Gargan is immune to Alter. You may not deploy 'insert' cards or operatives. While a rancor is at Rancor Pit, Trap Door is immune to Bo Shuda.{Flip} this card if you occupy two battleground sites (must occupy a third with a non-unique alien of your Rep's species if a non-Tatooine location is on table).No Love For The Empire:{While} this side up, once per turn you may cancel a Force drain or a just-drawn battle destiny by placing here from hand a copy of your Rep. Once during each of your control phases, you may retrieve a non-unique alien of your Rep's species. When two of your aliens are battling at any Tatooine location, add one destiny to total power. For remainder of game, your Rep may deploy from here as if from hand.{Flip} this card if you do not occupy 2 battleground sites.",
         "icons": [
           "Premium"
@@ -2335,7 +2335,7 @@
       ],
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 3 Force to cancel a battle just initiated at a system or sector. OR Cancel Besieged. OR Release (move for free) all your characters from a captured starship to your side of any docking bay site.",
         "icons": [
           "A New Hope"
@@ -2392,7 +2392,7 @@
     {
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Lose 1 Force to take up to three troopers into hand from Reserve Deck; reshuffle. OR Once per game, target three related battlegrounds occupied by your clones. Your Force drains at same and related battlegrounds this turn are +1.",
         "icons": [
           "Cloud City",
@@ -2617,7 +2617,7 @@
           "lightsaber"
         ],
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your Skywalker of ability > 3. May add 1 to Force drain where present. May target a character or creature for free. Draw two destiny. Target hit, and its forfeit = 0, if total destiny > defense value.",
         "icons": [
           "Hoth"
@@ -2836,7 +2836,7 @@
       "counterpart": "Knowledge And Defense (V)",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on table with any number of Defensive Shields from outside your deck face-down under here. Four times per game, may play a card from here (as if from hand). Unless canceling your Interrupt, opponent may not play Uncertain Is The Future until the end of your first turn.",
         "icons": [
           "Dagobah",
@@ -3324,7 +3324,7 @@
         ],
         "deploy": "4",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Attuned"
         ],
@@ -3442,7 +3442,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If a battle or duel was just initiated at a site, deploy (for free) a unique matching weapon on one of your participating characters from hand or Reserve Deck; reshuffle (if from Reserve Deck).",
         "icons": [
           "Cloud City"
@@ -3519,7 +3519,7 @@
           1,
           6
         ],
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Astromech Droid"
         ],
@@ -4131,7 +4131,7 @@
     {
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on any apprentice at the beginning of your turn. Apprentice 'rests' (may not attempt Jedi Tests) until end of your next turn, then relocate Immediate Effect to Jedi Test. When attempting this test, that apprentice adds 3 to training destiny. (Immune to Control.)",
         "icons": [
           "Dagobah"
@@ -4171,7 +4171,7 @@
         ],
         "deploy": "2",
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "2",
         "gametext": "Deploy on an exterior planet site. Your warrior present may target a vehicle at same or adjacent site using 2 Force. Draw destiny. Target crashes if destiny +2 > armor. Target hit if destiny +1 > maneuver.",
         "icons": [
@@ -4236,7 +4236,7 @@
       ],
       "front": {
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on Death Star: Trench. During your move phase, you may make an Attack Run as follows: Enter Trench: Move up to 3 of your starfighters into trench (for free). Dark Side may immediately follow with up to 3 TIEs (for free). Provide Cover: Identify your lead starfighter (Proton Torpedoes* required) and wingmen (if any). Turbolaser Batteries and TIEs with weapons may now target your starfighters (wingmen first, then lead if no wingmen remaining). Hit starfighters are immediately lost. It's Away!: Draw two destiny. Pull Up!: All starfighters now move to Death Star system (for free). If (total destiny + X + Y - Z) > 15, Death Star is 'blown away.' X = ability of lead pilot (or 3 if Targeting Computer aboard) just before Pull Up!. Y = total sites at largest Rebel Base (Yavin 4 or Hoth). Z = highest ability of opponent's TIE pilots in trench just before Pull Up!. *Your Proton Torpedoes are immune to Overload.",
         "icons": [
           "A New Hope"
@@ -4593,7 +4593,7 @@
       ],
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 4 Force to deploy on your side of table. A non-droid character you just lost may be placed here instead of Lost Pile. Holds 1 'patient' at a time. During your deploy phase, may use X Force to bring 'patient' to hand, where X = deploy cost of 'patient.'",
         "icons": [
           "Hoth"
@@ -4946,11 +4946,14 @@
           3.14159,
           6.28318
         ],
+        "errataDate": "2022-12-12",
+        "errataNotes": "Original Text: If just forfeited from a site, opponent may capture BB-8. While a captive, adds 1 to Force drains at same site. During your control phase, if at a battleground site and present with a Resistance character, opponent loses 1 Force.",
+        "errataSymbol": "E1",
         "extraText": [
           "Astromech Droid"
         ],
         "forfeit": "4",
-        "gametext": "If just forfeited from a site, opponent may capture BB-8. While a captive, adds 1 to Force drains at same site. During your control phase, if at a battleground site and present with a Resistance character, opponent loses 1 Force.",
+        "gametext": "If with a Resistance leader at a battleground site, Force drain +1 here. During your move phase, may place in Used Pile; 'break cover' of all Undercover spies here (if any). Elis Helrot may not transport cards to or from here. Immune to Restraining Bolt.",
         "icons": [
           "Nav Computer",
           "Episode VII",
@@ -4967,6 +4970,7 @@
       "gempId": "204_1",
       "id": 5088,
       "legacy": false,
+      "previousId": 40000,
       "printings": [
         {
           "set": "204"
@@ -4976,6 +4980,9 @@
         "Hero Of A Thousand Devices (V)"
       ],
       "rarity": "R1",
+      "rulings": [
+        "BB-8 may be placed in Used Pile even if there are no Undercover spies there."
+      ],
       "set": "204",
       "side": "Light"
     },
@@ -5056,7 +5063,7 @@
     {
       "front": {
         "destiny": "6",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on Bespin: Cloud City. Your Tibanna Gas Miners deploy free to Cloud City sites and double the Force they activate.",
         "icons": [
           "Cloud City"
@@ -5181,7 +5188,7 @@
         "ability": "6",
         "deploy": "5",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Jedi Knight"
         ],
@@ -5233,7 +5240,7 @@
         ],
         "deploy": "1",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Forfeit +2 when at same site as Owen Lars or a Hydroponics Station. If lost from table during opponent's turn, Luke is power +3 until the end of your next turn.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/berulars.gif",
@@ -5259,7 +5266,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Each player must immediately activate 2 Force. Also, you may activate 1 additional Force for each Beru Lars, Owen Lars or Hydroponics Station on table.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/berustew.gif",
         "lore": "Moisture farmers grow enough food to sustain Tatooine's population. Beru Lars has devised many dishes using herbs and roots naturally found in Tatooine's desert.",
@@ -5505,7 +5512,7 @@
         "ability": "2",
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "5",
         "gametext": "Adds 2 to power of anything he pilots. When piloting Red 3, also adds 1 to maneuver and draws one battle destiny if not able to otherwise.",
         "icons": [
@@ -5582,7 +5589,7 @@
       "counterpart": "Stunning Leader",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If a battle was just initiated at an interior site, use 1 Force; for remainder of battle, all characters of ability > 2 and all leaders (on both sides) are simultaneously excluded from that battle.",
         "icons": [
           "A New Hope"
@@ -5673,7 +5680,7 @@
           "blaster"
         ],
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to deploy on your warrior. May target a character, creature or vehicle using 1 Force. Draw destiny. Target hit if destiny > defense value.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/blaster.gif",
         "lore": "A Merr-Sonn Model 44 blaster pistol. Uses power packs and high-energy blaster gases to shoot bolts of explosive coherent light energy.",
@@ -5746,7 +5753,7 @@
       "counterpart": "Dark Strike",
       "front": {
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "USED: If you just targeted with a blaster, add 3 to your weapon destiny.  LOST: Lose 1 Force to cause one opponent's character just 'hit' to be immediately placed in Lost Pile. OR Cancel Levitation Attack.",
         "icons": [
           "Cloud City"
@@ -5781,7 +5788,7 @@
           "rifle"
         ],
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 2 Force to deploy on your warrior. May target a character, creature or vehicle using 2 Force. Draw destiny. Target hit if destiny +1 > defense value.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/blasterrifle.gif",
         "lore": "BlasTech E-11 blaster rifle. Standard issue for Imperial forces. So numerous that many have been stolen by Rebels. Extendable stock. Carries energy for 100 shots.",
@@ -5950,7 +5957,7 @@
       "front": {
         "deploy": "3",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "5",
         "gametext": "May add 1 pilot. Snap deploys free aboard. While Snap piloting, immune to attrition < 5 and, once per turn, may use 1 Force to cancel a Force drain at opponent's system within 1 parsec of Snap.",
         "hyperspeed": "5",
@@ -6164,7 +6171,7 @@
         ],
         "deploy": "2",
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "FLIGHT: 2"
         ],
@@ -6249,7 +6256,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your Fambaa. Twice per battle may draw destiny. If destiny < total number of opponent's characters and vehicles present, one of them is lost (opponent's choice).",
         "icons": [
           "Episode I",
@@ -6359,7 +6366,7 @@
         "ability": "4",
         "deploy": "4",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Sensitive"
         ],
@@ -6560,7 +6567,7 @@
       "front": {
         "darkSideIcons": 1,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Light:  Your spies deploy -1 here and at related sites. If you control, characters targeted by Undercover are immune to Hutt Smooch.  Dark:  Force drain -X here, where X= number of spies opponent has on table.",
         "icons": [
           "Planet",
@@ -6693,7 +6700,7 @@
     {
       "front": {
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use X Force to deploy on your warrior, where X = (7 - warrior's power). X cannot fall below 1. May target a character or creature using X Force. Draw destiny. Add 1 if targeting a character, 2 if targeting a creature. Target hit if total destiny > defense value.",
         "icons": [
           "A New Hope"
@@ -7621,7 +7628,7 @@
         ],
         "deploy": "4",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Attuned"
         ],
@@ -7862,7 +7869,7 @@
         ],
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "Adds 2 to power of anything he pilots (3 while piloting any Rebel capital starship). Deploys -1 aboard Tantive IV. While aboard Tantive IV, it is immune to Lateral Damage and attrition < 5.",
         "icons": [
@@ -8565,7 +8572,7 @@
         ],
         "deploy": "4",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "6",
         "gametext": "Power +1 at same location as Han. Adds 2 to power of anything he pilots. When piloting Falcon, also adds 1 to maneuver. Your vehicles, starships, and droids at same site that are 'hit' and about to be lost go to Used Pile instead.",
         "icons": [
@@ -9219,8 +9226,12 @@
       ],
       "back": {
         "destiny": "7",
-        "gametext": "City In The Clouds:Deploy Bespin system and a Cloud City battleground site. {While} this side up, once per turn may use 1 Force to deploy a Cloud City battleground site from Reserve Deck; reshuffle. {Flip} this card if you control two Cloud City battleground sites and occupy Bespin system, and opponent controls no Cloud City sites.You Truly Belong Here With Us:{While} this side up, once per game, may deploy Cloud City Celebration from Reserve Deck; reshuffle. Once during your control phase, may use 2 Force to take one Interrupt into hand from Reserve Deck; reshuffle. Once per turn, may move your character as a 'react' to a battle or Force drain at a Cloud City site. {Flip} this card if opponent controls more Cloud City sites than you.",
+        "errataDate": "2022-12-12",
+        "errataNotes": "Original card had Premium icon instead of Cloud City icon.",
+        "errataSymbol": "E1",
+        "gametext": "City In The Clouds:Deploy Bespin system and a Cloud City battleground site. May deploy Weather Vane. {While} this side up, once per turn, may use 1 Force to deploy a Cloud City battleground from Reserve Deck; reshuffle. {Flip} this card if you control two Cloud City battleground sites and occupy Bespin system, and opponent controls no Cloud City sites. You Truly Belong Here With Us:{While} this side up, once per game, may deploy Cloud City Celebration from Reserve Deck; reshuffle. Once during your control phase, may use 2 Force to take one Interrupt into hand from Reserve Deck; reshuffle. Once per turn, may move your character as a 'react' to a battle or Force drain at a Cloud City site. {Flip} this card if opponent controls more Cloud City sites than you.",
         "icons": [
+          "Cloud City",
           "Set P"
         ],
         "imageUrl": "https://res.starwarsccg.org/cards/DemoDeck-Light/large/youtrulybelongherewithus.gif",
@@ -9229,8 +9240,12 @@
       },
       "front": {
         "destiny": "0",
-        "gametext": "City In The Clouds:Deploy Bespin system and a Cloud City battleground site. {While} this side up, once per turn may use 1 Force to deploy a Cloud City battleground site from Reserve Deck; reshuffle. {Flip} this card if you control two Cloud City battleground sites and occupy Bespin system, and opponent controls no Cloud City sites.You Truly Belong Here With Us:{While} this side up, once per game, may deploy Cloud City Celebration from Reserve Deck; reshuffle. Once during your control phase, may use 2 Force to take one Interrupt into hand from Reserve Deck; reshuffle. Once per turn, may move your character as a 'react' to a battle or Force drain at a Cloud City site. {Flip} this card if opponent controls more Cloud City sites than you.",
+        "errataDate": "2022-12-12",
+        "errataNotes": "Original card did not have the option to start Weather Vane, and could only pull sites, not the Cloud City sector. Original card had Premium icon instead of Cloud City icon, and the underlying card was Cloud City Sabacc.",
+        "errataSymbol": "E1",
+        "gametext": "City In The Clouds:Deploy Bespin system and a Cloud City battleground site. May deploy Weather Vane. {While} this side up, once per turn, may use 1 Force to deploy a Cloud City battleground from Reserve Deck; reshuffle. {Flip} this card if you control two Cloud City battleground sites and occupy Bespin system, and opponent controls no Cloud City sites. You Truly Belong Here With Us:{While} this side up, once per game, may deploy Cloud City Celebration from Reserve Deck; reshuffle. Once during your control phase, may use 2 Force to take one Interrupt into hand from Reserve Deck; reshuffle. Once per turn, may move your character as a 'react' to a battle or Force drain at a Cloud City site. {Flip} this card if opponent controls more Cloud City sites than you.",
         "icons": [
+          "Cloud City",
           "Set P"
         ],
         "imageUrl": "https://res.starwarsccg.org/cards/DemoDeck-Light/large/cityintheclouds.gif",
@@ -9240,6 +9255,7 @@
       "gempId": "301_2",
       "id": 5421,
       "legacy": false,
+      "previousId": 40002,
       "printings": [
         {
           "set": "301"
@@ -9256,7 +9272,7 @@
       "counterpart": "Ability, Ability, Ability",
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on opponent's side of table. At the end of opponent's deploy phase, if they did not deploy a card with ability, opponent loses 2 Force. Effect lost if opponent has more cards with ability on table than you. (Immune to Alter.)",
         "icons": [
           "Cloud City"
@@ -9290,7 +9306,7 @@
       "front": {
         "darkSideIcons": 0,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Light:  If you occupy, each Bith character is destiny +2.  Dark:  If you control, each Bith character is destiny -1 and Ghhhk is power +2 in battles at a holosite.",
         "icons": [
           "Planet",
@@ -9649,7 +9665,7 @@
           "blaster"
         ],
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 2 Force to deploy on your warrior at a Cloud City site. May target a character or creature using 2 Force. Draw destiny. Target hit (and may not be used to satisfy attrition) if destiny > defense value.",
         "icons": [
           "Cloud City"
@@ -9901,7 +9917,7 @@
       "front": {
         "darkSideIcons": 1,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Light:  If Weather Vane on table, characters 'hit' here are instead immediately relocated there.  Dark:  If Weather Vane on table, characters 'hit' here are instead immediately relocated there.",
         "icons": [
           "Interior",
@@ -10078,7 +10094,7 @@
       "front": {
         "darkSideIcons": 2,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Light:  Your characters with lightsabers are each power +2 here.  Dark:  -",
         "icons": [
           "Interior",
@@ -10295,7 +10311,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force if opponent has at least two starships present at same system or sector. Draw destiny. If destiny < number of those starships, opponent must lose one of them.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/collision.gif",
         "lore": "High-speed collisions are a constant danger during chaotic starfighter dogfights. Scanners can be jammed. Pilots rely on vision, increasing the chances of such accidents.",
@@ -10333,7 +10349,7 @@
       "counterpart": "Colo Claw Fish",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on table. Cancels Opee Sea Killer. While no card here, you may place a card from hand face-up here. If you just drew weapon or battle destiny, you may exchange it for card here, which then counts as that destiny draw. (Immune to Alter.)",
         "icons": [
           "Episode I",
@@ -10498,7 +10514,7 @@
       "counterpart": "Precise Attack",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "During a battle, target opponent's starship present with two (or more) of your starship weapons. Add all weapon destiny draws together. Apply that total separately for each weapon in an order of your choosing.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/combinedattack.gif",
         "lore": "Efficient cooperation allowed the Rebels to coordinate the attack of their small starfighters effectively at the Battle of Yavin.",
@@ -10697,7 +10713,7 @@
         ],
         "deploy": "4",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Sensitive"
         ],
@@ -10922,7 +10938,7 @@
         ],
         "deploy": "3",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "When at a war room you control, adds 1 to power of each Rebel starship at the related system. May use 1 Force to cancel Astromech Shortage.",
         "icons": [
@@ -10996,7 +11012,7 @@
         ],
         "deploy": "3",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "6",
         "gametext": "Adds 3 to power of anything he pilots. When piloting Rogue 3, also adds 2 to maneuver and draws battle destiny if not able to otherwise. May use 2 Force to take one One More Pass into hand from Reserve Deck; reshuffle.",
         "icons": [
@@ -11133,7 +11149,7 @@
       ],
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on a superlaser. May not fire at a planet until 'recharged.' Opponent may use Force (stacking it here); accumulating 8 Force recharges superlaser. When fired at a planet, Effect is canceled. If Effect canceled, accumulated Force is placed in Used Pile.",
         "icons": [
           "A New Hope"
@@ -11230,7 +11246,7 @@
       ],
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 2 Force to deploy on your warrior. May 'throw' at same or adjacent site. Draw destiny. All characters, weapons and devices with that destiny number present at that site are lost. (Only your warrior is lost if destiny = 0.) Concussion Grenade also lost.",
         "icons": [
           "Hoth"
@@ -11435,7 +11451,7 @@
       "front": {
         "darkSideIcons": 1,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Light:  Your Falcon and your Corellian corvettes may deploy here as a 'react.'  Dark:  Each of your starships are hyperspeed +1 when moving from here.",
         "icons": [
           "Planet",
@@ -12646,7 +12662,7 @@
       ],
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your side of table. If you just lost a vehicle, droid, weapon, or device, may stack it here. Once during your deploy phase, you may exchange any one card in hand with one card stacked here. Any cards stacked here are considered 'supporting.'",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/crashsitememorial.gif",
         "lore": "Mos Eisley was built around wreckage of the colony ship Dowager Queen. The wreck remains as a monument where residents leave junk for Jawa scavengers.",
@@ -13008,7 +13024,7 @@
         ],
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "5",
         "gametext": "Adds 1 to weapon destiny draws of anything he is aboard as a passenger (adds 3 if aboard Rogue 1 or with Luke).",
         "icons": [
@@ -13040,7 +13056,7 @@
       "front": {
         "darkSideIcons": 2,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Light:  During your deploy phase, you may deploy one Dagobah site directly from Reserve Deck. Shuffle, cut and replace.  Dark:  Neither player may Force drain here.",
         "icons": [
           "Planet",
@@ -13666,7 +13682,7 @@
         ],
         "deploy": "7",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Sensitive"
         ],
@@ -13732,7 +13748,7 @@
         ],
         "deploy": "5",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Sensitive"
         ],
@@ -13786,7 +13802,7 @@
       ],
       "front": {
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on Bunker. Once during your control phase, if you control Bunker with a Rebel, you may attempt to 'blow away' Bunker as follows: Charges! Come On, Come On!: Draw two destiny. Add 3 to total for each Explosive Charge on Bunker. Move! Move! Move!: If total destiny > 12, your characters here may relocate to Back Door for free, Bunker and Landing Platform (if on table) are 'blown away,' opponent loses 8 Force and this card is lost.",
         "icons": [
           "Endor"
@@ -14181,7 +14197,7 @@
       ],
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 2 Force to deploy on any Imperial except Vader, Emperor or a stormtrooper. That Imperial is power -2 and its game text is canceled.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/demotion.gif",
         "lore": "Repercussions for failure are severe in the Imperial military. Many officers prefer demotion to 'alternative' punishment from Darth Vader.",
@@ -14297,7 +14313,7 @@
         ],
         "deploy": "4",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Jedi Master"
         ],
@@ -14339,7 +14355,7 @@
         ],
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "Power +2 when at same site as Biggs. Adds 2 to power of anything he pilots (3 if a Star Destroyer is at same location). When piloting Rogue 4, also adds 2 to maneuver.",
         "icons": [
@@ -14420,7 +14436,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "During your turn, if either player just placed a card in a Used Pile, deploy on table. All Used Piles are immediately re-circulated. When any player places one or more cards in a Used Pile, Immediate Effect canceled.",
         "icons": [
           "Dagobah"
@@ -14546,7 +14562,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "During a battle where your opponent has more characters participating than you, fire (for free) one blaster that cannot fire repeatedly, even if that blaster was already fired this battle. Add 1 to your total weapon destiny.",
         "icons": [
           "Reflections 3"
@@ -14578,7 +14594,7 @@
         ],
         "deploy": "3",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "2",
         "gametext": "Power +2 at Mos Eisley, any mobile site or any docking bay. Adds 2 to power of anything he pilots. When playing sabacc, may use clone cards to 'clone' his own destiny number.",
         "icons": [
@@ -14692,7 +14708,7 @@
       ],
       "back": {
         "destiny": "7",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Diplomatic Mission To Alderaan:Deploy Tatooine system (with Tantive IV, non-[Reflections 2] R2-D2, and Stolen Data Tapes there) and Dune Sea.{For} remainder of game, you may not deploy Sandwhirl or [Episode I] Jedi.{While} this side up, your Force drains at Tatooine system are -1. Once per turn, may deploy Alderaan or a Tatooine battleground site from Reserve Deck; reshuffle. Until the start of your turn, Tantive IV may be forfeited to satisfy all battle damage against you.{Flip} this card if Stolen Data Tapes 'delivered' and Rebels control two battlegrounds (a site and a system).A Weakness Can Be Found:{While} this this side up, your total battle destiny is +X, where X = number of battlegrounds occupied by Rebels of ability < 4. Once per turn, may deploy Alderaan or a Tatooine battleground site from Reserve Deck; reshuffle. Once per turn, if you just won a battle, may retrieve 1 Force.{Flip} this card if you do not occupy a battleground site and a battleground system (or you do not control any locations).",
         "icons": [
           "Set 3"
@@ -14703,7 +14719,7 @@
       },
       "front": {
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Diplomatic Mission To Alderaan:Deploy Tatooine system (with Tantive IV, non-[Reflections 2] R2-D2, and Stolen Data Tapes there) and Dune Sea.{For} remainder of game, you may not deploy Sandwhirl or [Episode I] Jedi.{While} this side up, your Force drains at Tatooine system are -1. Once per turn, may deploy Alderaan or a Tatooine battleground site from Reserve Deck; reshuffle. Until the start of your turn, Tantive IV may be forfeited to satisfy all battle damage against you.{Flip} this card if Stolen Data Tapes 'delivered' and Rebels control two battlegrounds (a site and a system).A Weakness Can Be Found:{While} this this side up, your total battle destiny is +X, where X = number of battlegrounds occupied by Rebels of ability < 4. Once per turn, may deploy Alderaan or a Tatooine battleground site from Reserve Deck; reshuffle. Once per turn, if you just won a battle, may retrieve 1 Force.{Flip} this card if you do not occupy a battleground site and a battleground system (or you do not control any locations).",
         "icons": [
           "Set 3"
@@ -14761,7 +14777,7 @@
       "counterpart": "Disarmed",
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If both players have a character with a weapon present at same site, deploy on that opponent's character during any control phase. Character loses all weapons, is power -1 and may no longer carry weapons. (Immune to Alter.)",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/disarmed.gif",
         "lore": "When Dr. Evazan and Ponda Baba confronted Luke in the Cantina, Obi-Wan pointed out, 'This little one isn't worth the effort.' A brawl ensued.",
@@ -15040,7 +15056,7 @@
       ],
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If one of your characters of ability > 2 was just targeted by a weapon, subtract 3 from each destiny draw. OR If opponent just initiated a battle at a site against one of your lone characters present, move that character away as a 'react' (for free).",
         "icons": [
           "Cloud City"
@@ -15263,7 +15279,7 @@
       "counterpart": "Fanfare (V) - Defensive Shield",
       "front": {
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Plays on table. Always Thinking With Your Stomach, Ice Storm, and Sandwhirl are canceled. Once per game, may take an Immediate Effect into hand from Reserve Deck; reshuffle. Unless opponent occupies a battleground system, Mobilization Points is suspended.",
         "icons": [
           "Defensive Shield",
@@ -15352,7 +15368,7 @@
       ],
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If Luke and Han are in a battle together, you may add two battle destiny. OR If opponent just initiated a battle at a system or sector, choose one TIE/ln present to be lost.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/dontgetcocky.gif",
         "lore": "Luke and Han made an effective team when defending the Millennium Falcon with its quad laser cannons against attacking TIE fighters. 'Great kid! Don't get cocky.'",
@@ -15526,7 +15542,7 @@
       "counterpart": "Nevar Yalnal",
       "front": {
         "destiny": "6",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If both players have a spy at same site, draw destiny. Add 2 if opponent's spy is Undercover. Opponent's spy is lost if destiny > 2. OR Opponent's Tonnika Sisters present at a site cross to your side.",
         "icons": [
           "A New Hope"
@@ -15707,7 +15723,7 @@
         "ability": "2",
         "deploy": "1",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Spaceport Speeders may be played at same site. Once per game, may do one of the following: activate 1 Force when you deploy a droid OR retrieve 1 Force when you deploy an astromech to a starfighter.",
         "icons": [
@@ -15770,7 +15786,7 @@
     {
       "front": {
         "destiny": "6",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Cancel an attempt by opponent to target your droid to be stolen, 'hit,' lost or captured. Droid is protected from all such attempts for remainder of turn.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/droidshutdown.gif",
         "lore": "If low on energy and unable to recharge, a droid can shutdown active systems to conserve power.",
@@ -15840,7 +15856,7 @@
           "laser cannon"
         ],
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 2 Force to deploy on your T-47. May target a character, creature or vehicle using 1 Force. Draw destiny. Subtract 1 if targeting a character or creature. Add 2 if targeting a vehicle. Target hit if total destiny > defense value.",
         "icons": [
           "Hoth"
@@ -15912,7 +15928,7 @@
         ],
         "deploy": "2",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "5",
         "gametext": "Adds 2 to power of anything he pilots. When piloting Gold 1, also adds 1 to maneuver and draws one battle destiny if not able to otherwise. Adds 1 to forfeit of each other Gold Squadron pilot at same location.",
         "icons": [
@@ -16217,7 +16233,7 @@
       "counterpart": "Stormtrooper Backpack",
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your trooper. May use any number of weapons and devices. Trooper is immune to attrition < 3 when at a planet site.",
         "icons": [
           "Hoth"
@@ -16257,7 +16273,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "USED: Cancel Limited Resources.  LOST: Use 3 Force to retrieve into hand one Effect of any kind.",
         "icons": [
           "Dagobah"
@@ -16283,7 +16299,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "USED: Cancel Broken Concentration, Lateral Damage, or Limited Resources. OR Place a card just stacked on Droid Racks or Strategic Reserves in opponent's Lost Pile. (Immune to Sense) OR If you just drew a starship for destiny, take that starship into hand to cancel and redraw that destiny.  LOST: Use 3 Force to retrieve an Effect of any kind or a non-[Maintenance] starship into hand.",
         "icons": [
           "Set 9"
@@ -16358,7 +16374,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "During opponent's control phase, if opponent has two or more capital starships at a system or sector together, draw destiny. If destiny -1 < number of those starships, they may not move or participate in battle until end of your next turn.",
         "icons": [
           "Dagobah"
@@ -16425,7 +16441,7 @@
       "counterpart": "Come With Me",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to target a starfighter having one or more permanent pilots. Draw destiny. If destiny > 2, deploy on starfighter to remove all permanent pilots (otherwise, Effect is lost). May add 1 pilot for each permanent pilot removed. (Immune to Alter.)",
         "icons": [
           "A New Hope"
@@ -16458,7 +16474,7 @@
     {
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to deploy on any warrior. At any time, you may peek at the top card of your Reserve Deck by using 2 Force. You may choose to move that card to the top of your Force Pile.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/electrobinoculars.gif",
         "lore": "Enhances distant targets using a computer-assisted zoom technology. Provides range information. Works in low-light. Rugged case protects the internal systems.",
@@ -16556,7 +16572,7 @@
       "counterpart": "Baniss Keeg",
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your non-pilot character (except droids) to give that character [Pilot] skill. Adds 2 to power of anything that character pilots. OR Deploy on your pilot. Adds 1 to power of anything that character pilots. (Immune to Alter.)",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/ellorrsmadak.gif",
         "lore": "Like many Duros, Madak has natural piloting and navigation skill. Former scout. Freelance instructor. Makes runs to important trade worlds Celanon, Byblos and Yaga Minor.",
@@ -16621,7 +16637,7 @@
         "ability": "2",
         "deploy": "3",
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Power +3 at same site as an Imperial. For remainder of game, Plastoid Armor is an Effect, is not unique, is immune to Alter while on table, and it deploys only on a Rebel or alien at same mobile site as Elom (character is now 'disguised').",
         "icons": [
@@ -16925,7 +16941,7 @@
         ],
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Power -1 while not on Endor. While Endor Scout Trooper is on Endor, Lieutenant Page and each of your Rebel scouts of ability < 3 at same and adjacent exterior sites are immune to attrition < 2.",
         "icons": [
@@ -17182,7 +17198,10 @@
       "front": {
         "darkSideIcons": 1,
         "destiny": "0",
-        "gametext": "Light:  While a Skywalker here, Prophecy Of The Force may not relocate from here.  Dark:  No starships or vehicles here.",
+        "errataDate": "2022-12-12",
+        "errataNotes": "Original was a 1/1 site instead of 2/1. Original Text: Light: While a Skywalker here, Prophecy Of The Force may not relocate from here.  Dark: No starships or vehicles here.",
+        "errataSymbol": "E1",
+        "gametext": "Light:  No starships or vehicles here. While Prophecy Of The Force with Luke here, it may not relocate.  Dark:  Force drain -1 here. While opponent's [Set 8] Effect with Luke here, your Force generation is -1 here.",
         "icons": [
           "Interior",
           "Exterior",
@@ -17190,7 +17209,7 @@
           "Set 8"
         ],
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/endorewokvillage.gif",
-        "lightSideIcons": 1,
+        "lightSideIcons": 2,
         "subType": "Site",
         "title": "•Endor: Ewok Village (V)",
         "type": "Location",
@@ -17199,6 +17218,7 @@
       "gempId": "208_23",
       "id": 5236,
       "legacy": false,
+      "previousId": 40005,
       "printings": [
         {
           "set": "208"
@@ -17210,6 +17230,10 @@
         "Wuta"
       ],
       "rarity": "U",
+      "rulings": [
+        "When Prophecy Of The Force and Luke are here together, Light's text only prevents Prophecy Of The Force from relocating. It does not prevent Luke from moving or relocating."
+      ],
+
       "set": "208",
       "side": "Light"
     },
@@ -17564,7 +17588,7 @@
     {
       "front": {
         "destiny": "6",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If your capital starship is about to be lost, relocate your characters aboard to any one planet site.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/escapepod.gif",
         "lore": "Capital starships have emergency escape pods. Equipped with food, water, flares, medpacs, hunting blaster and tracking beacon (R2-D2 deactivated this one's beacon).",
@@ -17591,7 +17615,7 @@
     {
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to take a dejarik into hand from Reserve Deck; reshuffle. OR For remainder of turn, you lose no Force to Cloud City Occupation, Rebel Base Occupation, Tatooine Occupation, That Thing's Operational, You May Start Your Landing, or You'll Be Dead!.",
         "icons": [
           "Set 4"
@@ -17664,7 +17688,7 @@
     {
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your war room. Once during each of your move phases, your Planet Defender Ion Cannon at same planet may fire. Also, each of your medium transports at same planet is hyperspeed +2, is immune to attrition < 3 and may move for free.",
         "icons": [
           "Hoth"
@@ -18266,7 +18290,7 @@
     {
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If opponent just initiated a battle at an exterior site with more than double your total power, use 1 Force to target an adjacent site where opponent has no presence. All your characters present in battle move away (for free) to the target site. The battle is canceled.",
         "icons": [
           "Hoth"
@@ -18354,7 +18378,7 @@
     {
       "front": {
         "destiny": "6",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If you just lost a character during a battle or duel at a Cloud City site, use 2 Force to relocate that character to Weather Vane instead of your Lost Pile. OR Search your Reserve Deck, take one Weather Vane into hand and reshuffle.",
         "icons": [
           "Cloud City"
@@ -18391,7 +18415,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Target one creature or up to two characters present that just initiated an attack or battle against you at Back Door, Rancor Pit, Tatooine: Jabba's Palace or any docking bay. Draw destiny. Target(s) immediately lost if destiny +2 > total defense value.",
         "icons": [
           "Jabba's Palace"
@@ -18588,7 +18612,7 @@
       ],
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your astromech droid. Cancels an 'exploding' Program Trap here. Any starship it is aboard is immune to Lateral Damage and ion cannons. If deployed on R2-D2, may lose Fire Extinguisher to cancel a battle just initiated where present at a site.",
         "icons": [
           "A New Hope"
@@ -18622,7 +18646,7 @@
       "counterpart": "Outflank",
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "During a battle, if you have weapons at at least 2 sites adjacent to that battle, add 3 to your total power and add one battle destiny. OR For remainder of turn, your scout at an exterior site is power +1 and adds 1 to each of that character's weapon destiny draws.",
         "icons": [
           "Endor"
@@ -18730,7 +18754,7 @@
         ],
         "deploy": "3",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Attuned"
         ],
@@ -18873,7 +18897,7 @@
       "counterpart": "Dark Forces",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on table. If Counter Assault is played, may use 1 Force to add one destiny to your total. If Sense or Alter just played, may use X Force to exclude X Dark Jedi from being the 'highest-ability character.'",
         "icons": [
           "Premium"
@@ -19279,7 +19303,7 @@
       "counterpart": "Lone Pilot",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If your pilot (or permanent pilot) is defending a battle alone at a system or sector, add one battle destiny. OR If Luke is defending a battle alone at a system or sector, add 1 to power and add one battle destiny.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/fullthrottle.gif",
         "lore": "Rebel pilots use visual scanning to supplement sensors for an edge against Imperial fighter pilots. Natural instincts allow lone Rebels to overcome superior numbers.",
@@ -19304,7 +19328,7 @@
       "counterpart": "Fusion Generator Supply Tanks",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your starship at a system or sector where a related docking bay is on table. Adds 1 to hyperspeed, power and maneuver.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/fusiongeneratorsupplytanks.gif",
         "lore": "Uses standard fusion technology. Provides starships with energy for hyperspace travel. Installed at docking bays and throughout the Outer Rim Territories.",
@@ -19335,7 +19359,7 @@
       "front": {
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Medical Droid"
         ],
@@ -19396,7 +19420,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If any gambler is defending a battle alone at a site, add one battle destiny (draw two destiny, and choose one). OR if your Lando is defending a battle alone at a site, add two battle destiny (draw three and choose two).",
         "icons": [
           "Cloud City"
@@ -19456,7 +19480,7 @@
         "ability": "1",
         "deploy": "3",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "2",
         "gametext": "Adds 1 to power of anything he pilots. Adds 1 to forfeit of each of your characters at same Tatooine site. Subtracts 1 from forfeit of each of opponent's characters at same Hoth site. Game text suspended if at same site as a tax collector.",
         "icons": [
@@ -20093,7 +20117,7 @@
         ],
         "deploy": "4",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Sensitive"
         ],
@@ -20254,7 +20278,7 @@
         ],
         "deploy": "4",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Attuned"
         ],
@@ -20671,7 +20695,7 @@
         ],
         "deploy": "3",
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Deploy on any exterior planet site. Your warrior present may target a creature, character or vehicle at same or adjacent site using 2 Force. Draw destiny. Add 2 if targeting a creature or character. Target hit if destiny > defense value.",
         "icons": [
@@ -20747,7 +20771,7 @@
         ],
         "deploy": "1",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "May add 2 pilots or passengers. May forfeit in place of your other starfighter hit in Death Star: Trench, restoring that starfighter to normal.",
         "hyperspeed": "4",
@@ -20874,7 +20898,7 @@
         ],
         "deploy": "1",
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "May add 2 pilots or passengers, and 1 astromech.",
         "hyperspeed": "4",
@@ -21150,7 +21174,7 @@
       "counterpart": "Imperial Detention",
       "front": {
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Plays on table. For opponent to deploy a character, starship, or vehicle for free (except by that card's own game text), opponent must first use 2 Force. They Must Never Again Leave This City is suspended during opponent's first turn.",
         "icons": [
           "Defensive Shield",
@@ -21288,7 +21312,7 @@
       "counterpart": "Tentacle",
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If opponent just played an Interrupt, use 1 Force to deploy on table. That Interrupt is played out but is then 'grappled' (placed here but is out of play). Any new Interrupts of the same name are now unique (•). (Immune to Control.)",
         "icons": [
           "A New Hope",
@@ -21517,7 +21541,7 @@
       ],
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on table. If Death Star 'blown away': Whenever you deploy a unique (*) starship to a system location, retrieve 3 Force; Once per during each of your turns you may deploy (for free) a starship from hand or Reserve Deck and reshuffle. (Immune to Alter.)",
         "icons": [
           "Tatooine"
@@ -21553,7 +21577,7 @@
       ],
       "front": {
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on a Dagobah site. Target a mentor here. Also, target or deploy (regardless of location deployment restrictions) an apprentice here. Attempt when targets are present at the beginning of your control phase. Draw training destiny. If destiny + apprentice's ability > 12, test completed: Place on apprentice. All opponent's Force drain bonuses are canceled.  Mentor: Your character of ability > 2. Apprentice: Your non-droid, non-Jedi character of lesser ability than mentor. Each time you complete any Jedi Test, you may exchange one card in hand for one Jedi Test in your Lost Pile.",
         "icons": [
           "Dagobah"
@@ -21898,7 +21922,7 @@
           "dejarik"
         ],
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "USED: If opponent has 13 or more cards in hand, place all but 8 (random selection) in Used Pile.  LOST: Cancel Molator (even at a holosite). OR Use 4 Force to reveal opponent's hand. All cards opponent has two or more of in hand are lost.",
         "icons": [
           "A New Hope"
@@ -21941,7 +21965,7 @@
         ],
         "deploy": "3",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Attuned"
         ],
@@ -22330,7 +22354,7 @@
         ],
         "deploy": "3",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Attuned"
         ],
@@ -22418,7 +22442,7 @@
       "id": 1100,
       "legacy": false,
       "matching": [
-        "Gold Squadron 1 Millennium Falcon"
+        "Millennium Falcon"
       ],
       "matchingWeapon": [
         "Han's Heavy Blaster Pistol",
@@ -22451,7 +22475,7 @@
         ],
         "deploy": "6",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "8",
         "gametext": "Permanent pilots are •Han and •Chewie: provide ability of 5, add one battle destiny, and add 5 to power. Immune to attrition < 6, Come With Me, and Lateral Damage. End of your turn: Use 3 Force to maintain OR Place out of play.",
         "hyperspeed": "7",
@@ -22613,7 +22637,7 @@
           "blaster"
         ],
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to deploy on Han, or 3 on your warrior. May target a character, creature or vehicle using 1 Force. Draw destiny. Target hit if destiny +1 > defense value. If hit by Han, target's forfeit = 0.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/hansheavyblasterpistol.gif",
         "lore": "BlasTech DL-44 heavy pistol. Short range, but relatively powerful. Carries energy for 25 shots. Illegal or restricted on most systems.",
@@ -22652,7 +22676,7 @@
           "blaster"
         ],
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on Beckett or non-spy Han. May target a character. Draw destiny. Target hit, and its forfeit = 0, if destiny +2 > defense value. If on Han, may fire once during your control phase, and may place this weapon in Used Pile to cancel a weapon destiny targeting Han.",
         "icons": [
           "Set 0"
@@ -22697,7 +22721,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to deploy on one of your characters, vehicles or starships (free on Falcon or Han). While aboard a vehicle or starship, you may use 1 Force to cancel any Interrupt or Effect of any kind (except those immune to Alter or Control) which targets that vehicle or starship.",
         "icons": [
           "Dagobah"
@@ -22782,7 +22806,7 @@
         ],
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "Adds 2 to power of anything he pilots. For each of opponent's non-battleground locations on table, your Force generation is +1. Once per game, may take an Immediate Effect into hand from Reserve Deck; reshuffle.",
         "icons": [
@@ -22852,7 +22876,7 @@
       ],
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on one of the following systems: Rendezvous Point, Hoth, Yavin 4, Alderaan or Sullust. Your starships deploy -2 and your pilots deploy -1 here. When battling here, you may add one battle destiny. Effect canceled if opponent controls this system. (Immune to Alter.)",
         "icons": [
           "Cloud City"
@@ -22918,7 +22942,7 @@
       ],
       "back": {
         "destiny": "7",
-        "gametext": "He Is The Chosen One:Deploy Jedi Council Chamber (with Prophecy Of The Force there), Ewok Village, and I Feel The Conflict.{For} remainder of game, you may not deploy [Episode I] or [Episode VII] characters or locations (except Obi-Wan and Yoda). Luke may not be captured by Bring Him Before Me unless there are two cards stacked on Insignificant Rebellion during any move phase.{While} this side up, you may initiate battles for free.{Flip} this card if Luke or a Jedi at a battleground site (unless an opponent's character of ability > 4 is). He Will Bring Balance:{While} this side up, once during your control phase, may peek at up to X cards from the top of your Reserve Deck, where X = number of battlegrounds you occupy; take one into hand and shuffle your Reserve Deck. During your draw phase, may retrieve any one card; opponent may stack a card from hand on I Feel The Conflict to place that out of play instead.{Flip} this card (unless Vader crossed over) if opponent's character of ability > 4 at a battleground site or you do not have Luke (or a Jedi) at a battleground site.",
+        "gametext": "He Is The Chosen One: Deploy Anakin’s Funeral Pyre (with Prophecy Of The Force there), Ewok Village, and I Feel The Conflict. For remainder of game, you may not deploy [Episode I] or [Episode VII] characters or locations (except Obi-Wan, Yoda, and Lars' Moisture Farm). If Luke just won a battle, may re-circulate and shuffle Reserve Deck. Emperor’s Power does not increase deploy costs at battlegrounds. While this side up, you may initiate battles for free. Flip this card if Luke or a Jedi at a battleground site (unless an opponent's character of ability > 4 is). He Will Bring Balance:{While} this side up, once during your control phase, may peek at up to X cards from the top of your Reserve Deck, where X = number of battlegrounds you occupy; take one into hand and shuffle your Reserve Deck. During your draw phase, may retrieve any one card; opponent may stack a card from hand on I Feel The Conflict to place that out of play instead.{Flip} this card (unless Vader crossed over) if opponent's character of ability > 4 at a battleground site or you do not have Luke (or a Jedi) at a battleground site.",
         "icons": [
           "Set 8"
         ],
@@ -22928,8 +22952,10 @@
       },
       "front": {
         "destiny": "0",
-        "errataVersion": "E1",
-        "gametext": "He Is The Chosen One:Deploy Jedi Council Chamber (with Prophecy Of The Force there), Ewok Village, and I Feel The Conflict.{For} remainder of game, you may not deploy [Episode I] or [Episode VII] characters or locations (except Obi-Wan and Yoda). Luke may not be captured by Bring Him Before Me unless there are two cards stacked on Insignificant Rebellion during any move phase.{While} this side up, you may initiate battles for free.{Flip} this card if Luke or a Jedi at a battleground site (unless an opponent's character of ability > 4 is). He Will Bring Balance:{While} this side up, once during your control phase, may peek at up to X cards from the top of your Reserve Deck, where X = number of battlegrounds you occupy; take one into hand and shuffle your Reserve Deck. During your draw phase, may retrieve any one card; opponent may stack a card from hand on I Feel The Conflict to place that out of play instead.{Flip} this card (unless Vader crossed over) if opponent's character of ability > 4 at a battleground site or you do not have Luke (or a Jedi) at a battleground site.",
+        "errataDate": "2022-12-12",
+        "errataNotes": "E1 Text: Deploy Jedi Council Chamber (with Prophecy Of The Force there), Ewok Village, and I Feel The Conflict. For remainder of game, you may not deploy [Episode I] or [Episode VII] characters or locations (except Obi-Wan and Yoda). Luke may not be captured by Bring Him Before Me unless there are two cards stacked on Insignificant Rebellion during any move phase. While this side up, you may initiate battles for free. Flip this card if Luke or a Jedi at a battleground site (unless an opponent's character of ability > 4 is).",
+        "errataSymbol": "E2",
+        "gametext": "He Is The Chosen One: Deploy Anakin’s Funeral Pyre (with Prophecy Of The Force there), Ewok Village, and I Feel The Conflict. For remainder of game, you may not deploy [Episode I] or [Episode VII] characters or locations (except Obi-Wan, Yoda, and Lars' Moisture Farm). If Luke just won a battle, may re-circulate and shuffle Reserve Deck. Emperor’s Power does not increase deploy costs at battlegrounds. While this side up, you may initiate battles for free. Flip this card if Luke or a Jedi at a battleground site (unless an opponent's character of ability > 4 is). He Will Bring Balance:{While} this side up, once during your control phase, may peek at up to X cards from the top of your Reserve Deck, where X = number of battlegrounds you occupy; take one into hand and shuffle your Reserve Deck. During your draw phase, may retrieve any one card; opponent may stack a card from hand on I Feel The Conflict to place that out of play instead.{Flip} this card (unless Vader crossed over) if opponent's character of ability > 4 at a battleground site or you do not have Luke (or a Jedi) at a battleground site.",
         "icons": [
           "Set 8"
         ],
@@ -22940,6 +22966,7 @@
       "gempId": "208_25",
       "id": 5572,
       "legacy": false,
+      "previousId": 40007,
       "printings": [
         {
           "set": "208"
@@ -22947,7 +22974,8 @@
       ],
       "rarity": "R",
       "rulings": [
-        "When playing against Bring Him Before Me, Light <u>may</u> select Luke as the card to be retrieved, but Dark <u>may not</u> stack a card from hand on I Feel The Conflict to place that Luke out of play instead."
+        "(0-side) An empty Used Pile does not prevent Light from performing the 're-circulate and shuffle Reserve Deck' action.",
+        "(7-side) When playing against Bring Him Before Me, Light <u>may</u> select Luke as the card to be retrieved, but Dark <u>may not</u> stack a card from hand on I Feel The Conflict to place that Luke out of play instead."
       ],
       "set": "208",
       "side": "Light"
@@ -23016,7 +23044,7 @@
     {
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If opponent just targeted your starship with a starship weapon, subtract 2 from each of that weapon's destiny draws.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/hearmebabyholdtogether.gif",
         "lore": "Smuggler and Rebel starships use black market armor plating and deflector shields to withstand enemy fire. Expensive but life-saving modifications.",
@@ -23313,7 +23341,7 @@
         ],
         "deploy": "*",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "1",
         "gametext": "* Deploys only on Tatooine for 2 Force from each player's Force Pile. Het is power +1 for each Stormtrooper at same site, unless Reegesk is present.",
         "icons": [
@@ -23356,7 +23384,7 @@
       ],
       "back": {
         "destiny": "7",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Hidden Base:Deploy Rendezvous Point. Place a planet system (with a parsec number from 1 to 8) from outside your deck face down on your side of table (not in play); that card indicates the planet where your 'Hidden Base' is located.{While} this side up, once during each of your deploy phases, may deploy one system from Reserve Deck; reshuffle. Opponent loses no more than 1 Force from each of your Force drains at systems and sectors.{Flip} this card any time after you have deployed five battleground systems and your 'Hidden Base' system.Systems Will Slip Through Your Fingers:{While} this side up, to draw a card from Force Pile, opponent must first use 1 Force. For each battleground system you control, you may cancel one opponent's Force drain (limit twice per turn). You may not deploy any systems. At each system opponent occupies during any deploy phase, opponent may 'probe' there by placing one card from hand face down beneath that system.{Place} out of play if 'Hidden Base' system is 'probed.' Dark side places 'probe' cards in Used Pile (and may retrieve 1 Force for each Probe Droid used to 'probe').",
         "icons": [
           "Special Edition"
@@ -23367,7 +23395,7 @@
       },
       "front": {
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Hidden Base:Deploy Rendezvous Point. Place a planet system (with a parsec number from 1 to 8) from outside your deck face down on your side of table (not in play); that card indicates the planet where your 'Hidden Base' is located.{While} this side up, once during each of your deploy phases, may deploy one system from Reserve Deck; reshuffle. Opponent loses no more than 1 Force from each of your Force drains at systems and sectors.{Flip} this card any time after you have deployed five battleground systems and your 'Hidden Base' system.Systems Will Slip Through Your Fingers:{While} this side up, to draw a card from Force Pile, opponent must first use 1 Force. For each battleground system you control, you may cancel one opponent's Force drain (limit twice per turn). You may not deploy any systems. At each system opponent occupies during any deploy phase, opponent may 'probe' there by placing one card from hand face down beneath that system.{Place} out of play if 'Hidden Base' system is 'probed.' Dark side places 'probe' cards in Used Pile (and may retrieve 1 Force for each Probe Droid used to 'probe').",
         "icons": [
           "Special Edition"
@@ -23466,7 +23494,7 @@
       "counterpart": "End This Destructive Conflict",
       "front": {
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "USED: During a battle at a site, instead of firing one character weapon, cause one opponent's character present to be power -4 until end of turn.  LOST: During a battle at a site, use 3 Force to cancel one battle destiny just drawn.",
         "icons": [
           "Cloud City"
@@ -23493,7 +23521,7 @@
     {
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on C-3PO. Eyes In The Dark, The Professor, Mantellian Savrip and Hopping Mad are immune to Alter. Also, at the end of every turn, unless C-3PO is present with a Wookiee, you may examine the cards in your Used Pile. (Immune to Alter.)",
         "icons": [
           "Cloud City"
@@ -23558,7 +23586,7 @@
         ],
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Adds 2 to power of anything she pilots. Adds 2 to deploy cost of each opponent's male Imperial when that Imperial is deploying to same or adjacent site.",
         "icons": [
@@ -24178,7 +24206,7 @@
       "front": {
         "darkSideIcons": 0,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Light:  Once per turn, when you deploy a medical droid, it is deploy -2.  Dark:  If you control, with an Imperial present, Force drain +1 here.",
         "icons": [
           "Underground",
@@ -24347,7 +24375,7 @@
           "dejarik"
         ],
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "During the damage segment of a battle you lost, if you have no cards left that can be forfeited, cancel all remaining battle damage. (Immune to Sense.) OR Cancel Sunsdown.",
         "icons": [
           "A New Hope"
@@ -24384,7 +24412,7 @@
       "counterpart": "Ghhhk & Those Rebels Won't Escape Us",
       "front": {
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "USED: If opponent just initiated a battle at a system or sector where you have a starship with maneuver > 3, use 1 Force to add one battle destiny.  LOST: If you just forfeited all your cards that participated in a battle you lost, cancel all remaining battle damage. (Immune to Sense.)",
         "icons": [
           "Reflections 2"
@@ -24471,7 +24499,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to deploy on any exterior Tatooine site. Cannot be moved. The first Force you activate during your activate phase may be drawn into hand instead. If a Vaporator on table, the second Force you activate may also be drawn into hand.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/hydroponicsstation.gif",
         "lore": "Grows fruits and vegetables. Very efficient water use. Often underground. Feeds moisture farm families, but excess vegetables are often sold at markets.",
@@ -24507,7 +24535,7 @@
       ],
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If a battle was just initiated at any system or sector, move all your starships and vehicles there away.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/hyperescape.gif",
         "lore": "'We'll be safe enough once we make the jump to hyperspace.' A starship in hyperspace cannot be tracked unless a homing beacon has been hidden aboard.",
@@ -24583,7 +24611,7 @@
       ],
       "front": {
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on table if you've won a Podrace. Once per game, may place Boonta Eve Podrace out of play to retrieve 4 Force. If you occupy a battleground site and a battleground system, once during each of your control phases may reveal the bottom card of your Lost Pile and place it on top of your Force Pile. At the end of opponent's turn opponent must lose 2 Force or place their Force Pile onto their Used Pile.",
         "icons": [
           "Episode I",
@@ -24969,7 +24997,7 @@
     {
       "front": {
         "destiny": "7",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Sacrifice (lose) your creature vehicle to protect one character present from Exposure, Ice Storm, Frostbite and Gravel Storm for remainder of turn. (Two characters may be protected if sacrificing a ronto.) OR Double Tzizvvt's power until he moves.",
         "icons": [
           "Hoth"
@@ -25274,7 +25302,7 @@
       ],
       "front": {
         "destiny": "6",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If you have a spy present at the Detention Block Corridor, target a captive there. Draw destiny. If destiny + ability of spy > ability of captive, target is released. Otherwise, spy is captured. OR Cancel Spice Mines Of Kessel (releasing targeted captive).",
         "icons": [
           "A New Hope"
@@ -25638,7 +25666,7 @@
       "counterpart": "Infantry Mine",
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy at same exterior site as your mining droid. 'Explodes' if a character deploys or moves (without using a vehicle or starfighter) to or across same site. Draw destiny. Character lost if destiny +2 > ability. Infantry Mine is also lost.",
         "icons": [
           "Hoth"
@@ -25699,7 +25727,7 @@
       ],
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "USED: If your gambler was just targeted by a weapon, opponent must choose to select a new target or lose 2 Force.  LOST: Cancel any Effect (except those immune to Alter) deployed on Han or your Lando.",
         "icons": [
           "Cloud City"
@@ -25888,7 +25916,7 @@
     {
       "front": {
         "destiny": "6",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Relocate one of your characters from a Cloud City site to Weather Vane (if 'hit,' character is first restored to normal). May be played even after a battle has just been initiated.",
         "icons": [
           "Cloud City"
@@ -25918,7 +25946,7 @@
           "missile"
         ],
         "destiny": "7",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your B-wing, Z-95, YT-1300 Transport, or Falcon. May target a capital starship for free. Draw destiny. Add 3 if that capital starship was targeted by another weapon this turn. Target hit if total destiny > defense value. After firing, place Missile in Used Pile.",
         "icons": [
           "Special Edition"
@@ -25988,7 +26016,7 @@
       "counterpart": "I'd Just As Soon Kiss A Wookiee",
       "front": {
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 3 Force to place an opponent's just deployed character, starship, vehicle, weapon, or device in opponent's hand. On opponent's next turn, that card (or one card of same title) may deploy for free.",
         "icons": [
           "Hoth"
@@ -26353,7 +26381,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If you just initiated a battle at a location where you have less power than the opponent, double opponent's battle damage if you win the battle (if Han is present at the battle location, triple opponent's battle damage).",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/ivegotabadfeelingaboutthis.gif",
         "lore": "Han's smuggling adventures in Corporate Sector and Hutt Space put him in many tight scrapes. He's about to be in another.",
@@ -26520,7 +26548,7 @@
         ],
         "deploy": "0",
         "destiny": "7",
-        "errataVersion": "E2",
+        "errataSymbol": "E2",
         "forfeit": "2",
         "gametext": "If either player just deployed a card with ability here, you may use 1 Force to place The Mythrol out of play; if card was Din Djarin or a bounty hunter, you may activate 2 Force. If about to leave table, place out of play.",
         "icons": [
@@ -26545,7 +26573,7 @@
         ],
         "deploy": "0",
         "destiny": "0",
-        "errataVersion": "E2",
+        "errataSymbol": "E2",
         "extraText": [
           "Carbon-Frozen"
         ],
@@ -26767,7 +26795,7 @@
       "front": {
         "darkSideIcons": 0,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Light:  Once per game, may deploy Rey here from Reserve Deck; reshuffle. Rey deploys -2 here. If Rey present, she may not be targeted by weapons.  Dark:",
         "icons": [
           "Interior",
@@ -26804,7 +26832,7 @@
       "front": {
         "darkSideIcons": 2,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Light:  If you just deployed a scavenger here, may retrieve a device, droid, or weapon.  Dark:  Unless you occupy, your non-scavenger characters deploy and move to here for +1 Force.",
         "icons": [
           "Exterior",
@@ -27044,7 +27072,7 @@
       ],
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to deploy on your Jawa, 3 on your warrior. May target a character using 1 Force. Draw destiny. Targeted droid stolen if destiny +1 > forfeit. Targeted non-droid character excluded from battle if destiny = defense value.",
         "icons": [
           "A New Hope"
@@ -27224,7 +27252,10 @@
       "counterpart": "Sith Fury (V)",
       "front": {
         "destiny": "4",
-        "gametext": "USED: If you just drew a character for destiny, take that card into hand to cancel and redraw that destiny.  LOST: Use 3 Force to retrieve a non-[Maintenance] character into hand.",
+        "errataDate": "2022-12-12",
+        "errataNotes": "Original Text: USED: If you just drew a character for destiny, take that card into hand to cancel and redraw that destiny.  LOST: Use 3 Force to retrieve a non-[Maintenance] character into hand.",
+        "errataSymbol": "E1",
+        "gametext": "USED: If you just drew a character for destiny, choose: Take that card into hand. OR Cancel and redraw that destiny. LOST: Once per game, use 4 Force to take a character into hand from Lost Pile.",
         "icons": [
           "Dagobah",
           "Set 0"
@@ -27238,6 +27269,7 @@
       "gempId": "200_54",
       "id": 1385,
       "legacy": false,
+      "previousId": 40009,
       "printings": [
         {
           "set": "200"
@@ -27247,6 +27279,9 @@
         "Yoda's Hope"
       ],
       "rarity": "R",
+      "rulings": [
+        "The Lost function is not retrieval."
+      ],
       "set": "200",
       "side": "Light"
     },
@@ -27261,7 +27296,7 @@
           "lightsaber"
         ],
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use X Force to deploy on your warrior where X = (7 - warrior's ability). May add 1 to Force drain where present. May target a character or creature by using X Force. Draw two destiny. Target hit if total destiny > defense value.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/jedilightsaber.gif",
         "lore": "Elegant sword of pure energy. 'This is the weapon of a Jedi Knight. Not as clumsy or as random as a blaster. A lightsaber can be dangerous to an unskilled user.'",
@@ -27404,7 +27439,7 @@
         "ability": "2",
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "Adds 2 to power of anything he pilots. When piloting Red 6, also adds 1 to maneuver and draws one battle destiny if not able to otherwise.",
         "icons": [
@@ -27446,7 +27481,7 @@
         ],
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "Adds 2 to power of anything he pilots. When in battle with a Rebel leader, subtracts 1 from opponent's total battle destiny.",
         "icons": [
@@ -27707,7 +27742,7 @@
       "front": {
         "deploy": "2",
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Protocol Droid"
         ],
@@ -27827,7 +27862,7 @@
         ],
         "deploy": "0",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "5",
         "gametext": "When in a battle, if both players draw only one battle destiny and yours is higher, reduces opponent's total battle destiny to zero. Landspeed = 3. Adds 2 to power of anything she pilots. May not be aboard starfighters or enclosed vehicles.",
         "icons": [
@@ -28302,7 +28337,7 @@
         ],
         "deploy": "3",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "5",
         "gametext": "When at a site and opponent is losing Force from Force drains at cloud sectors on same planet, lost Force must come from Reserve Deck, if possible.",
         "icons": [
@@ -28429,7 +28464,7 @@
         ],
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "Adds 2 to the power of anything he pilots. When at a system, sector, or docking bay, once during each of your deploy phases, subtracts 2 from deploy cost of your unique (•) X-wing deploying here.",
         "icons": [
@@ -29061,7 +29096,7 @@
           "dejarik"
         ],
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your side of table. For each unit of ability you have present during a battle, you may use 1 Force to raise your total power by 1. Ability used in this way cannot also be used to draw destiny.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/klorslug.gif",
         "lore": "Dejarik hologram of venomous swamp creature from Noe'ha'on. Keen senses of smell and vision. Dangerous hunter. Lays eggs - hundreds of ravenously hungry hatchlings.",
@@ -29100,7 +29135,7 @@
           "dejarik"
         ],
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on table. If your character, starship, or vehicle in battle is about to be lost before the damage segment, it is instead lost at end of battle (if forfeited, forfeit for 0). (Immune to Alter.)",
         "icons": [
           "Set 0"
@@ -29304,7 +29339,7 @@
         ],
         "deploy": "3",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Attuned"
         ],
@@ -29599,7 +29634,7 @@
         ],
         "deploy": "6",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Attuned"
         ],
@@ -29946,7 +29981,7 @@
       "counterpart": "Pride Of The Empire",
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If opponent just lost a starship in a battle you won, deploy on your participating starfighter. Once during each of opponent's move phases, opponent loses 1 Force (2 if starfighter is Falcon or Red 5). Also, that starfighter is power +2 (Immune to Control.)",
         "icons": [
           "Special Edition"
@@ -30109,7 +30144,7 @@
     {
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on Leia (or your female of ability < 4). Opponent may not cancel or reduce Force drains at same battleground. If on Leia, she is power +2 and, once per battle, may cancel the game text of an opponent's leader of ability < 4 here.",
         "icons": [
           "Set 5"
@@ -30322,7 +30357,7 @@
         ],
         "deploy": "4",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Sensitive"
         ],
@@ -30461,7 +30496,7 @@
           "blaster"
         ],
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to deploy on Leia, or 2 on your warrior. May target a character, creature or vehicle for free. Draw destiny. Target hit if destiny -1 > defense value. If hit by Leia, target's forfeit = 0.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/leiassportingblaster.gif",
         "lore": "Defender sporting blaster, made by Drearian Defense Conglomerate. Intended for personal defense or small-game hunting. Short range. Low power. Carries energy for 50 shots.",
@@ -30507,7 +30542,7 @@
         ],
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "2",
         "gametext": "Adds 3 to power of anything she pilots. While at Audience Chamber, adds 2 to the power bonus provided by Ellorrs Madak.",
         "icons": [
@@ -30582,7 +30617,7 @@
       ],
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "During a battle at a holosite, add one battle destiny. OR Target an opponent's character of ability < 5 present with your Wookiee that just participated in a battle you lost; character is Disarmed (power -1 and may no longer carry weapons). Stack on that character.",
         "icons": [
           "A New Hope"
@@ -31271,7 +31306,7 @@
         "ability": "2",
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "Adds 2 to power of anything he pilots. When at a system, sector or docking bay, once during each of your deploy phases, subtracts 2 from deploy cost of your unique (•) Y-wing deploying there.",
         "icons": [
@@ -31544,7 +31579,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your character with ability > 2 and a lightsaber. That character is power +3 in battles or may add 1 to Force drain where present. Effect is lost if character loses lightsaber.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/lightsaberproficiency.gif",
         "lore": "A Jedi learns not only to wield a lightsaber, but how to channel the Force to increase skill and control the lightsaber's damage.",
@@ -31585,7 +31620,7 @@
       "conceptBy": "(Original concept by Chris Kelly)",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If an Endor site on table, deploy on table. [Death Star II] Luke is deploy = 6 and may not be Disarmed. If Luke is at a battleground (even as a captive), your battle destiny draws are +1 there and, once during your turn, may deploy Luke's Lightsaber from Reserve Deck (reshuffle) or place a card from hand on Force Pile. (Immune to Alter.)",
         "icons": [
           "Set 2"
@@ -31625,7 +31660,7 @@
       "front": {
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Mining Droid"
         ],
@@ -31958,7 +31993,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If one of your pilots is at an exterior Hoth site, use 2 Force to search your Reserve Deck and take one T-47 into hand. OR If your piloted T-47 is defending a battle alone at a site, add one battle destiny.",
         "icons": [
           "Premium"
@@ -32191,7 +32226,7 @@
         "ability": "4",
         "deploy": "3",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Sensitive"
         ],
@@ -32439,7 +32474,7 @@
         ],
         "deploy": "6",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Jedi Knight"
         ],
@@ -32770,7 +32805,7 @@
           "blaster"
         ],
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to deploy on Luke, 3 on your other warrior. May target a character, creature or vehicle using 2 Force (if targeted by Luke, target loses immunity to attrition for remainder of turn.) Draw destiny. Add 1 if targeting a character or creature. Target hit if total destiny > defense value.",
         "icons": [
           "Cloud City"
@@ -32857,7 +32892,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 2 Force to deploy on a Rebel or alien. If Luke's Cape is not at a Tatooine location, your total Force generation is +1. That character is immune to attrition < 3.",
         "icons": [
           "A New Hope"
@@ -32890,7 +32925,7 @@
           "rifle"
         ],
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to deploy on Luke or Owen Lars, 3 on your non-droid character. May target a character or creature using 1 Force. Draw destiny. Subtract 1 if targeting a character. Add 2 if targeting a creature. Target hit if total destiny > defense value.",
         "icons": [
           "A New Hope"
@@ -33076,7 +33111,7 @@
       "front": {
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "May add 1 driver and 2 passengers. Moves free if Luke aboard. May move as a 'react.'",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/lukesx34landspeeder.gif",
@@ -33182,7 +33217,7 @@
       "front": {
         "deploy": "3",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Binary Hydroponics Droid"
         ],
@@ -33516,7 +33551,7 @@
       "counterpart": "Magnetic Suction Tube",
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your sandcrawler. Once during each of your control phases, may target one character present. Draw destiny. If destiny > character's ability, 'suck up' character (relocate to related interior Sandcrawler site or owner's Used Pile).",
         "icons": [
           "A New Hope"
@@ -33557,7 +33592,7 @@
         "ability": "2",
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "5",
         "gametext": "While on Hoth, opponent may not 'react' to any Echo site, and Derlin may use 1 Force to cancel Breached Defenses. While at Cantina, power +1 and may use 1 Force to cancel Local Trouble.",
         "icons": [
@@ -34114,7 +34149,7 @@
           "dejarik"
         ],
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 3 Force to deploy on your side of table (free if C-3PO on table). After losing any battle: characters, starships and vehicles may be forfeited directly from your hand (for forfeit value) to reduce attrition or battle damage.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/mantelliansavrip.gif",
         "lore": "Dejarik game uses holograms of mythological and real creatures from across the galaxy. The hulking Mantellian savrip is a nasty predator from Ord Mantell.",
@@ -34780,7 +34815,7 @@
         ],
         "deploy": "3",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "1",
         "gametext": "Deploy on a site. May be moved by two warriors for 1 additional Force. Your warrior present may target up to two characters or two creatures at same or adjacent site using 2 Force. Draw two destiny. Target(s) hit if total destiny > total defense value.",
         "icons": [
@@ -34978,7 +35013,7 @@
       "counterpart": "Swilla Corey",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your non-thief to give that character thief skill. Once during each of your control phases, may target one device at same site. Draw destiny. If destiny < target's destiny number, it is stolen. OR Deploy on a weapon to prevent theft. (Immune to Alter.)",
         "icons": [
           "A New Hope"
@@ -35381,7 +35416,7 @@
         ],
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "5",
         "gametext": "Adds 2 to power of anything she pilots. When piloting Pulsar Skate, draws one battle destiny if not able to otherwise. Once per turn, may use 1 Force to place a card from hand on bottom of Used Pile and draw top card of Reserve Deck.",
         "icons": [
@@ -35580,7 +35615,7 @@
       "counterpart": "Kuat Drive Yards (V)",
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on table. Star Cruisers (except Profundity) may deploy -2 (to a maximum of -3), ignore deployment restrictions in their game text, draw one battle destiny if not able to otherwise, and are immune to attrition < 4. (Immune to Alter.)",
         "icons": [
           "Death Star II",
@@ -35739,7 +35774,7 @@
           "blaster"
         ],
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to deploy on your alien warrior (free if on Tatooine). May target a character for free. Draw destiny. Target is forfeit -2 for remainder of turn if destiny +2 > defense value.",
         "icons": [
           "Jabba's Palace"
@@ -35772,7 +35807,7 @@
       "front": {
         "darkSideIcons": 1,
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploys for 1 Force to an unoccupied site. Deploys and moves like an undercover spy. When present with Motti (or pilot) of ability < 3, choose one to be immediately lost (treat as an 'all cards' situation). Seeker also lost.",
         "icons": [
           "A New Hope"
@@ -35827,7 +35862,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Target one starfighter participating in a battle at a system or sector. For remainder of turn, starfighter may not move, is immune to attrition and, if piloted by any Corellian, is power +2.",
         "icons": [
           "Dagobah"
@@ -35934,7 +35969,7 @@
         ],
         "deploy": "3",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "SWARM: 3"
         ],
@@ -36177,7 +36212,7 @@
       "front": {
         "darkSideIcons": 2,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Light:  Once per game may take Gungan Energy Shield into hand from Reserve Deck; reshuffle.  Dark:  Your AATs deploy +1 here.",
         "icons": [
           "Exterior",
@@ -36435,7 +36470,7 @@
       "front": {
         "darkSideIcons": 2,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Light:  Any characters of ability < 5 'hit' here (and all cards on them) are placed in owner's Used Pile.  Dark:  Any characters of ability < 5 'hit' here (and all cards on them) are placed in owner's Used Pile.",
         "icons": [
           "Interior",
@@ -36585,7 +36620,7 @@
       "counterpart": "Elis Helrot",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "At any time (except during battle), target any or all of your characters at one site to 'transport' (relocate) to any one other site. Draw destiny. Use that much Force to 'transport,' or place Interrupt in Lost Pile.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/nabrunleids.gif",
         "lore": "Four-armed smuggler and pilot for hire. A Morseerian male. Breathes methane. Former fighter pilot. He can take you anywhere for the right price.",
@@ -36896,7 +36931,7 @@
       ],
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If opponent just initiated battle at a site where you have a Rebel of ability > 2 present, move all of your cards with ability there away (using their landspeed).",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/narrowescape.gif",
         "lore": "Blast doors seal off compartments during battles, hull ruptures or as security measures. Thick doors repel blaster rifle shots.",
@@ -37376,7 +37411,7 @@
         ],
         "deploy": "1",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "CAMOUFLAGE: 1"
         ],
@@ -37459,7 +37494,7 @@
         ],
         "deploy": "5",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Jedi Knight"
         ],
@@ -37859,7 +37894,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 2 Force to deploy on your Rebel or alien. Character is immune to attrition < 5. Also, When a battle was just initiated where present, may use 1 Force to choose one opponent's character of ability = 1 present to move away (for free), or that character is lost.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/obiwanscape.gif",
         "lore": "A symbol of the noble Jedi and his mysterious powers.",
@@ -37892,7 +37927,7 @@
       ],
       "front": {
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on Luke or Obi-Wan. Your characters present armed with a unique (•) lightsaber Weapon card may not be Disarmed, once per battle may cancel a weapon destiny just drawn, and that lightsaber's Force drain modifiers may not be canceled. Lost if about to be stolen.",
         "icons": [
           "Reflections 2"
@@ -38035,7 +38070,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If your character is about to be hit, use 1 Force (free if by a [Permanent Weapon] weapon); for remainder of turn, its forfeit may not be reduced, it may not be used to satisfy attrition, and it is immune to Dr. Evazan. OR Cancel Disarmed. (Immune to Sense.) OR Cancel a 'react.' OR During your move phase, target any or all of your characters at one site to 'transport' (relocate) to an exterior or battleground site. Draw destiny. Use that much Force to 'transport,' or place Interrupt in Lost Pile.",
         "icons": [
           "Coruscant",
@@ -38214,8 +38249,10 @@
       ],
       "back": {
         "destiny": "7",
-        "errataVersion": "E1",
-        "gametext": "Old Allies:Deploy Jakku system and Niima Outpost Shipyard (with [Episode VII] Falcon there). May deploy Graveyard Of Giants.{For} remainder of game, you may not deploy Harc Seff, Luke, or Jedi. Your Destiny is suspended. Opponent's [Reflections 2] objective targets Rey instead of Luke. While Rey at a battleground site, Visage Of The Emperor is suspended.{While} this side up, once per turn, may deploy a Jakku location from Reserve Deck; reshuffle.{Flip} this card if you control Jakku system and occupy two Jakku battleground sites (or vice versa).We Need Your Help{While} this side up, once per turn, may deploy a Jakku location from Reserve Deck; reshuffle. Once during opponent's control phase, if you control two Jakku battlegrounds and are about to lose Force (except to a Force drain at a Jakku location), may reduce that Force loss to 1 (may not be further reduced). Once per battle involving your Resistance character, may subtract 2 from a just drawn destiny. While with Han, your [Episode VII] characters and [Episode VII] starships are defense value +2.{Flip} this card if you do not occupy two battlegrounds.",
+        "errataDate": "2022-12-12",
+        "errataNotes": "E1 version allowed subtracting 2 from a destiny 'once per battle' instead of 'once per turn during battle'. The Jakku location pull used to be in the While section of both sides (no gameplay difference).",
+        "errataSymbol": "E2",
+        "gametext": "Old Allies: Deploy Jakku system and Niima Outpost Shipyard (with [Episode VII] Falcon there). May deploy Graveyard Of Giants. For remainder of game, you may not deploy Combined Fleet Action, Harc Seff, Luke, or Jedi. Your Destiny is suspended. Opponent's [Reflections 2] objective targets Rey instead of Luke. While Rey at a battleground site, Visage Of The Emperor is suspended. Once per turn, may deploy a Jakku location from Reserve Deck; reshuffle. Flip this card if you control Jakku system and occupy two Jakku battleground sites (or vice versa). We Need Your Help: While this side up, once during opponent's control phase, if you control two Jakku battlegrounds and are about to lose Force (except to a Force drain at a Jakku location), may reduce that Force loss to 1 (may not be further reduced). Once per turn, during battle involving your Resistance character, may subtract 2 from a just drawn destiny. While with Han, your [Episode VII] characters and [Episode VII] starships are defense value +2. Flip this card if you do not occupy two battlegrounds.",
         "icons": [
           "Premium",
           "Episode VII",
@@ -38227,8 +38264,10 @@
       },
       "front": {
         "destiny": "0",
-        "errataVersion": "E1",
-        "gametext": "Old Allies:Deploy Jakku system and Niima Outpost Shipyard (with [Episode VII] Falcon there). May deploy Graveyard Of Giants.{For} remainder of game, you may not deploy Harc Seff, Luke, or Jedi. Your Destiny is suspended. Opponent's [Reflections 2] objective targets Rey instead of Luke. While Rey at a battleground site, Visage Of The Emperor is suspended.{While} this side up, once per turn, may deploy a Jakku location from Reserve Deck; reshuffle.{Flip} this card if you control Jakku system and occupy two Jakku battleground sites (or vice versa).We Need Your Help:{While} this side up, once per turn, may deploy a Jakku location from Reserve Deck; reshuffle. Once during opponent's control phase, if you control two Jakku battlegrounds and are about to lose Force (except to a Force drain at a Jakku location), may reduce that Force loss to 1 (may not be further reduced). Once per battle involving your Resistance character, may subtract 2 from a just drawn destiny. While with Han, your [Episode VII] characters and [Episode VII] starships are defense value +2.{Flip} this card if you do not occupy two battlegrounds.",
+        "errataDate": "2022-12-12",
+        "errataNotes": "E1 version allowed Combined Fleet Action. The Jakku location pull used to be in the While section of both sides (no gameplay difference).",
+        "errataSymbol": "E2",
+        "gametext": "Old Allies: Deploy Jakku system and Niima Outpost Shipyard (with [Episode VII] Falcon there). May deploy Graveyard Of Giants. For remainder of game, you may not deploy Combined Fleet Action, Harc Seff, Luke, or Jedi. Your Destiny is suspended. Opponent's [Reflections 2] objective targets Rey instead of Luke. While Rey at a battleground site, Visage Of The Emperor is suspended. Once per turn, may deploy a Jakku location from Reserve Deck; reshuffle. Flip this card if you control Jakku system and occupy two Jakku battleground sites (or vice versa). We Need Your Help: While this side up, once during opponent's control phase, if you control two Jakku battlegrounds and are about to lose Force (except to a Force drain at a Jakku location), may reduce that Force loss to 1 (may not be further reduced). Once per turn, during battle involving your Resistance character, may subtract 2 from a just drawn destiny. While with Han, your [Episode VII] characters and [Episode VII] starships are defense value +2. Flip this card if you do not occupy two battlegrounds.",
         "icons": [
           "Premium",
           "Episode VII",
@@ -38241,6 +38280,7 @@
       "gempId": "204_32",
       "id": 5776,
       "legacy": false,
+      "previousId": 40013,
       "printings": [
         {
           "set": "204"
@@ -38258,7 +38298,7 @@
       ],
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force if any of your characters (except Obi-Wan) was just forfeited from a Tatooine site. Mysterious 'crazy wizard' steps in and revives (returns from Lost Pile) that character back to same site.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/oldben.gif",
         "lore": "'That old man's just a crazy wizard.' Obi-Wan lived in Tatooine's deserts for years...ready for the right moment to act.",
@@ -38402,7 +38442,7 @@
     {
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If you are about to draw power harpoon weapon destiny, add ability of one pilot aboard same vehicle.",
         "icons": [
           "Hoth"
@@ -38571,7 +38611,7 @@
       "front": {
         "darkSideIcons": 1,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Light:  If you control, each of opponent's bounty hunters is forfeit -2.  Dark:  Each of your bounty hunter pilots add an additional 1 to power of starships they pilot here.",
         "icons": [
           "Planet",
@@ -38964,7 +39004,7 @@
       ],
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If opponent just initiated a battle at a system or sector where you have a starship with maneuver > 3, use 1 Force to add one battle destiny.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/outofnowhere.gif",
         "lore": "Black market sensor-stealth arrays can be used to hide starships from enemy sensor scans. Stellar interference can naturally shield a starship for surprise attacks.",
@@ -39116,7 +39156,7 @@
         "ability": "3",
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Attuned"
         ],
@@ -39469,7 +39509,7 @@
         ],
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "2",
         "gametext": "Adds 2 to power of anything he pilots. While at Audience Chamber, all your Corellians are power and forfeit +1 (+2 if non-unique) and your Force generation at the Corellia system is +2.",
         "icons": [
@@ -39629,7 +39669,7 @@
       "counterpart": "Emergency Deployment",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If opponent just initiated a battle where opponent has more than double your power, reveal up to 3 cards from your Reserve Deck. Of those 3, deploy anywhere (for free) any characters, starships, vehicles, devices or weapons. Any others are lost.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/panic.gif",
         "lore": "Cornered by Imperial troops, Han's gambler reflexes led him to do what comes naturally - attack! Surprise assaults work...sometimes.",
@@ -40004,7 +40044,7 @@
         ],
         "deploy": "4",
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "Deploy on an exterior Rebel Base site. During a battle at related system, may target a capital starship there using 2 Force. Draw destiny. If destiny +3 > armor, all starship weapons aboard target are lost, power = 0 and hyperspeed = 0.",
         "icons": [
@@ -40067,7 +40107,7 @@
     {
       "front": {
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Plays on any site. This location may not be targeted by Proton Bombs. Cancels Program Trap here. Unless Death Star: Docking Bay 327 on table, Commence Primary Ignition is canceled.",
         "icons": [
           "Defensive Shield",
@@ -40103,7 +40143,7 @@
       ],
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on a Death Star site where a stormtrooper was just lost. Target one of your characters not on Death Star. When target reaches Utinni Effect, relocate to target. Target is now 'disguised:' gains spy skill, power and forfeit +2, and armor = 5.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/plastoidarmor.gif",
         "lore": "Luke and Han took the armor suits from fallen stormtroopers and used them as both protection and disguise to penetrate the detention cell block aboard the Death Star.",
@@ -40405,7 +40445,7 @@
         "ability": "2",
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "Adds 2 to power of anything he pilots. When piloting Gold 5, also adds 1 to maneuver and draws one battle destiny if not able to otherwise.",
         "icons": [
@@ -40605,7 +40645,7 @@
       ],
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 2 Force to deploy on your combat or shuttle vehicle. May target an AT-AT or AT-ST for 1 Force. Draw destiny. Target crashes if destiny + your vehicle's maneuver > 8. Your vehicle crashes if destiny = 0.",
         "icons": [
           "Hoth"
@@ -40713,7 +40753,7 @@
         ],
         "deploy": "4",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Sensitive"
         ],
@@ -40997,7 +41037,6 @@
       "id": 1948,
       "legacy": false,
       "matchingWeapon": [
-        "Anakin's Lightsaber (V)",
         "Leia's Blaster Rifle",
         "Leia's Sporting Blaster"
       ],
@@ -41210,7 +41249,7 @@
           "proton torpedoes"
         ],
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to deploy on your X-wing, Y-wing or B-wing. May target a starship using 1 Force. Draw destiny. Target hit if destiny > defense value.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/protontorpedoes.gif",
         "lore": "Powerful ballistic projectiles. Carries proton-scattering energy warheads. Short range. Pierces energy shields, but blocked by particle shields.",
@@ -41245,7 +41284,7 @@
           "proton torpedoes"
         ],
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to deploy on your N-1 starfighter. May target a starship using 1 Force. Draw Destiny. Target hit if destiny > defense value. While on Bravo Fighter and you are attempting to 'blow away' Blockade Flagship, adds 2 to your total.",
         "icons": [
           "Episode I",
@@ -41283,7 +41322,7 @@
         ],
         "deploy": "3",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "While on Cloud City, adds 1 to your Force drains at Cloud City sites and adds 4 to destiny of each of your miners drawn for battle destiny. During your deploy phase, may deploy one non-unique Rebel to same Cloud City site from Reserve Deck; reshuffle.",
         "icons": [
@@ -41396,7 +41435,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If Han or your Lando is piloting a starfighter which is defending a battle at a system, add one battle destiny (add two if starfighter is Falcon). Also, starfighter is immune to attrition for remainder of turn.",
         "icons": [
           "Cloud City"
@@ -41428,7 +41467,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If one of your characters was just targeted by a weapon during battle, use 3 Force to cancel that targeting. OR Cancel Double Back or Res Luk Ra'auf.",
         "icons": [
           "Cloud City"
@@ -41486,7 +41525,7 @@
           "laser cannon"
         ],
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 2 Force to deploy on your Corellian Corvette or Falcon. May target a starship using 1 Force. Draw destiny. Add 1 if targeting a starfighter. Target hit if total destiny > defense value.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/quadlasercannon.gif",
         "lore": "Starship blaster, often slung in turret mounts to take advantage of light weight and quick targeting motions. Installed on many starships including the Millennium Falcon.",
@@ -42232,7 +42271,7 @@
         ],
         "deploy": "4",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Astromech & Protocol"
         ],
@@ -42346,7 +42385,7 @@
           2,
           5
         ],
-        "errataVersion": "E2",
+        "errataSymbol": "E2",
         "extraText": [
           "Astromech Droid"
         ],
@@ -42467,7 +42506,7 @@
         ],
         "deploy": "2",
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Astromech Droid"
         ],
@@ -42508,7 +42547,7 @@
         ],
         "deploy": "1",
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Vehicle Droid"
         ],
@@ -42544,7 +42583,7 @@
         ],
         "deploy": "2",
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Astromech Droid"
         ],
@@ -42621,7 +42660,7 @@
       "front": {
         "deploy": "2",
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Servant Droid"
         ],
@@ -43040,7 +43079,7 @@
         ],
         "deploy": "3",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "Adds 2 to power of anything he pilots (or 4 if trained by Rycar Ryjerd). Any starfighter Rayc pilots is immune to Tallon Roll and is not lost if an asteroid sector is drawn for asteroid destiny.",
         "icons": [
@@ -43230,7 +43269,7 @@
     {
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your pilot character. While piloting any starfighter, combat vehicle or shuttle vehicle, that character is considered to be the 'matching pilot' (pilot adds 2 to maneuver (limit +2) and draws one battle destiny if not able to otherwise).",
         "icons": [
           "Dagobah"
@@ -43296,7 +43335,7 @@
         "ability": "1",
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "1",
         "gametext": "Power +4 when defending a battle. Cannot move.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/rebelguard.gif",
@@ -43408,7 +43447,7 @@
         "ability": "2",
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "2",
         "gametext": "Adds 2 to power of anything he pilots.",
         "icons": [
@@ -43446,7 +43485,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to deploy at Massassi War Room or any docking bay. Adds X to your total power at the related system and related sectors, where X = the number of your starships present there.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/rebelplanners.gif",
         "lore": "Rebel strategists worked under master tactician General Dodonna. They devised an unorthodox battle plan to destroy the Death Star at the Battle of Yavin.",
@@ -43505,7 +43544,7 @@
         ],
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "May move as a 'react' (for free) to a battle where you have a Rebel of ability > 2 or a leader.",
         "icons": [
@@ -43579,7 +43618,7 @@
         ],
         "deploy": "2",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Adds 1 to forfeit of your other troopers and Rebel Guards at same site. When moving with a 'squad' of exactly three other troopers and/or Rebel Guards, all four move for 1 Force. Rebel Guards at same site may move.",
         "icons": [
@@ -43633,7 +43672,7 @@
       },
       "front": {
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Rebel Strike Team:Deploy Endor system and Rebel Landing Site.{While} this side up, opponent loses no more than 1 Force from each of your Force drains at Endor locations. Once during each of your deploy phases, may use 2 Force to take one Bunker or Deactivate The Shield Generator into hand from Reserve Deck; reshuffle.{Flip} this card if Bunker 'blown away' or if, during your move phase, you control three exterior Endor sites (with two Rebel scouts at each).{Place} out of play if Endor 'blown away.'Garrison Destroyed:{While} this side up, at each Endor site where you have a Rebel scout, your Force drains may not be modified or canceled by opponent, except by a 'react'. Rebel scouts are immune to attrition < 4. Once during each of your draw phases, may retrieve one Rebel scout of ability < 3. Your Epic Event destiny draws are each +2.{Flip} this card (unless Bunker 'blown away') if, during an opponent's move phase, opponent controls three exterior Endor sites or Endor system.{Place} out of play if Endor is 'blown away'.",
         "icons": [
           "Endor"
@@ -43659,7 +43698,7 @@
         "ability": "1",
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "When at your war room: Cumulatively adds 1 to total of Attack Run. OR Once during each of your control phases, may send this tech to your Used Pile and take Death Star: Trench into hand from Reserve Deck; reshuffle.",
         "icons": [
@@ -43743,7 +43782,7 @@
         ],
         "deploy": "1",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "1",
         "gametext": "Deploys free to same site as a Rebel leader. When forfeited at same site as a Rebel 'veteran' (a leader or non-recruit trooper), also satisfies all remaining attrition against you. Once per turn, may target a non-unique Rebel warrior present; target is power +1 for remainder of turn.",
         "icons": [
@@ -43844,7 +43883,7 @@
     {
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 3 Force. Each player places hand onto Reserve Deck (if possible), then places Used Pile onto Reserve Deck; reshuffle. Each player then draws cards from Reserve Deck equal to the number of cards just placed from hand onto Reserve Deck (if any).",
         "icons": [
           "Dagobah"
@@ -43870,7 +43909,7 @@
     {
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to deploy on your starship. You may deploy cards as a 'react' to a battle at same system or sector.",
         "icons": [
           "A New Hope"
@@ -44060,7 +44099,7 @@
         ],
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "5",
         "gametext": "May add 1 pilot and 1 astromech. Immune to attrition < 3 if Wedge piloting.",
         "hyperspeed": "5",
@@ -44114,7 +44153,7 @@
         ],
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "5",
         "gametext": "May add 1 pilot and 1 astromech.",
         "hyperspeed": "5",
@@ -44162,7 +44201,7 @@
         ],
         "deploy": "3",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "6",
         "gametext": "May add 1 pilot and 1 astromech. Immune to attrition < 4 if Luke piloting. When firing in an Attack Run, adds 1 to total.",
         "hyperspeed": "5",
@@ -44488,7 +44527,7 @@
         ],
         "deploy": "2",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "5",
         "gametext": "Adds 2 to power of anything he pilots. When piloting Red 1, also adds 1 to maneuver and draws one battle destiny if not able to otherwise. Adds 1 to forfeit of each other Red Squadron pilot at same location.",
         "icons": [
@@ -44775,7 +44814,7 @@
         ],
         "deploy": "5",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "Deploy -2 at Yavin 4 or to same location as Red Leader. Permanent pilot provides ability of 2 and adds 2 to power. Proton Torpedoes deploy and fire free aboard.",
         "hyperspeed": "5",
@@ -44892,7 +44931,7 @@
     {
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on Leia. Once during each of your control phases, you may use 3 Force to retrieve 1 Force. Also, when an apprentice, adds 1 to her training destiny.",
         "icons": [
           "Dagobah"
@@ -44956,7 +44995,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to deploy at any site. Moves like a character at normal use of the Force. Once during each of your control phases, may: Select one character present to be power or forfeit +1 for remainder of turn. OR Use 2 Force to cancel any seeker present.",
         "icons": [
           "A New Hope"
@@ -44993,7 +45032,7 @@
       "front": {
         "darkSideIcons": 0,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Light:  Your starships deploy -2 here and are hyperspeed +2 when moving to or from here. Neither player may Force drain here.  Dark:  -",
         "icons": [
           "Space",
@@ -45261,7 +45300,7 @@
       ],
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "USED: At a system or Bespin location, choose: Cancel a just drawn destiny targeting the ability or defense value of your non-Undercover character of ability < 5. OR During battle, draw one battle destiny if unable to otherwise.  LOST: Cancel Close Call.",
         "icons": [
           "Cloud City",
@@ -45433,7 +45472,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on any R-unit droid to give that droid thief skill. Once during each of your control phases, you may use 1 Force to target a weapon or device present. Draw destiny. If destiny > 2, target is 'stolen.' Target may then be transferred for free. Droid may not be Disarmed.",
         "icons": [
           "Dagobah"
@@ -46102,7 +46141,7 @@
         ],
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "5",
         "gametext": "May add 2 pilots or passengers. Immune to attrition < 3 if Zev piloting. May add 2 to search party destiny draw if all pilots aboard are part of that search party.",
         "icons": [
@@ -46278,7 +46317,7 @@
         ],
         "deploy": "2",
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "May add 2 'riders' (passengers). Bantha ability = ½. May move as a 'react.' Whenever a battle was just initiated at same site, one Tusken Raider present (your choice) is 'trampled' (immediately lost).",
         "icons": [
@@ -46314,7 +46353,7 @@
         ],
         "deploy": "1",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "1",
         "gametext": "Adds 1 to weapon destiny draws of anything he is aboard as a passenger.",
         "icons": [
@@ -46536,9 +46575,11 @@
         "ability": "2",
         "deploy": "1",
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataDate": "2022-12-12",
+        "errataNotes": "Original Text was the same as the E1 Text except for a minor wording error. E1 Text: If Finn is about to be lost from same site, may place him in Used Pile instead. During your control phase, if present at a battleground site, and another Resistance character on table (or Paige out of play), may retrieve 1 Force.",
+        "errataSymbol": "E2",
         "forfeit": "2",
-        "gametext": "If Finn is about to be lost from same site, may place him in your Used Pile instead. During your control phase, if present at a battleground site, and another Resistance character on table (or Paige out of play), may retrieve 1 Force.",
+        "gametext": "If Finn is about to be lost from same site, may place him in Used Pile instead. Once during battle, if your starship (or your other Resistance character) here is about to be 'hit' (and Rose is not 'hit'), may cause Rose to be 'hit' (and forfeit = 0) instead.",
         "icons": [
           "Pilot",
           "Warrior",
@@ -46556,12 +46597,17 @@
       "gempId": "209_11",
       "id": 5877,
       "legacy": false,
+      "previousId": 40014,
       "printings": [
         {
           "set": "209"
         }
       ],
       "rarity": "C2",
+      "rulings": [
+        "When Rose uses her text to make herself hit, she always becomes forfeit = 0 (regardless of whether the original target would have been).",
+        "Automatic 'about to be hit' actions (such as Theed Palace Generator Core) happen before optional ones (such as Rose Tico)."
+      ],
       "set": "209",
       "side": "Light"
     },
@@ -46637,7 +46683,7 @@
       ],
       "front": {
         "destiny": "6",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "At any time, move Luke as a regular move (using landspeed for free) to a battle just initiated at an adjacent site. Luke is power +2 during that battle, unless Vader is present or adjacent to the battle site. OR You may cancel Vader's Obsession.",
         "imageUrl": "https://res.starwarsccg.org/cards/PremiereIntroductoryTwoPlayerGame-Light/large/runlukerun.gif",
         "lore": "After seeing Vader strike down Obi-Wan, Luke attacked recklessly until he heard the old Jedi Master's voice warn, 'Run Luke, Run!'",
@@ -46661,7 +46707,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your non-smuggler to give that character smuggler skill. OR Deploy on your smuggler. That character is power +1. (Immune to Alter.)",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/rycarryjerd.gif",
         "lore": "A Bimm trader and smuggler of starship weapons. Trusts no one. Does business with anyone. Teaches smuggler apprentices. Has mastered Jawa language.",
@@ -47025,7 +47071,7 @@
       "counterpart": "Ket Maliss",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your non-warrior character (except droids) to give that character [Warrior] skill. OR Deploy on your warrior. That character is power +1. (Immune to Alter.)",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/saitorrkalfas.gif",
         "lore": "Saurin female from planet Durkteel. Bodyguard of Hrchek, a Saurin droid trader. Sai'torr will teach battle skills to those who prove themselves worthy.",
@@ -47053,7 +47099,7 @@
       "counterpart": "Blaster Rack (V)",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on table. Once per turn, may deploy a matching weapon on your unique (•) character present at a site from Reserve Deck; reshuffle. (Immune to Alter.)",
         "icons": [
           "Set 0"
@@ -47093,7 +47139,7 @@
         ],
         "deploy": "3",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "5",
         "gametext": "Deploys only to a Tatooine site. May add 1 driver and 7 passengers. May relocate only to planet sites. Adds 1 to forfeit of each Jawa at same exterior site.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/sandcrawler.gif",
@@ -47121,7 +47167,7 @@
       "front": {
         "darkSideIcons": 0,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Light:  Deploy on your sandcrawler. Each Jawa is forfeit +2 here. 'Nighttime conditions' here.  Dark:  Your characters may enter/exit here for 1 Force each. 'Nighttime conditions' here.",
         "icons": [
           "Interior",
@@ -47202,7 +47248,7 @@
         ],
         "deploy": "2",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "May add 1 pilot or passenger. Permanent pilot provides ability of 1. May move as a 'react' to Tatooine or desert sites.",
         "icons": [
@@ -47311,7 +47357,7 @@
         "ability": "3",
         "deploy": "4",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Attuned"
         ],
@@ -48068,7 +48114,7 @@
         ],
         "deploy": "3",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "5",
         "gametext": "Agenda: rebellion. Deploys -1 aboard your capital starship. Once per turn, while in a senate majority (or Stolen Data Tapes on table), may take your just drawn battle destiny into hand. Once per game, may deploy Chandrila from Reserve Deck; reshuffle.",
         "icons": [
@@ -48621,7 +48667,7 @@
         ],
         "deploy": "3",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "Whenever you just initiated a battle at same site as Shawn, your troopers at adjacent sites who have not already battled this turn may immediately move to same site (as a regular move).",
         "icons": [
@@ -48987,7 +49033,7 @@
         ],
         "deploy": "3",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Deploy -1 to a Tatooine site. May add 1 driver and 5 passengers. May move as a 'react.' If lost, any characters aboard may 'jump off' (disembark).",
         "icons": [
@@ -49253,7 +49299,7 @@
         ],
         "deploy": "2",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "May add 1 pilot or passenger. Permanent pilot aboard provides ability of 1. May move as a 'react' to Hoth sites.",
         "icons": [
@@ -49341,7 +49387,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If Han is defending a battle alone at a site, add two battle destiny. OR If any alien is defending a battle alone at a site, add one battle destiny.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/solohan.gif",
         "lore": "As a smuggler, Solo must always be alert for trouble, even when appearing relaxed. Bounty hunters are eager to claim the price on the Corellian pirate's head.",
@@ -49365,7 +49411,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your warrior to give that warrior scout skill. That warrior may move as a 'react.' OR Deploy on your scout. When that scout 'reacts,' it is power +2 for remainder of turn. (Immune to Alter.)",
         "icons": [
           "A New Hope"
@@ -49398,7 +49444,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If Han was just lost and Leia is on table (or vice versa), place the just lost character on your Used Pile instead. OR If Leia is present at a site where Han is captive, release Han. OR Cancel a Force drain at a prison.",
         "icons": [
           "Jabba's Palace"
@@ -49462,7 +49508,7 @@
         "ability": "5",
         "deploy": "5",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Sensitive"
         ],
@@ -49523,7 +49569,7 @@
         ],
         "deploy": "2",
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "May add 1 driver and 3 passengers. Moves free if Owen Lars, Beru Lars or Luke aboard. May move as a 'react'.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/sorosuubv35landspeeder.gif",
@@ -49558,7 +49604,7 @@
       "counterpart": "Sniper",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "During your control phase, fire one of your weapons. If Han firing, may add 1 to each weapon destiny draw. (A seeker may be targeted by a character weapon, as if a character with defense value of 4.) Any 'hit' targets are immediately lost.",
         "icons": [
           "A New Hope"
@@ -49855,7 +49901,7 @@
     {
       "front": {
         "destiny": "6",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Sell one of your vehicles or droids at Mos Eisley or same site as Wioslea. Draw two destiny (three destiny if vehicle is Luke's X-34 Landspeeder). The total is the 'offer,' which you must accept. Activate that much Force; then vehicle or droid is lost.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/spaceportspeeders.gif",
         "lore": "Spacesport Speeders buys, trades and sells floater. Wioslea is known as a shrewd bargainer. Luke got 2,000 credits for his X-24 speeder.",
@@ -49961,7 +50007,7 @@
       ],
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to deploy on any starship to add 2 to its armor or maneuver. If on Falcon with Han, Lando or Chewie piloting, also adds 2 to power and forfeit.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/specialmodifications.gif",
         "lore": "Han's 'special modifications' for Millennium Falcon included security mechanisms, deflector shields, hull plating, faster hyperdrive and enhanced weapons.",
@@ -50194,7 +50240,7 @@
     {
       "front": {
         "destiny": "6",
-        "errataVersion": "E2",
+        "errataSymbol": "E2",
         "gametext": "Deploy on Data Vault. At any time, may relocate Stardust to your spy present. During your control phase, if on your spy at a battleground you occupy, opponent loses 1 Force. If about to leave table (for any reason, even if inactive), relocate to Data Vault. (Immune to Alter.)",
         "icons": [
           "Set 9"
@@ -50312,7 +50358,7 @@
     {
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "During your control phase, fire one of your starship weapons (for free). If Han or any gunner is aboard that starship, may add 2 to destiny draw. 'Hit' target is lost. OR If you just fired a weapon in battle, add that weapon's destiny number to your total power.",
         "icons": [
           "Special Edition"
@@ -50396,7 +50442,7 @@
     {
       "front": {
         "destiny": "6",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on R2-D2. If about to leave table (for any reason, even if inactive), relocate to Dune Sea. If at Dune Sea, may relocate to your character there. If at Alderaan (or a 'blown away' system), tapes 'delivered'; relocate this Effect to table and may take any card into hand from Reserve Deck; reshuffle. (Immune to Alter.)",
         "icons": [
           "Set 3"
@@ -50430,7 +50476,7 @@
     {
       "front": {
         "destiny": "6",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on R2-D2. If about to leave table (for any reason, even if inactive), relocate to Dune Sea. If at Dune Sea, may relocate to your character there. If at Alderaan (or a 'blown away' system), tapes 'delivered'; relocate this Effect to table and may take any card into hand from Reserve Deck; reshuffle. (Immune to Alter.)",
         "icons": [
           "Set 3"
@@ -50498,7 +50544,7 @@
     {
       "front": {
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 2 Force to deploy on any Dagobah site. Randomly select two cards from opponent's hand and place them, unseen, face down beneath Stone Pile. Cards return to opponent's hand if Effect leaves table. Canceled if opponent occupies this site.",
         "icons": [
           "Dagobah"
@@ -50948,7 +50994,7 @@
           "cannon"
         ],
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to deploy on your starfighter, free on Falcon. May target a character or creature at same site using 1 Force. Draw destiny. Target hit if destiny +1 > defense value.",
         "icons": [
           "Hoth"
@@ -51090,7 +51136,7 @@
           "ion cannon"
         ],
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 1 Force to deploy on your Y-wing or B-wing. May target a starship using 1 Force. Draw destiny. If destiny > target's defense value, all starship weapons deployed on target are lost, armor or maneuver = 0 and hyperspeed = 0.",
         "icons": [
           "A New Hope"
@@ -51236,7 +51282,7 @@
       ],
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploys for 1 Force to an unoccupied site. Deploys and moves like an undercover spy. When present with Tagge (or warrior) of ability < 3, choose one to be immediately lost (treat as an 'all cards' situation). Seeker is also lost.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/taggeseeker.gif",
         "lore": "Military version of a 'remote.' Programmed to stalk specific targets or secondary targets. Heat and light sensors track with fatal accuracy. Can stow away on starships.",
@@ -51659,7 +51705,7 @@
         "ability": "2",
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Adds 2 to power of anything he pilots. Your starships may move from same exterior site for free. While at Echo Docking Bay, once every turn, may allow one character on Hoth to be immune to The Shield Doors Must Be Closed.",
         "icons": [
@@ -51701,7 +51747,7 @@
         ],
         "deploy": "4",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Attuned"
         ],
@@ -51902,7 +51948,7 @@
       ],
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploys for 1 Force to an unoccupied site. Deploys and moves like an undercover spy. When present with Tarkin (or alien) of ability < 3, choose one to be immediately lost (treat as an 'all cards' situation). Seeker is also lost.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/tarkinseeker.gif",
         "lore": "Military version of a 'remote.' Programmed to stalk specific targets or secondary targets. Heat and light sensors track with fatal accuracy. Can stow away on starships.",
@@ -52384,7 +52430,7 @@
       "front": {
         "darkSideIcons": 1,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Light:  Your characters here aboard vehicles are each power +1.  Dark:  Unless you control Hutt Trade Route, your game text on Tatooine: Jabba's Palace is canceled.",
         "icons": [
           "Exterior",
@@ -52574,7 +52620,7 @@
       "front": {
         "darkSideIcons": 1,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Light:  Beru Lars and Luke deploy -1 here.  Dark:  Add 1 to each of your weapon destiny draws here.",
         "icons": [
           "Exterior",
@@ -52992,7 +53038,7 @@
       "front": {
         "darkSideIcons": 1,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Light:  While you occupy, Force generation +2 here. Immune to Revolution.  Dark:  If Watto present, Force drain +1 here and opponent's battle destiny draws here are -2.",
         "icons": [
           "Exterior",
@@ -53029,7 +53075,7 @@
       "front": {
         "deploy": "1",
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "May add 1 'rider' (passenger). Deploy only on Hoth. Ability = ¼. May move as a 'react' from a battle. May be 'sacrificed' (lost) to make rider immune to Exposure this turn.",
         "icons": [
@@ -53094,7 +53140,7 @@
         ],
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Adds 2 to power of any creature vehicle he rides. When riding a tauntaun, also draws one battle destiny if not able to otherwise.",
         "icons": [
@@ -53594,7 +53640,7 @@
       "back": {
         "deploy": "0",
         "destiny": "7",
-        "errataVersion": "E2",
+        "errataSymbol": "E2",
         "forfeit": "7",
         "gametext": "May not be placed in Reserve Deck. If Falcon about to leave table, place it out of play. May add 2 pilots and 2 passengers. Has ship-docking capability. While [Episode VII] Han or Rey piloting, maneuver +2 and immune to attrition < 4 (< 6 if both). Once during your move phase, if at a site, may flip this card (even if unpiloted).May not be placed in Reserve Deck. If Falcon about to leave table, place it out of play. May add 2 pilots and 2 passengers. Immune to Trample and Unsalvageable, even if unpiloted. While Finn or Rey aboard, immune to attrition < 4 (< 6 if both). Once during your move phase, if piloted, may flip this card.",
         "hyperspeed": "6",
@@ -53724,7 +53770,7 @@
       ],
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If your Padawan or Skywalker is in battle with a Dark Jedi, either add one battle destiny or cancel I Have You Now. OR If Luke is in battle with an opponent's character of ability > 3, add one battle destiny.",
         "icons": [
           "Set 3"
@@ -53756,8 +53802,10 @@
       ],
       "back": {
         "destiny": "7",
-        "errataVersion": "E1",
-        "gametext": "The Galaxy May Need A Legend:Deploy Ahch-To system and any [Episode VII] battleground.{For} remainder of game, Luke deploys only to Ahch-To. You may not Force drain on Ahch-To. You may not deploy [Episode I] locations or non-[Episode VII] Luke. You may not deploy Jedi while a Jedi on table. Once per game, may take any one card into hand from Force Pile; reshuffle. {While} this side up, once per turn, may use 1 Force to deploy an Ahch-To location or [Episode VII] battleground from Reserve Deck; reshuffle. {May flip} this card if Luke on Ahch-To and a battle was just initiated involving a Resistance character. We Need Luke Skywalker:{Immediately} place Luke out of play (ignore [Death Star II] objective restrictions, if any). For remainder of battle, opponent may not fire weapons.{While} this side up, opponent's immunity to attrition is limited to < 5. Once during your turn, may peek at the top card of your Force Pile and Reserve Deck; place both cards (in any order) on top of one of those piles. Where you have two unique (•) Resistance characters: once per turn, if you just Force drained, opponent loses 1 Force; and once per turn during battle, may cancel an opponent's just drawn destiny to cause a re-draw.",
+        "errataDate": "2022-12-12",
+        "errataNotes": "Previous version only prevented opponent from firing weapons, limited immunity to < 5, and instead of Force drain +1, caused 1 direct damage per turn when Force draining with two unique Resistance characters.",
+        "errataSymbol": "E1",
+        "gametext": "The Galaxy May Need A Legend:Deploy Ahch-To system and any [Episode VII] battleground. For remainder of game, Luke deploys only to Ahch-To. You may not Force drain on Ahch-To. You may not deploy [Episode I] locations or non-[Episode VII] Luke. You may not deploy Jedi while a Jedi on table. Once per game, may take any one card into hand from Force Pile; reshuffle. While this side up, once per turn, may use 1 Force to deploy an Ahch-To location or [Episode VII] battleground from Reserve Deck; reshuffle. May flip this card if Luke on Ahch-To and a battle was just initiated involving a Resistance character. We Need Luke Skywalker: Immediately place Luke out of play (ignore [Death Star II] objective restrictions, if any). For remainder of battle, weapons may not be fired. While this side up, opponent's immunity to attrition is limited to < 6. Once during your turn, may peek at the top card of your Force Pile and Reserve Deck; place both cards (in any order) on top of one of those piles. Where you have two unique (•) Resistance characters, your Force drains are +1 and, once per turn during battle, may cancel an opponent's just drawn destiny to cause a redraw.",
         "icons": [
           "Episode VII",
           "Set 11"
@@ -53768,8 +53816,8 @@
       },
       "front": {
         "destiny": "0",
-        "errataVersion": "E1",
-        "gametext": "The Galaxy May Need A Legend:Deploy Ahch-To system and any [Episode VII] battleground.{For} remainder of game, Luke deploys only to Ahch-To. You may not Force drain on Ahch-To. You may not deploy [Episode I] locations or non-[Episode VII] Luke. You may not deploy Jedi while a Jedi on table. Once per game, may take any one card into hand from Force Pile; reshuffle. {While} this side up, once per turn, may use 1 Force to deploy an Ahch-To location or [Episode VII] battleground from Reserve Deck; reshuffle. {May flip} this card if Luke on Ahch-To and a battle was just initiated involving a Resistance character. We Need Luke Skywalker:{Immediately} place Luke out of play (ignore [Death Star II] objective restrictions, if any). For remainder of battle, opponent may not fire weapons.{While} this side up, opponent's immunity to attrition is limited to < 5. Once during your turn, may peek at the top card of your Force Pile and Reserve Deck; place both cards (in any order) on top of one of those piles. Where you have two unique (•) Resistance characters: once per turn, if you just Force drained, opponent loses 1 Force; and once per turn during battle, may cancel an opponent's just drawn destiny to cause a re-draw.",
+        "errataSymbol": "E1",
+        "gametext": "The Galaxy May Need A Legend:Deploy Ahch-To system and any [Episode VII] battleground. For remainder of game, Luke deploys only to Ahch-To. You may not Force drain on Ahch-To. You may not deploy [Episode I] locations or non-[Episode VII] Luke. You may not deploy Jedi while a Jedi on table. Once per game, may take any one card into hand from Force Pile; reshuffle. While this side up, once per turn, may use 1 Force to deploy an Ahch-To location or [Episode VII] battleground from Reserve Deck; reshuffle. May flip this card if Luke on Ahch-To and a battle was just initiated involving a Resistance character. We Need Luke Skywalker: Immediately place Luke out of play (ignore [Death Star II] objective restrictions, if any). For remainder of battle, weapons may not be fired. While this side up, opponent's immunity to attrition is limited to < 6. Once during your turn, may peek at the top card of your Force Pile and Reserve Deck; place both cards (in any order) on top of one of those piles. Where you have two unique (•) Resistance characters, your Force drains are +1 and, once per turn during battle, may cancel an opponent's just drawn destiny to cause a redraw.",
         "icons": [
           "Episode VII",
           "Set 11"
@@ -53781,6 +53829,7 @@
       "gempId": "211_36",
       "id": 5961,
       "legacy": false,
+      "previousId": 40016,
       "printings": [
         {
           "set": "211"
@@ -53790,7 +53839,8 @@
       "rulings": [
         "While a Jedi on table, also cannot use persona replacement to replace a Jedi with a Jedi, or to replace a non-Jedi with a Jedi.",
         "Be With Me creates an exception to the above ruling, allowing Set 14 Rey to deploy (and thereby also allowing her to persona replace another Rey).",
-        "(0 side) May flip even if the Resistance character is introduced to the battle during the 'battle just initiated' responses (e.g. Light may deploy Finn as a react, then flip)."
+        "(0 side) May flip even if the Resistance character is introduced to the battle during the 'battle just initiated' responses (e.g. Light may deploy Finn as a react, then flip).",
+        "(7-side) When calculating immunity to attrition, start with the base immunity and apply any modifiers. Finally, apply the limit of < 6 from this Objective last."
       ],
       "set": "211",
       "side": "Light"
@@ -53868,7 +53918,7 @@
       ],
       "back": {
         "destiny": "7",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "The Hyperdrive Generator's Gone:Deploy Watto's Junkyard, City Outskirts, and Credits Will Do Fine.{For} remainder of game, you may not deploy cards with ability except unique (•) aliens, Republic characters and starships, and [Episode I] Jedi. Your Destiny is suspended. While this side up, once per game may take Coruscant and/or Tatooine system into hand from Reserve Deck; reshuffle. You may not deploy any systems. Maul is immune to attrition.{Flip} this card if there are 4 or more cards beneath Credits Will Do Fine.We'll Need A New One:{While} this side up, your unique (•) Republic characters are power +1 and forfeit +2. Aliens may not have their deploy cost modified and Imperials deploy +1 to Tatooine sites. Whenever you draw battle destiny (unless canceled), may retrieve 1 Force (Force retrieved in this way may be taken into hand.) While Queen's Royal Starship at a planet system, once during each of opponent's control phases may activate up to 2 Force. Once during each of your control phases, opponent loses 1 Force for each battleground site you occupy with a senator.",
         "icons": [
           "Episode I",
@@ -54265,10 +54315,12 @@
     {
       "front": {
         "destiny": "0",
-        "gametext": "Plays on Your Destiny unless Leia or Luke has been deployed this game (even as a captive). [Death Star II] Luke and We're The Bait are lost. Opponent's Objective and [Death Star II] Effects target Leia instead of Luke. Force loss from Take Your Father's Place is -1.",
+        "errataDate": "2022-12-12",
+        "errataNotes": "Original had a Reflections III icon. Original Text: Plays on Your Destiny unless Leia or Luke has been deployed this game (even as a captive). [Death Star II] Luke and We're The Bait are lost. Opponent's Objective and [Death Star II] Effects target Leia instead of Luke. Force loss from Take Your Father's Place is -1.",
+        "errataSymbol": "E1",
+        "gametext": "Plays on Your Destiny unless Leia or Luke has been deployed this game (even as a captive). We're The Bait is lost. Opponent's Objective and [Death Star II] Effects target Leia instead of Luke. Attempts to cross Leia over are -2. Opponent loses no Force to their Objective.",
         "icons": [
           "Defensive Shield",
-          "Reflections 3",
           "Set D"
         ],
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/thereisanother.gif",
@@ -54280,6 +54332,7 @@
       "gempId": "209_15",
       "id": 5971,
       "legacy": false,
+      "previousId": 40017,
       "printings": [
         {
           "set": "209"
@@ -54312,7 +54365,7 @@
       },
       "front": {
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "There Is Good In Him:Deploy Chief Chirpa's Hut (with [Death Star II] Luke and Luke's Lightsaber there), Endor: Landing Platform and I Feel The Conflict.{For} remainder of game, you may not play Alter, Strangle, or Captive Fury.{While} this side up, your Force generation is +2 at Luke's site. While an Imperial is at Landing Platform, you may not Force drain or generate Force at Luke's location. When any Imperial is at Luke's site, Luke is captured (seized by an Imperial, if possible, even if not a warrior).{Flip} this card if Luke captured.I Can Save Him:{While} this side up, at end of each of opponent's turns, opponent loses 2 Force unless Vader is escorting Luke. At any time, an Imperial escorting Luke may transfer Luke to Vader, if present with Vader. Vader may not transfer Luke. Once during each of your turns, if Vader present with Luke (even as a non-frozen captive), may shuffle Reserve Deck and draw destiny. If destiny > 14, Vader crosses to Light Side, totally depleting opponent's Life Force.{Flip} if Luke neither present with Vader nor a captive.",
         "icons": [
           "Death Star II"
@@ -54382,7 +54435,7 @@
         ],
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "Adds 2 to the power of anything he pilots. While at a battleground system, opponent's starships may not 'cloak.' May lose 1 Force (free if piloting Red 10) to cancel a just-drawn weapon destiny targeting a starship he is piloting.",
         "icons": [
@@ -54419,8 +54472,8 @@
       ],
       "back": {
         "destiny": "7",
-        "errataVersion": "E1",
-        "gametext": "They Have No Idea We're Coming:Deploy Scarif system, Data Vault (with Stardust there), and Massassi War Room.{For} remainder of game, you may not deploy Jedi. Baze, Chirrut, and Rebel troopers are spies.{While} this side up, once per turn, may deploy a Rebel starship (except Home One or [Reflections 3] Falcon) or a Scarif site from Reserve Deck; reshuffle. {Flip} this card if you control two Scarif locations.Until We Win, Or The Chances Are Spent:{While} this side up, your spies are defense value +2 (and power +1 if with Stardust) and are immune to Undercover. While Stardust on your spy, opponent may not cancel your Force drains at battlegrounds. Once per turn, may place a Rebel in your Lost Pile out of play to make a regular move with your Rebel spy during your control phase or cancel an attempt to target your non-Undercover Rebel spy with a weapon.{Flip} this card if you do not occupy two Scarif locations (unless Rogue One at a Scarif site you occupy).",
+        "errataSymbol": "E1",
+        "gametext": "They Have No Idea We're Coming: Deploy Scarif system, Data Vault (with Stardust there), and Massassi War Room. For remainder of game, Baze, Chirrut, and Rebel troopers are spies. You may not deploy Taking Them With Us or Jedi. While this side up, once per turn, may deploy Rogue One, a corvette, or a Scarif site from Reserve Deck; reshuffle. Flip this card if you control two Scarif locations. Until We Win, Or The Chances Are Spent: While this side up, your spies are defense value +2 (and power +1 if with Stardust) and are immune to Undercover. While Stardust on your spy, opponent may not cancel your Force drains at battlegrounds. Once per turn, may place a Rebel in your Lost Pile out of play to make a regular move with your Rebel spy during your control phase or cancel an attempt to target your non-Undercover Rebel spy with a weapon. Flip this card if you do not occupy two Scarif locations (unless Rogue One at a Scarif site you occupy).",
         "icons": [
           "Premium",
           "Set 9"
@@ -54431,8 +54484,10 @@
       },
       "front": {
         "destiny": "0",
-        "errataVersion": "E1",
-        "gametext": "They Have No Idea We're Coming:Deploy Scarif system, Data Vault (with Stardust there), and Massassi War Room.{For} remainder of game, you may not deploy Jedi. Baze, Chirrut, and Rebel troopers are spies.{While} this side up, once per turn, may deploy a Rebel starship (except Home One or [Reflections 3] Falcon) or a Scarif site from Reserve Deck; reshuffle. {Flip} this card if you control two Scarif locations.Until We Win, Or The Chances Are Spent:{While} this side up, your spies are defense value +2 (and power +1 if with Stardust) and are immune to Undercover. While Stardust on your spy, opponent may not cancel your Force drains at battlegrounds. Once per turn, may place a Rebel in your Lost Pile out of play to make a regular move with your Rebel spy during your control phase or cancel an attempt to target your non-Undercover Rebel spy with a weapon.{Flip} this card if you do not occupy two Scarif locations (unless Rogue One at a Scarif site you occupy).",
+        "errataDate": "2022-12-12",
+        "errataNotes": "E1 version allowed Taking Them With Us, and could pull any Rebel starship except Home One or Reflections III Falcon.",
+        "errataSymbol": "E2",
+        "gametext": "They Have No Idea We're Coming: Deploy Scarif system, Data Vault (with Stardust there), and Massassi War Room. For remainder of game, Baze, Chirrut, and Rebel troopers are spies. You may not deploy Taking Them With Us or Jedi. While this side up, once per turn, may deploy Rogue One, a corvette, or a Scarif site from Reserve Deck; reshuffle. Flip this card if you control two Scarif locations. Until We Win, Or The Chances Are Spent: While this side up, your spies are defense value +2 (and power +1 if with Stardust) and are immune to Undercover. While Stardust on your spy, opponent may not cancel your Force drains at battlegrounds. Once per turn, may place a Rebel in your Lost Pile out of play to make a regular move with your Rebel spy during your control phase or cancel an attempt to target your non-Undercover Rebel spy with a weapon. Flip this card if you do not occupy two Scarif locations (unless Rogue One at a Scarif site you occupy).",
         "icons": [
           "Premium",
           "Set 9"
@@ -54444,12 +54499,13 @@
       "gempId": "209_29",
       "id": 5974,
       "legacy": false,
+      "previousId": 40018,
       "printings": [
         {
           "set": "209"
         }
       ],
-      "rarity": "C",
+      "rarity": "U",
       "rulings": [
         "When deploying a starship from Reserve Deck, if the starship is unpiloted, may combine it with a pilot from hand, allowing deployment to a system or sector.",
         "Once the player initiates the action to deploy a card from Reserve Deck, they must deploy something if possible. Player is <u>required</u> to combine an unpiloted starship with a pilot from hand if that is the only possible option.",
@@ -54526,7 +54582,7 @@
       ],
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Once per game, use 2 Force to deploy on Dantooine system. Target Death Star. Opponent may not play Commence Primary Ignition until target reaches Dantooine, canceling Utinni Effect.",
         "icons": [
           "A New Hope"
@@ -54596,7 +54652,7 @@
       "counterpart": "A Dark Time For The Rebellion (V)",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "USED: Add or subtract 1 from opponent's just drawn destiny. OR Activate 1 Force. LOST: Cancel Close Call, Gravity Shadow, Overwhelmed, or They've Shut Down The Main Reactor. (Immune to Sense.)",
         "icons": [
           "Set 7"
@@ -54659,7 +54715,7 @@
       "counterpart": "Self-Destruct Mechanism",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Lose a droid to cancel all attrition against you at same site this turn. OR Re-target an opponent's weapon to one of your droids at same site as target. If droid is 'hit', use original target's forfeit number.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/thisisallyourfault.gif",
         "lore": "'We seem to be made to suffer. It's our lot in life.'",
@@ -55267,7 +55323,7 @@
         "ability": "2",
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "Adds 2 to power of anything he pilots. When piloting Gold 2, also adds 1 to maneuver and (when in Death Star: Trench) adds 1 to total of Attack Run.",
         "icons": [
@@ -55395,7 +55451,7 @@
         ],
         "deploy": "2",
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Adds 2 to power of anything she pilots. When at any war room, adds 1 to weapon destiny draws of your Planet Defender Ion Cannon on same planet.",
         "icons": [
@@ -55431,7 +55487,7 @@
         ],
         "deploy": "2",
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Adds 2 to power of anything she pilots. Your total battle destiny here is +1 (+2 if piloting a transport). Once per turn, if a battle just ended here, may 'rescue' (retrieve from Lost Pile) a Rebel of ability < 3 forfeited from same location this turn.",
         "icons": [
@@ -55529,7 +55585,7 @@
         "ability": "1",
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "2",
         "gametext": "During your control phase, may 'sell' one Interrupt card from hand. Opponent must use X Force, where X = destiny of that card or entire Force Pile (opponent's choice). Place sold card on opponent's Used Pile and activate X Force.",
         "icons": [
@@ -55729,7 +55785,7 @@
       ],
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on table. Once per turn, may take The Force Is Strong With This One or [Death Star II] Anakin Skywalker into hand from Reserve Deck: reshuffle. May use 2 Force to cancel Dark Jedi Presence or You Are Beaten (unless canceling Uncontrollable Fury). (Immune to Alter.)",
         "icons": [
           "Death Star II"
@@ -56094,7 +56150,7 @@
       ],
       "front": {
         "destiny": "6",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "During your control phase, target a vehicle with armor present with your warrior. Draw destiny. If warrior has a Concussion Grenade or a lightsaber, add 3 to destiny draw (7 if both). Vehicle (and grenade) lost if total destiny > armor.",
         "icons": [
           "Hoth"
@@ -56121,7 +56177,7 @@
       "counterpart": "Undercover",
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on your spy at a site and cross spy to opponent's side.  Spy is now Undercover.  During your deploy phase, may voluntarily 'break cover' (lose Effect) if at a site. (Immune to Alter.)",
         "icons": [
           "A New Hope"
@@ -56285,7 +56341,7 @@
       "front": {
         "deploy": "2",
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "May add 1 pilot. May move as a 'react'. Matching vehicle for any Resistance pilot. Pilot's power = 0, and if targeted by Force Lightning, Trample, or a weapon, may use this card's defense value instead.",
         "icons": [
@@ -56345,7 +56401,7 @@
       "counterpart": "Vehicle Mine",
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy at same exterior site as your mining droid. 'Explodes' if starfighter (use 5 as defense value) or non-creature vehicle deploys or moves to or across same site.  Draw destiny.  Target lost if destiny +2 > defense value.  Vehicle Mine also lost.",
         "icons": [
           "Hoth"
@@ -56379,7 +56435,7 @@
       "counterpart": "Vibro-Ax",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 3 Force to deploy on any alien warrior. Adds 1 to power. May target a character using 1 Force. Both players draw destiny. Target immediately excluded from battle if warrior's power + your destiny > target's power + opponent's destiny.",
         "icons": [
           "Jabba's Palace"
@@ -56462,7 +56518,7 @@
         ],
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "SLITHER: 3"
         ],
@@ -56565,7 +56621,7 @@
         "ability": "2",
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "2",
         "gametext": "Adds 2 to power of anything he pilots. Twice during battle at same system, may use 2 Force to add 2 to any destiny of 2. If present with Tonnika Sisters, Vul and Tonnika Sisters are lost.",
         "icons": [
@@ -56666,7 +56722,7 @@
       "counterpart": "Lone Warrior",
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If any warrior is defending a battle alone at a site, add one battle destiny. OR If Leia is defending a battle alone at a site, add two battle destiny.",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/warriorscourage.gif",
         "lore": "Each Rebel soldier is driven by bravery and a belief in the Rebel Alliance's ideal of freedom. Courageous and quick-thinking Rebels often defeat Imperial legions.",
@@ -56724,7 +56780,7 @@
       ],
       "back": {
         "destiny": "7",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Watch Your Step:Deploy Cantina, Docking Bay 94 and Tatooine System.{For} remainder of game, opponent activates no Force at your Cantina. Your cards with ability are deploy +6 except Luke, smugglers, freighters, and [Independent] starships. Opponent's game text on Kessel is canceled.{While} this side up, once during each of your deploy phases, may take Corellia or Kessel into hand from Reserve Deck; reshuffle.{Flip} this card if you occupy two battlegrounds with smugglers or have completed two Kessel Runs.This Place Can Be A Little Rough:{While} this side up, your Force generation is +1 at each system you control with a smuggler. Opponent's Force generation at non-battleground locations is limited to 1. When you have two or more smugglers in a battle, add one battle destiny. Each of your smugglers is forfeit +2. Once during each turn, may play one interrupt from Lost Pile as if from hand (then place that card out of play). Sense, Alter, and Keep Your Eyes Open may not be played.{Flip} this card if you do not occupy two battlegrounds (unless you have completed two Kessel Runs).",
         "icons": [
           "Reflections 2"
@@ -57101,7 +57157,7 @@
       "front": {
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Maintenance Droid"
         ],
@@ -57141,7 +57197,7 @@
       "front": {
         "deploy": "2",
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Maintenance Droid"
         ],
@@ -57182,7 +57238,7 @@
         ],
         "deploy": "2",
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "6",
         "gametext": "Adds 3 to power of anything he pilots. When piloting Red 2, also adds 2 to maneuver and draws one battle destiny if not able to otherwise. May use 1 Force to take one Corellian Slip into hand from Reserve Deck; reshuffle.",
         "icons": [
@@ -57532,7 +57588,7 @@
       "counterpart": "Mind Tricks Don't Work On Me",
       "front": {
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 3 Force to deploy on table. During the damage segment of a battle your opponent initiated, if you have no cards left that can be forfeited, you may place this Effect out of play to cancel all remaining battle damage. (Immune to Alter.)",
         "icons": [
           "Episode I",
@@ -57642,7 +57698,7 @@
         ],
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "5",
         "gametext": "Adds 1 to weapon destiny draws of anything he is aboard as a passenger (adds 3 if aboard Rogue 3 or with Wedge or Jek).",
         "icons": [
@@ -57796,7 +57852,7 @@
       ],
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Deploy on Emperor or any system. Target one character whose lore uses the word 'Emperor.' Target cannot use ability to draw battle destiny and is excluded from being the 'highest-ability character.' Utinni Effect canceled when reached by target.",
         "icons": [
           "Dagobah"
@@ -57869,7 +57925,7 @@
       "counterpart": "There'll Be Hell To Pay",
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Use 3 Force to deploy on table and stack one just-played interrupt here. To play any new Interrupt of the same name, player must first stack it here and use +1 Force for each Interrupt in stack, even if Interrupt is normally free. (Immune to Control.)",
         "icons": [
           "A New Hope",
@@ -58218,7 +58274,7 @@
         ],
         "deploy": "1",
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "2",
         "gametext": "During your control phase, may use 1 Force to target an opponent's unoccupied transport vehicle or droid present. Draw destiny. If destiny > target's destiny number, use Force equal to target's deploy cost to 'purchase' target (use as if stolen).",
         "imageUrl": "https://res.starwarsccg.org/cards/Premiere-Light/large/wioslea.gif",
@@ -58333,7 +58389,7 @@
       "conceptBy": "(Original concept by Eric Hunter - Gen Con Winner 2002)",
       "front": {
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Unless Massassi Throne Room on table, deploy on table.  Your total Force generation is +1.  Once per game, may use 3 Force to take an Effect that has no deploy cost and deploys on another card into hand from Reserve Deck; reshuffle.  May place this Effect out of play to retrieve 1 Force. (Immune to Alter.)",
         "icons": [
           "Endor",
@@ -58434,7 +58490,7 @@
     {
       "front": {
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If Chewie is defending a battle alone at a site, add two battle destiny.  OR  Use 3 Force to take Chewie into hand from Reserve Deck; reshuffle.  OR  Scare off (lose) one 'mouse' droid on table.",
         "icons": [
           "A New Hope"
@@ -58626,7 +58682,7 @@
         ],
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Once during each of your control phases, may peek at X cards randomly selected from opponent's hand, where X = number of [Dark Side Force] icons at same site. Also, when you are drawing destiny, adds 2 to the destiny of any card with 'scan' in the title.",
         "icons": [
@@ -59159,7 +59215,7 @@
       },
       "front": {
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Yavin 4 Base Operations:Deploy Yavin 4 system and Massassi War Room. May deploy Restore Freedom To The Galaxy.{While} this side up, once per turn, may use 1 Force to deploy a battleground system from Reserve Deck; reshuffle.{Flip} this card if Rebels control two battleground systems (or if four Rebels are on table).The Time To Fight Is Now:{While} this side up, during battles at sites related to systems you occupy, for each piloted unique (•) snub fighter present at that system, your total power is +2. Once during your draw phase, if a system is 'liberated', may place a card from your Lost Pile out of play to retrieve 1 Force.{Flip} this card if you do not occupy two battlegrounds (unless four Rebels are on table).",
         "icons": [
           "Set 8"
@@ -59734,7 +59790,7 @@
     {
       "front": {
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "USED: During opponent's turn, take up to 4 cards from your hand and place them on top of your Force Pile.  LOST: At the start of the damage segment during a battle, before any cards have been forfeited, cause all attrition for both sides to be reduced to 0.",
         "icons": [
           "Reflections 2"
@@ -59763,7 +59819,7 @@
         "ability": "7",
         "deploy": "5",
         "destiny": "1",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Jedi Master"
         ],
@@ -60161,7 +60217,7 @@
     {
       "front": {
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "At the start of the damage segment during a battle, before any cards have been forfeited, cause all attrition for both sides to be reduced to zero.",
         "icons": [
           "Dagobah"
@@ -60742,7 +60798,7 @@
         "ability": "2",
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "3",
         "gametext": "Deploys free to (and power +2 at) a Cloud City, Jabba's Palace, or Maz's Castle location. Once per turn, if you just drew an alien (or [Independent] starship) for destiny, may take that card into hand to cancel and redraw that destiny.",
         "icons": [
@@ -60972,7 +61028,7 @@
         ],
         "deploy": "2",
         "destiny": "2",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "Adds 2 to power of anything he pilots. When piloting Rogue 2, also adds 3 to maneuver and may draw one battle destiny if not able to otherwise.",
         "icons": [
@@ -61045,7 +61101,7 @@
       ],
       "front": {
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Plays on table. Cancels A Dangerous Time and Imperial Supply. Each player may play only one card with 'sabacc' in title each turn. You may cancel an opponent's card with 'sabacc' in title by losing 1 Force from hand.",
         "icons": [
           "Reflections 3",
@@ -61077,7 +61133,7 @@
     {
       "front": {
         "destiny": "5",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "USED: Cancel Elis Helrot or Stunning Leader. (Immune to Sense) OR Cancel a smuggler's game text for remainder of turn. OR Take Mercenary Armor or [Reflections 2] Chewie into hand from Reserve Deck; reshuffle.  LOST: During your move phase, 'break cover' of an Undercover spy.",
         "icons": [
           "A New Hope",
@@ -61110,7 +61166,7 @@
         ],
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "extraText": [
           "Force-Attuned"
         ],
@@ -61487,7 +61543,7 @@
         ],
         "deploy": "4",
         "destiny": "4",
-        "errataVersion": "E2",
+        "errataSymbol": "E2",
         "extraText": [
           "Jedi Master"
         ],
@@ -61659,7 +61715,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E2",
+        "errataSymbol": "E2",
         "gametext": "During any move phase, if I Feel The Conflict on table, take [Endor] Leia or [Dagobah] Luke into hand from Reserve Deck; reshuffle. OR During a battle at a site involving [Death Star II] Luke, choose: Add one destiny to attrition. OR Cancel the game text of a character of ability < 4.",
         "icons": [
           "Death Star II",
@@ -61857,7 +61913,7 @@
       "front": {
         "darkSideIcons": 2,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Light:  Force drain +1 here. For remainder of game, Kessel Run is immune to Alter and may not be canceled. Dark:",
         "icons": [
           "Planet",
@@ -62050,7 +62106,7 @@
         "ability": "2",
         "deploy": "2",
         "destiny": "3",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "forfeit": "4",
         "gametext": "At same and related locations, deploy cost of opponent's characters may not be modified. If you have ten cards in Lost Pile, Force drain +1 here. Once during battle, may add Beaumont's power to another character present; Beaumont is 'hit.'",
         "icons": [
@@ -62201,7 +62257,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Relocate Prophecy Of The Force to a site. OR If Like My Father Before Me on table, take Yoda's Hut or a Death Star II site into hand from Reserve Deck; reshuffle.",
         "icons": [
           "Death Star II",
@@ -62561,7 +62617,10 @@
     {
       "front": {
         "destiny": "5",
-        "gametext": "If Leia imprisoned, deploy on table. [Set 8] Luke is a spy and stormtrooper. Han, Leia, and Luke are immune to Nevar Yalnal and Put All Sections On Alert. Once per turn, may deploy a Death Star site from Reserve Deck; reshuffle. Immune to This Is Some Rescue! (Immune to Alter.)",
+        "errataDate": "2022-12-12",
+        "errataNotes": "Original did not require Leia to have a [Set 20] icon. Original only protected Han, Leia, and Luke. Original did not protect against Physical Choke.",
+        "errataSymbol": "E1",
+        "gametext": "If [Set 20] Leia imprisoned, deploy on table. [Set 8] Luke is a spy and stormtrooper. Chewie, Leia, and stormtroopers are immune to Nevar Yalnal, Physical Choke, and Put All Sections On Alert. Once per turn, may deploy a Death Star site from Reserve Deck; reshuffle. Immune to This Is Some Rescue! [Immune to Alter.]",
         "icons": [
           "Set 15"
         ],
@@ -62574,6 +62633,7 @@
       "gempId": "215_5",
       "id": 6879,
       "legacy": false,
+      "previousId": 40001,
       "printings": [
         {
           "set": "215"
@@ -62638,7 +62698,10 @@
         ],
         "darkSideIcons": 1,
         "destiny": "0",
-        "gametext": "Light:  If you control with a spy, may use 2 Force to release Leia here (retrieve 1 Force).  Dark:  If Leia is about to be lost from a Death Star site, imprison her here instead (even if inactive).",
+        "errataDate": "2022-12-12",
+        "errataNotes": "Original Dark text worked with any Leia, but did not protect against 'all cards' situations: If Leia is about to be lost from a Death Star site, imprison her here instead (even if inactive).",
+        "errataSymbol": "E1",
+        "gametext": "Light:  If you control with a spy, may use 2 Force to release Leia here (retrieve 1 Force).  Dark:  If [Set 20] Leia is about to leave table (for any reason, even if inactive), imprison her here instead.",
         "icons": [
           "Interior",
           "Mobile",
@@ -62655,6 +62718,7 @@
       "gempId": "215_7",
       "id": 6881,
       "legacy": false,
+      "previousId": 40003,
       "printings": [
         {
           "set": "215"
@@ -62663,9 +62727,9 @@
       "rarity": "C",
       "rulings": [
         "When Dark's text imprisons Leia, she is restored to normal (no longer hit or forfeit = 0, etc).",
-        "When Dark's text imprisons Leia, any weapons and other cards on Leia remain on her.",
+        "When Dark's text imprisons Leia, any weapons and other cards on Leia remain on her (she did not leave table).",
         "When Dark's text imprisons Leia from another site, she is placed here but it is not considered movement. It is not blocked by e.g. You Are Beaten.",
-        "Dark's text does not prevent an 'all cards situation', e.g. Program Trap will make Leia go to Lost Pile."
+        "The 'for any reason' text will even work against an 'all cards' situation, e.g. Program Trap will send Leia here instead of the Lost Pile."
       ],
       "set": "215",
       "side": "Light"
@@ -62790,7 +62854,7 @@
         ],
         "deploy": "4",
         "destiny": "1",
-        "errataVersion": "E2",
+        "errataSymbol": "E2",
         "extraText": [
           "Force-Attuned"
         ],
@@ -63476,7 +63540,7 @@
       "front": {
         "darkSideIcons": 0,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Light:  If Yoda here or [Set 16] Yoda 'communing,' Broken Concentration is canceled and, once per turn, you may subtract 2 from attrition against you.  Dark:  -",
         "icons": [
           "Dagobah",
@@ -63557,12 +63621,16 @@
         "Cloud City Occupation",
         "Rebel Base Occupation",
         "Tatooine Occupation",
+        "Force Lightning",
         "Reacts involving a combat vehicle",
-        "Reacts to or from same site as Leia or Luke"
+        "Suspends A Million Voices Crying Out and An Entire Legion Of My Best Troops"
       ],
       "front": {
         "destiny": "5",
-        "gametext": "Cancel Cloud City Occupation, Rebel Base Occupation, or Tatooine Occupation. (Immune to Sense.) OR During your turn, target opponent's spy (or unpiloted combat vehicle) at a site you control; target is lost. OR Cancel an attempt to deploy or move a combat vehicle as a 'react.' OR Cancel a 'react' to or from same site as Leia or Luke.",
+        "errataDate": "2022-12-12",
+        "errataNotes": "Original Text: Cancel Cloud City Occupation, Rebel Base Occupation, or Tatooine Occupation. (Immune to Sense.) OR During your turn, target opponent's spy (or unpiloted combat vehicle) at a site you control; target is lost. OR Cancel an attempt to deploy or move a combat vehicle as a 'react.' OR Cancel a 'react' to or from same site as Leia or Luke.",
+        "errataSymbol": "E1",
+        "gametext": "Cancel Cloud City Occupation, Rebel Base Occupation, or Tatooine Occupation. [Immune to Sense.] OR Cancel Force Lightning (unless targeting an Undercover spy). OR Cancel an attempt to deploy or move a combat vehicle as a 'react.' OR During your turn, target opponent's spy (or unpiloted combat vehicle) at a site you control; target is lost. (Immune to Oh, Switch Off.) OR For remainder of turn, suspend the following cards on table (if any): A Million Voices Crying Out and An Entire Legion Of My Best Troops.",
         "icons": [
           "Coruscant",
           "Set 16"
@@ -63576,6 +63644,7 @@
       "gempId": "216_28",
       "id": 6931,
       "legacy": false,
+      "previousId": 40006,
       "printings": [
         {
           "set": "216"
@@ -63587,7 +63656,9 @@
       ],
       "rarity": "R",
       "rulings": [
-        "This may target an Undercover spy."
+        "Fourth function: This may target an Undercover spy.",
+        "Fourth function: In the event that the target was already protected by Oh, Switch Off earlier in the turn, that card is now protected for remainder of turn and cannot be targeted by this Interrupt.",
+        "Fifth function: This may be played even if neither A Million Voices Crying Out nor An Entire Legion Of My Best Troops is on table."
       ],
       "set": "216",
       "side": "Light"
@@ -63905,11 +63976,14 @@
         "ability": "7",
         "deploy": "7",
         "destiny": "1",
+        "errataDate": "2022-12-12",
+        "errataNotes": "Original card allowed all Jedi to be deployed. Only Jedi Council Members got destiny +1.",
+        "errataSymbol": "E1",
         "extraText": [
           "Jedi Master"
         ],
         "forfeit": "8",
-        "gametext": "While 'communing': You may not deploy Rebels; Jedi Council members are destiny +1; your total power in battles is +1 for each Jedi 'communing'; once per turn, may place a card from hand on Used Pile to draw top card of Force Pile.",
+        "gametext": "While 'communing': You may not deploy Jedi (except Jedi Council members) or Rebels; Jedi are destiny +1; your total power in battles is +1 for each Jedi 'communing'; once per turn, may place a card from hand on Used Pile to draw top card of Force Pile.",
         "icons": [
           "Warrior",
           "Episode I",
@@ -63926,6 +64000,7 @@
       "gempId": "216_37",
       "id": 6940,
       "legacy": false,
+      "previousId": 40011,
       "matchingWeapon": [
         "Qui-Gon Jinn's Lightsaber",
         "Qui-Gon's Lightsaber"
@@ -63947,11 +64022,14 @@
         "ability": "7",
         "deploy": "5",
         "destiny": "1",
+        "errataDate": "2022-12-12",
+        "errataNotes": "Original Text: While 'communing': You may not deploy Jedi Knights or [Maintenance] cards; [Dagobah] Luke is deploy -1 and power and defense value +1; once per turn, may deploy a battleground with two [Dark Side] from Reserve Deck; reshuffle; once per game, may retrieve 1 Force.",
+        "errataSymbol": "E1",
         "extraText": [
           "Jedi Master"
         ],
         "forfeit": "9",
-        "gametext": "While 'communing': You may not deploy Jedi Knights or [Maintenance] cards; [Dagobah] Luke is deploy -1 and power and defense value +1; once per turn, may deploy a battleground with two [Dark Side] from Reserve Deck; reshuffle; once per game, may retrieve 1 Force.",
+        "gametext": "While 'communing': You may not deploy Jedi Knights, [Maintenance] cards, or [Permanent Weapon] cards; your immunity to attrition is limited to < 4; once per turn, may deploy a battleground with two [Dark Side] from Reserve Deck; reshuffle; once per game, may retrieve 1 Force.",
         "icons": [
           "Set 16"
         ],
@@ -63966,6 +64044,7 @@
       "gempId": "216_38",
       "id": 6941,
       "legacy": false,
+      "previousId": 40012,
       "printings": [
         {
           "set": "216"
@@ -63973,7 +64052,10 @@
       ],
       "rarity": "U",
       "rulings": [
-        "You may not persona replace a character if the new version would violate this card's deployment restrictions."
+        "You may not persona replace a character if the new version would violate this card's deployment restrictions.",
+        "(7-side) When calculating immunity to attrition, start with the base immunity and apply any modifiers (such as Darth Tyranus). Finally, apply the limit (limit of < 4 from Master Yoda) last.",
+        "For example, Master Windu (normally immune < 6) would first be reduced to < 5 by Tyranus first. Then the limit of < 4 would be applied.",
+        "For example, Qui-Gon Jinn (fully immune to attrition) would not be affected by Tyranus at all. Then the limit of < 4 would be applied to Qui-Gon."
       ],
       "set": "216",
       "side": "Light"
@@ -63981,7 +64063,10 @@
     {
       "front": {
         "destiny": "5",
-        "gametext": "If your starting location had 'communing' in game text, deploy Communing and stack a Jedi with 'communing' in game text on it. Deploy up to three Effects that deploy on table and are always immune to Alter. Place Interrupt in Lost Pile.",
+        "errataDate": "2022-12-12",
+        "errataNotes": "Original card did not require the Effects to deploy for free, which meant the original could start We're Leaving.",
+        "errataSymbol": "E1",
+        "gametext": "If your starting location had 'communing' in game text, deploy Communing and stack a Jedi with 'communing' in game text on it. Deploy up to three Effects that deploy on table, deploy for free, and are always immune to Alter. Place Interrupt in Lost Pile.",
         "icons": [
           "Episode I",
           "Set 16"
@@ -63996,6 +64081,7 @@
       "gempId": "216_39",
       "id": 6942,
       "legacy": false,
+      "previousId": 40008,
       "printings": [
         {
           "set": "216"
@@ -64134,7 +64220,7 @@
       "front": {
         "darkSideIcons": 0,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Light:  While Obi-Wan 'communing,' no Force drains here and, once per turn, may subtract 2 from a just drawn [Permanent Weapon] weapon destiny.  Dark:  -",
         "icons": [
           "Exterior",
@@ -64736,7 +64822,10 @@
       "front": {
         "darkSideIcons": 0,
         "destiny": "0",
-        "gametext": "Dark:  Light: Deploys only as a starting location. There Is Another does not cause [Reflections 2] Luke to be lost. If you just chose I Have It on your [Skywalker] Epic Event, deploy Like My Father Before Me from Reserve Deck; reshuffle.",
+        "errataDate": "2022-12-12",
+        "errataNotes": "Original text (all on Light side): Deploys only as a starting location. There Is Another does not cause [Reflections 2] Luke to be lost. If you just chose I Have It on your [Skywalker] Epic Event, deploy Like My Father Before Me from Reserve Deck; reshuffle.",
+        "errataSymbol": "E1",
+        "gametext": "Dark:  Light: If you just chose I Have It on your [Skywalker] Epic Event, deploy Like My Father Before Me from Reserve Deck; reshuffle. If Anakin 'communing,' you may initiate battles for free.",
         "icons": [
           "Exterior",
           "Planet",
@@ -64754,6 +64843,7 @@
       "gempId": "217_34",
       "id": 6986,
       "legacy": false,
+      "previousId": 40004,
       "printings": [
         {
           "set": "217"
@@ -64763,9 +64853,6 @@
         "Like My Father Before Me"
       ],
       "rarity": "C2",
-      "rulings": [
-        "Cannot be deployed by another card (such as an Objective or Starting Interrupt)."
-      ],
       "set": "217",
       "side": "Light"
     },
@@ -65445,7 +65532,9 @@
       "counterpart": "Revenge Of The Sith",
       "front": {
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataDate": "2022-12-12",
+        "errataNotes": "E1 version did not have 'Your lightsabers may not be stolen.'",
+        "errataSymbol": "E2",
         "gametext": "Deploy on table (only at start of game) and choose: My Father Has It: Anakin (and [Episode I] Obi-Wan) I Have It: Luke (and [Set 1] Obi-Wan) You Have That Power, Too: Rey (and [Episode VII] Luke) [Set 16] Anakin is deploy -1. Your total Force generation is +1. You may not deploy Boss Nass' Chambers or Jedi (except Yoda and the chosen characters). If you just initiated battle involving a Skywalker (or if opponent's Sidious just lost from table), may retrieve 1 Force.",
         "icons": [
           "Skywalker",
@@ -65461,6 +65550,7 @@
       "gempId": "217_50",
       "id": 7003,
       "legacy": false,
+      "previousId": 40015,
       "printings": [
         {
           "set": "217"
@@ -66771,7 +66861,7 @@
       "front": {
         "darkSideIcons": 0,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Light: During your move phase, [Episode I] Jedi may move between here and a battleground site. While a Jedi here, opponent's characters deploy +2 here and cancels Force drains at Jedi Council Chamber. Dark: ",
         "icons": [
           "Episode I",
@@ -66951,13 +67041,13 @@
       "side": "Light"
     },
     {
-      "abbr": [
-        "L("
-      ],
       "front": {
         "darkSideIcons": 1,
         "destiny": "0",
-        "gametext": "Light: Ghost deploys -2 here. While Ghost piloted here, opponent's battle destiny draws are -1 here. Dark: Unless Chimaera or Thrawn here, Force drain -1 here.",
+        "errataDate": "2022-12-12",
+        "errataNotes": "Original Text: Light: Ghost deploys -2 here. While Ghost piloted here, opponent's battle destiny draws are -1 here. Dark: Unless Chimaera or Thrawn here, Force drain -1 here.",
+        "errataSymbol": "E1",
+        "gametext": "Light: Hera deploys -1 here. Once per game, may take This is MY Ship! into hand from Reserve Deck; reshuffle. Dark: Unless Thrawn here, Force drain -1 here and This Is MY Ship! is [Immune to Sense]. While Lothal converted, gains one [Dark Side] icon.",
         "icons": [
           "Planet",
           "Set 19"
@@ -66973,12 +67063,17 @@
       "gempId": "219_38",
       "id": 7109,
       "legacy": false,
+      "previousId": 40010,
       "printings": [
         {
           "set": "219"
         }
       ],
       "rarity": "U2",
+      "rulings": [
+        "Only follow the 'While Lothal converted' text of the topmost (active) Lothal system card.  It is applicable if there exists one (or more) converted copies of Lothal underneath.",
+        "Disregard the text of the copies of Lothal underneath."
+      ],
       "set": "219",
       "side": "Light"
     },
@@ -67056,7 +67151,7 @@
       "front": {
         "darkSideIcons": 1,
         "destiny": "0",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Light: Ezra and Kanan deploy -1 here. Unless you occupy, Vader may not deploy here and opponent's characters, vehicles, and starships deploy and move to here for +2 Force. Dark: ",
         "icons": [
           "Exterior",
@@ -67188,7 +67283,7 @@
       ],
       "front": {
         "destiny": "4",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "If Lothal on table, deploy on table. Chopper, Sabine, and Zeb are deploy -1. Once per turn, may deploy Malachor, Mandalore, or Seelos (or Chopper, Wedge, Zeb, or an A-wing to a Lothal location) from Reserve Deck; reshuffle. [Immune to Alter.]",
         "icons": [
           "Set 19"
@@ -67345,7 +67440,7 @@
       ],
       "back": {
         "destiny": "7",
-        "errataVersion": "E1",
+        "errataSymbol": "E1",
         "gametext": "Zero Hour: Deploy Lothal system and a Lothal site. For remainder of game, Menace Fades and Projection Of A Skywalker are canceled. Jedi (except Ahsoka and Kanan), Resistance characters, and [Resistance] starships are deploy +1. Chopper, Ezra, Hera, Kanan, Sabine, and Zeb gain Phoenix Squadron. Once per turn, may deploy a Lothal site from Reserve Deck; reshuffle. Flip this card if Rebels control three Lothal locations (or you occupy three Lothal locations with Phoenix Squadron characters) and opponent controls no Lothal locations. Liberation Of Lothal: While this side up, if you Force drained at a battleground this turn, your other Force drains at battlegrounds are +1. Once per turn during battle, may add or subtract X from a just drawn battle destiny (or opponent's weapon destiny), where X = number of battlegrounds you occupy with Phoenix Squadron characters. At Lothal system, the number of battle destiny draws may not be limited for either player. Flip this card if opponent controls more Lothal locations than you.",
         "icons": [
           "Set 19"
@@ -67380,6 +67475,623 @@
         "(7-side) During battle at Lothal system, players may initiate an action that would limit battle destiny draws, such as taking a card off I Don't Like Sand or playing the limiting function on Imperial Command & In Range.  The limit is simply ignored."
       ],
       "set": "219",
+      "side": "Light"
+    },
+    {
+      "abbr": [
+        "BD"
+      ],
+      "front": {
+        "destiny": "4",
+        "gametext": "USED: Target your Mandalorian that was just 'hit' by a character weapon. Opponent chooses: Restore target to normal or the character that fired the weapon is also 'hit.' LOST: Once per game, if your Mandalorian is in battle, add 2 to a just drawn destiny.",
+        "icons": [
+          "Set 20"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual20-Light/large/beskardeflection.gif",
+        "lore": "Blank",
+        "subType": "Used Or Lost",
+        "title": "Beskar Deflection",
+        "type": "Interrupt"
+      },
+      "gempId": "220_6",
+      "id": 7128,
+      "legacy": false,
+      "printings": [
+        {
+          "set": "220"
+        }
+      ],
+      "rarity": "C",
+      "rulings": [
+        "Initiating the Used function is an attempt to hit a character and can be canceled by Oh, Switch Off.",
+        "The Used function cannot be initiated against a card that is already protected by an earlier usage of Oh, Switch Off."
+      ],
+      "set": "220",
+      "side": "Light"
+    },
+    {
+      "abbr": [
+        "MFv"
+      ],
+      "front": {
+        "characteristics": [
+          "Rebel (starship)"
+        ],
+        "deploy": "3",
+        "destiny": "2",
+        "forfeit": "7",
+        "gametext": "May add 2 pilots and 2 passengers. Once per game, if your [Reflections II] or [Skywalker] site on table, may deploy Han or Chewie aboard from Reserve Deck; reshuffle. While Han or Chewie piloting, immune to attrition < 5 (< 7 if both).",
+        "hyperspeed": "6",
+        "icons": [
+          "Scomp Link",
+          "Nav Computer",
+          "Set 20"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual20-Light/large/millenniumfalcon.gif",
+        "lore": "Modified YT-1300 freighter. Owned by Lando Calrissian until won by Han in a sabacc game. 26.7 meters long. 'She may not look like much, but she's got it where it counts.'",
+        "maneuver": "4",
+        "power": "3",
+        "subType": "Starfighter: Modified Light Freighter",
+        "title": "•Millennium Falcon (V)",
+        "type": "Starship",
+        "uniqueness": "*"
+      },
+      "gempId": "220_7",
+      "id": 7129,
+      "legacy": false,
+      "matching": [
+        "Any Han",
+        "Any Chewie",
+        "Artoo & Threepio",
+        "General Calrissian",
+        "Lando Calrissian",
+        "Lando Calrissian, Scoundrel"
+      ],
+      "printings": [
+        {
+          "set": "220"
+        }
+      ],
+      "pulledBy": [
+        "All Wings Report In & Darklighter Spin",
+        "Best Starpilot In The Galaxy",
+        "Life Debt"
+      ],
+      "pulls": [
+        "Any Han",
+        "Any Chewie"
+      ],
+      "rarity": "R1",
+      "set": "220",
+      "side": "Light"
+    },
+    {
+      "abbr": [
+        "NTPG"
+      ],
+      "front": {
+        "darkSideIcons": 2,
+        "destiny": "0",
+        "gametext": "Light: While Qui-Gon 'communing,' opponent's [Reflections II] objective targets Anakin instead of Luke. Dark: Dark Jedi are power +1 here. Jedi are power +2 here. Force drain -1 here.",
+        "icons": [
+          "Interior",
+          "Planet",
+          "Reflections III",
+          "Episode I",
+          "Set 20"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual20-Light/large/nabootheedpalacegenerator.gif",
+        "lightSideIcons": 2,
+        "subType": "Site",
+        "title": "•Naboo: Theed Palace Generator",
+        "type": "Location",
+        "uniqueness": "*"
+      },
+      "gempId": "220_8",
+      "id": 7130,
+      "legacy": false,
+      "printings": [
+        {
+          "set": "220"
+        }
+      ],
+      "rarity": "PM",
+      "set": "220",
+      "side": "Light"
+    },
+    {
+      "abbr": [
+        "P2187"
+      ],
+      "front": {
+        "ability": "3",
+        "characteristics": [
+          "Alderaanian",
+          "senator",
+          "female"
+        ],
+        "deploy": "6",
+        "destiny": "1",
+        "extraText": [
+          "Force-Attuned"
+        ],
+        "forfeit": "6",
+        "gametext": "While on Death Star (even if imprisoned): Force drain +1 where you have a Rebel stormtrooper, Leia may not be transferred, moves using landspeed for free, draws one battle destiny if unable to otherwise, and her game text may not be canceled.",
+        "icons": [
+          "Premium",
+          "Warrior"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual20-Light/large/prisoner2187.gif",
+        "lore": "Princess Leia Organa. Alderaanian senator. Targeted by Vader for capture and interrogation. The Dark Lord Of The Sith wanted her alive.",
+        "power": "4",
+        "subType": "Rebel",
+        "title": "•Prisoner 2187 (V)",
+        "type": "Character",
+        "uniqueness": "*"
+      },
+      "gempId": "220_9",
+      "id": 7131,
+      "legacy": false,
+      "matchingWeapon": [
+        "Leia's Blaster Rifle",
+        "Leia's Sporting Blaster"
+      ],
+      "printings": [
+        {
+          "set": "220"
+        }
+      ],
+      "pulledBy": [
+        "I Know",
+        "Leia's Back",
+        "Might Of The Republic"
+      ],
+      "rarity": "PM",
+      "rulings": [
+        "Prisoner 2187 (V)'s text works while in prison, but does not work while she is an escorted captive."
+      ],
+      "set": "220",
+      "side": "Light"
+    },
+    {
+      "abbr": [
+        "TBv"
+      ],
+      "front": {
+        "destiny": "0",
+        "gametext": "Plays on table. At end of a turn, if opponent has 15 or more cards in hand, may use 2 Force to shuffle all but 9 (random selection) into Used Pile. If Monnok or Drop! just targeted your hand, may reveal 2 cards from hand; they cannot be removed or checked for duplicates.",
+        "icons": [
+          "Episode I",
+          "Set D"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual20-Light/large/thrownback.gif",
+        "lore": "Being sent to dispose of two Jedi is the battle droid equivalent of a really bad day at the office.",
+        "title": "•Thrown Back (V)",
+        "type": "Defensive Shield",
+        "uniqueness": "*"
+      },
+      "gempId": "220_10",
+      "id": 7132,
+      "legacy": false,
+      "printings": [
+        {
+          "set": "220"
+        }
+      ],
+      "rarity": "C",
+      "rulings": [
+        "A player may view cards that are being removed from their own hand.",
+        "When 2 cards are revealed to prevent them from being placed in Used Pile, the hand will still be reduced to the size required by Drop! or Monnok.",
+        "If a player has 2 of the same card and reveals 1 to prevent it from being checked for duplicates, the other copy is not lost. If a player has 3 of the same card and reveals 2 of them, the other copy is not lost. If a player has 3 of the same card and reveals only 1 of them, the other 2 are duplicates of each other and are lost."
+      ],
+      "set": "220",
+      "side": "Light"
+    },
+    {
+      "front": {
+        "deploy": "3",
+        "destiny": "π",
+        "destinyValues": [
+          3.14159
+        ],
+        "forfeit": "5",
+        "gametext": "May add 1 pilot. Permanent astromech aboard is •BB-8. If Poe piloting, may lose 1 Force to cancel a just drawn weapon destiny targeting this starship. Immune to attrition < 4.",
+        "hyperspeed": "6",
+        "icons": [
+          "Resistance",
+          "Nav Computer",
+          "Scomp Link",
+          "Episode VII",
+          "Set 11"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/VirtualAlternateImage-Light/large/bb8inblacksquadron1_ai.gif",
+        "lore": "Blank.",
+        "maneuver": "5",
+        "power": "4",
+        "subType": "Starfighter: X-wing",
+        "title": "•BB-8 In Black Squadron 1 (AI)",
+        "type": "Starship",
+        "uniqueness": "*"
+      },
+      "gempId": "211_28",
+      "id": 7139,
+      "legacy": false,
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
+      "rarity": "U",
+      "set": "211",
+      "side": "Light"
+    },
+    {
+      "abbr": [
+        "EPP Chewie V"
+      ],
+      "front": {
+        "ability": "2",
+        "characteristics": [
+          "smuggler",
+          "Wookiee"
+        ],
+        "deploy": "5",
+        "destiny": "1",
+        "forfeit": "6",
+        "gametext": "Deploys -1 to Falcon. While 'hit,' draws one battle destiny if unable to otherwise. Permanent weapon is •Chewbacca's Bowcaster (may target a character or vehicle for free; draw two destiny; target hit, and its forfeit = 0, if total destiny > defense value).",
+        "icons": [
+          "Pilot",
+          "Warrior",
+          "Permanent Weapon",
+          "Episode VII",
+          "Set 4"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/VirtualAlternateImage-Light/large/chewiewithbowcaster_ai.gif",
+        "lore": "Wookiee smuggler.",
+        "power": "6",
+        "subType": "Alien/Resistance",
+        "title": "•Chewie With Bowcaster (AI)",
+        "type": "Character",
+        "uniqueness": "*"
+      },
+      "gempId": "204_4",
+      "id": 7140,
+      "legacy": false,
+      "matching": [
+        "Chewie's AT-ST",
+        "Gold Squadron 1",
+        "Lando In Millennium Falcon",
+        "Millennium Falcon",
+        "The Falcon",
+        "The Falcon, Junkyard Garbage"
+      ],
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
+      "pulledBy": [
+        "Beldon's Eye (V)",
+        "Life Debt",
+        "Seeking An Audience (V)",
+        "Wookiee Roar"
+      ],
+      "rarity": "PM",
+      "set": "204",
+      "side": "Light"
+    },
+    {
+      "front": {
+        "darkSideIcons": 1,
+        "destiny": "0",
+        "gametext": "Light:  Your starfighters take off and land here for free.  Dark:  Your gangsters and scavengers deploy -1 here.",
+        "icons": [
+          "Exterior",
+          "Planet",
+          "Episode VII",
+          "Set 4"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/VirtualAlternateImage-Light/large/jakkuniimaoutpostshipyard_ai.gif",
+        "lightSideIcons": 2,
+        "subType": "Site",
+        "title": "•Jakku: Niima Outpost Shipyard (AI)",
+        "type": "Location",
+        "uniqueness": "*"
+      },
+      "gempId": "204_27",
+      "id": 7141,
+      "legacy": false,
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
+      "pulledBy": [
+        "Mindful Of The Future"
+      ],
+      "rarity": "C",
+      "set": "204",
+      "side": "Light"
+    },
+    {
+      "conceptBy": "(Image courtesy of Leo Camacho)",
+      "front": {
+        "ability": "2",
+        "characteristics": [
+          "leader"
+        ],
+        "deploy": "4",
+        "destiny": "2",
+        "forfeit": "6",
+        "gametext": "Adds 3 to power of anything he pilots. Deploy -1 to Jakku. When piloting, adds one battle destiny. Anything he pilots is immune to attrition < 5.",
+        "icons": [
+          "Pilot",
+          "Warrior",
+          "Episode VII",
+          "Set 4"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/VirtualAlternateImage-Light/large/poedameron_ai.gif",
+        "lore": "Leader.",
+        "power": "3",
+        "subType": "Resistance",
+        "title": "•Poe Dameron (AI)",
+        "type": "Character",
+        "uniqueness": "*"
+      },
+      "gempId": "204_8",
+      "id": 7142,
+      "legacy": false,
+      "matching": [
+        "Stolen First Order TIE"
+      ],
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
+      "rarity": "U",
+      "set": "204",
+      "side": "Light"
+    },
+    {
+      "front": {
+        "darkSideIcons": 1,
+        "destiny": "0",
+        "gametext": "Light:  While opponent occupies, Stardust (and any character it is on) may not move from here.  Dark:  All immunity to attrition (and Ephant Mon's game text) here is canceled.",
+        "icons": [
+          "Interior",
+          "Planet",
+          "Scomp Link",
+          "Set 9"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/VirtualAlternateImage-Light/large/scarifdatavault_ai.gif",
+        "lightSideIcons": 1,
+        "subType": "Site",
+        "title": "•Scarif: Data Vault (AI)",
+        "type": "Location",
+        "uniqueness": "*"
+      },
+      "gempId": "209_25",
+      "id": 7143,
+      "legacy": false,
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
+      "rarity": "C",
+      "set": "209",
+      "side": "Light"
+    },
+    {
+      "front": {
+        "ability": "3",
+        "characteristics": [
+          "smuggler",
+          "Corellian"
+        ],
+        "deploy": "4",
+        "destiny": "1",
+        "forfeit": "7",
+        "gametext": "Adds 3 to power of anything he pilots. Deploys -1 to Falcon. Draws one battle destiny if unable to otherwise. Adds one battle destiny if with Chewie or Rey. Once per game, may play an Interrupt from Lost Pile as if from hand (then place that card out of play).",
+        "icons": [
+          "Pilot",
+          "Warrior",
+          "Episode VII",
+          "Set 4"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/VirtualAlternateImage-Light/large/solo_ai.gif",
+        "lore": "Smuggler.",
+        "power": "4",
+        "subType": "Alien/Resistance",
+        "title": "•Solo (AI)",
+        "type": "Character",
+        "uniqueness": "*"
+      },
+      "gempId": "204_11",
+      "id": 7144,
+      "legacy": false,
+      "matching": [
+        "Millennium Falcon",
+        "The Falcon",
+        "The Falcon, Junkyard Garbage"
+      ],
+      "matchingWeapon": [
+        "Han's Heavy Blaster Pistol",
+        "Han's Heavy Blaster Pistol (V)"
+      ],
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
+      "pulledBy": [
+        "Han's Back"
+      ],
+      "rarity": "R",
+      "set": "204",
+      "side": "Light"
+    },
+    {
+      "front": {
+        "armor": "4",
+        "characteristics": [
+          "Rebel (starship)",
+          "ship-docking capability"
+        ],
+        "deploy": "4",
+        "destiny": "1",
+        "forfeit": "7",
+        "gametext": "May deploy without presence or Force icons. May add 3 pilots and 4 passengers. Permanent pilot provides ability of 2. Adds one [Light Side] icon here.",
+        "hyperspeed": "3",
+        "icons": [
+          "Pilot",
+          "Nav Computer",
+          "Scomp Link",
+          "A New Hope",
+          "Set 1"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/VirtualAlternateImage-Light/large/tantiveiv_ai.gif",
+        "lore": "Royal House of Alderaan consular ship. Used by Princess Leia for Imperial Senate business (and secret Rebel espionage). Captured by the Devastator over Tatooine.",
+        "power": "5",
+        "subType": "Capital: Corellian Corvette",
+        "title": "•Tantive IV (V) (AI)",
+        "type": "Starship",
+        "uniqueness": "*"
+      },
+      "gempId": "201_19",
+      "id": 7145,
+      "legacy": false,
+      "printings": [
+        {
+          "set": "201"
+        }
+      ],
+      "pulledBy": [
+        "Fly Casual"
+      ],
+      "rarity": "R1",
+      "set": "201",
+      "side": "Light"
+    },
+    {
+      "abbr": [
+        "Flip Falcon"
+      ],
+      "back": {
+        "deploy": "0",
+        "destiny": "7",
+        "errataSymbol": "E2",
+        "forfeit": "7",
+        "gametext": "May not be placed in Reserve Deck. If Falcon about to leave table, place it out of play. May add 2 pilots and 2 passengers. Has ship-docking capability. While [Episode VII] Han or Rey piloting, maneuver +2 and immune to attrition < 4 (< 6 if both). Once during your move phase, if at a site, may flip this card (even if unpiloted).May not be placed in Reserve Deck. If Falcon about to leave table, place it out of play. May add 2 pilots and 2 passengers. Immune to Trample and Unsalvageable, even if unpiloted. While Finn or Rey aboard, immune to attrition < 4 (< 6 if both). Once during your move phase, if piloted, may flip this card.",
+        "hyperspeed": "6",
+        "icons": [
+          "Resistance",
+          "Scomp Link",
+          "Episode VII",
+          "Set 4"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/VirtualAlternateImage-Light/large/thefalconjunkyardgarbageback_ai.gif",
+        "landspeed": "2",
+        "lore": "Han's 'special modifications' for Millennium Falcon included security mechanisms, deflector shields, hull plating, faster hyperdrive and enhanced weapons. Enclosed.",
+        "maneuver": "5",
+        "power": "3",
+        "subType": "Combat Vehicle: Heavily-Modified Light Freighter",
+        "title": "•The Falcon, Junkyard Garbage / •The Falcon, Junkyard Garbage (AI)",
+        "type": "Vehicle",
+        "uniqueness": "*"
+      },
+      "front": {
+        "deploy": "0",
+        "destiny": "0",
+        "forfeit": "7",
+        "gametext": "May not be placed in Reserve Deck. If Falcon about to leave table, place it out of play. May add 2 pilots and 2 passengers. Has ship-docking capability. While [Episode VII] Han or Rey piloting, maneuver +2 and immune to attrition < 4 (< 6 if both). Once during your move phase, if at a site, may flip this card (even if unpiloted).May not be placed in Reserve Deck. If Falcon about to leave table, place it out of play. May add 2 pilots and 2 passengers. Immune to Trample and Unsalvageable, even if unpiloted. While Finn or Rey aboard, immune to attrition < 4 (< 6 if both). Once during your move phase, if piloted, may flip this card.",
+        "hyperspeed": "6",
+        "icons": [
+          "Nav Computer",
+          "Resistance",
+          "Scomp Link",
+          "Episode VII",
+          "Set 4"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/VirtualAlternateImage-Light/large/thefalconjunkyardgarbagefront_ai.gif",
+        "landspeed": "2",
+        "lore": "The Millennium Falcon's well-known reputation is favorable not only for its captain and first mate, but for the Alliance as well.",
+        "maneuver": "4",
+        "power": "3",
+        "subType": "Starfighter: Heavily-Modified Light Freighter",
+        "title": "•The Falcon, Junkyard Garbage / •The Falcon, Junkyard Garbage (AI)",
+        "type": "Starship",
+        "uniqueness": "*"
+      },
+      "gempId": "204_35",
+      "id": 7146,
+      "legacy": false,
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
+      "pulledBy": [
+        "My Parents Were Strong",
+        "Old Allies / We Need Your Help"
+      ],
+      "rarity": "C",
+      "rulings": [
+        "If Falcon is about to be lost, it is not possible to send it to a docking bay with I'll Take The Leader. The Falcon would go out of play first.",
+        "When Falcon flips to the vehicle side, any starship weapons are lost (even Concussion Missiles, which deploys on a freighter).",
+        "When Falcon flips to the vehicle side, any Devices or Effects (of any kind) which use a clause of their deployment text to deploy on and/or target the Falcon as a starship, are lost unless that same deployment clause can also target vehicles. Do not recheck any other deployment conditions.",
+        "Similar logic to the above two rulings applies when flipping Falcon to the starship side (i.e. lose vehicle weapons, lose any Devices or Effects of any kind unless the deployment clause can also target a starship).",
+        "Flipping from starship to vehicle causes attached Mynocks to detach."
+      ],
+      "set": "204",
+      "side": "Light"
+    },
+    {
+      "combo": [
+        "Commander Cody + Captain Rex"
+      ],
+      "front": {
+        "ability": "3",
+        "armor": "4",
+        "characteristics": [
+          "captain",
+          "leader",
+          "clone trooper",
+          "trooper"
+        ],
+        "deploy": "4",
+        "destiny": "2",
+        "forfeit": "4",
+        "gametext": "Your clones deploy -1 here. While at an [Episode I] battleground site, adds one battle destiny. Permanent weapon is •Twin Blasters (may target a character for free; draw two destiny; target hit and forfeit -3 if total destiny -2 > defense value).",
+        "icons": [
+          "Warrior",
+          "Permanent Weapon",
+          "Clone Army",
+          "Episode I",
+          "Set 0"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/VirtualAlternateImage-Light/large/captainrex501stlegionholo_ai.gif",
+        "lore": "Leader. Clone trooper.",
+        "power": "3",
+        "subType": "Republic",
+        "title": "•Captain Rex, 501st Legion (Holo AI)",
+        "type": "Character",
+        "uniqueness": "*"
+      },
+      "gempId": "200_3",
+      "id": 7147,
+      "legacy": false,
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
+      "rarity": "C2",
+      "rulings": [
+        "This weapon is a blaster (e.g. for Blaster Proficiency)."
+      ],
+      "set": "200",
       "side": "Light"
     }
   ]

--- a/LightPreErrata.json
+++ b/LightPreErrata.json
@@ -1,0 +1,739 @@
+{
+  "cards": [
+    {
+      "front": {
+        "characteristics": [
+          "r-unit"
+        ],
+        "deploy": "2",
+        "destiny": "π or 2π",
+        "destinyValues": [
+          3.14159,
+          6.28318
+        ],
+        "extraText": [
+          "Astromech Droid"
+        ],
+        "forfeit": "4",
+        "gametext": "If just forfeited from a site, opponent may capture BB-8. While a captive, adds 1 to Force drains at same site. During your control phase, if at a battleground site and present with a Resistance character, opponent loses 1 Force.",
+        "icons": [
+          "Nav Computer",
+          "Episode VII",
+          "Set 4"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/bb8.gif",
+        "lore": "Blank.",
+        "power": "1",
+        "subType": "Droid",
+        "title": "•BB-8 (Beebee-Ate)",
+        "type": "Character",
+        "uniqueness": "*"
+      },
+      "gempId": "204_1",
+      "id": 40000,
+      "legacy": false,
+      "nextId": 5088,
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
+      "pulledBy": [
+        "Hero Of A Thousand Devices (V)"
+      ],
+      "rarity": "R1",
+      "set": "204",
+      "side": "Light"
+    },
+    {
+      "front": {
+        "destiny": "5",
+        "gametext": "If Leia imprisoned, deploy on table. [Set 8] Luke is a spy and stormtrooper. Han, Leia, and Luke are immune to Nevar Yalnal and Put All Sections On Alert. Once per turn, may deploy a Death Star site from Reserve Deck; reshuffle. Immune to This Is Some Rescue! [Immune to Alter.]",
+        "icons": [
+          "Set 15"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual15-Light/large/cell2187.gif",
+        "lore": "'Aren't you a little short for a stormtrooper?'",
+        "title": "•Cell 2187 (V)",
+        "type": "Effect",
+        "uniqueness": "*"
+      },
+      "gempId": "215_5",
+      "id": 40001,
+      "legacy": false,
+      "nextId": 6879,
+      "printings": [
+        {
+          "set": "215"
+        }
+      ],
+      "pulledBy": [
+        "The Signal",
+        "We Wish To Board At Once"
+      ],
+      "rarity": "R1",
+      "rulings": [
+        "This causes [Set 8] Luke to be a spy, stormtrooper, and trooper in all card states.",
+        "For example, [Set 8] Luke can be taken into hand by Ambush (V)."
+      ],
+      "set": "215",
+      "side": "Light"
+    },
+    {
+      "abbr": [
+        "CITC/YTBHWU",
+        "LS Demo Deck"
+      ],
+      "back": {
+        "destiny": "7",
+        "gametext": "City In The Clouds:Deploy Bespin system and a Cloud City battleground site. {While} this side up, once per turn may use 1 Force to deploy a Cloud City battleground site from Reserve Deck; reshuffle. {Flip} this card if you control two Cloud City battleground sites and occupy Bespin system, and opponent controls no Cloud City sites.You Truly Belong Here With Us:{While} this side up, once per game, may deploy Cloud City Celebration from Reserve Deck; reshuffle. Once during your control phase, may use 2 Force to take one Interrupt into hand from Reserve Deck; reshuffle. Once per turn, may move your character as a 'react' to a battle or Force drain at a Cloud City site. {Flip} this card if opponent controls more Cloud City sites than you.",
+        "icons": [
+          "Premium",
+          "Set P"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/DemoDeck-Light/large/youtrulybelongherewithus.gif",
+        "title": "City In The Clouds / You Truly Belong Here With Us",
+        "type": "Objective"
+      },
+      "front": {
+        "destiny": "0",
+        "gametext": "City In The Clouds:Deploy Bespin system and a Cloud City battleground site. {While} this side up, once per turn may use 1 Force to deploy a Cloud City battleground site from Reserve Deck; reshuffle. {Flip} this card if you control two Cloud City battleground sites and occupy Bespin system, and opponent controls no Cloud City sites.You Truly Belong Here With Us:{While} this side up, once per game, may deploy Cloud City Celebration from Reserve Deck; reshuffle. Once during your control phase, may use 2 Force to take one Interrupt into hand from Reserve Deck; reshuffle. Once per turn, may move your character as a 'react' to a battle or Force drain at a Cloud City site. {Flip} this card if opponent controls more Cloud City sites than you.",
+        "icons": [
+          "Premium",
+          "Set P"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/DemoDeck-Light/large/cityintheclouds.gif",
+        "title": "City In The Clouds / You Truly Belong Here With Us",
+        "type": "Objective"
+      },
+      "gempId": "301_2",
+      "id": 40002,
+      "legacy": false,
+      "nextId": 5421,
+      "printings": [
+        {
+          "set": "301"
+        }
+      ],
+      "rarity": "PM",
+      "set": "301",
+      "side": "Light"
+    },
+    {
+      "counterpart": "Death Star: Detention Block Corridor",
+      "front": {
+        "characteristics": [
+          "prison"
+        ],
+        "darkSideIcons": 1,
+        "destiny": "0",
+        "gametext": "Light:  If you control with a spy, may use 2 Force to release Leia here (retrieve 1 Force).  Dark:  If Leia is about to be lost from a Death Star site, imprison her here instead (even if inactive).",
+        "icons": [
+          "Interior",
+          "Mobile",
+          "Scomp Link",
+          "Set 15"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual15-Light/large/deathstardetentionblockcorridor.gif",
+        "lightSideIcons": 0,
+        "subType": "Site",
+        "title": "•Death Star: Detention Block Corridor (V)",
+        "type": "Location",
+        "uniqueness": "*"
+      },
+      "gempId": "215_7",
+      "id": 40003,
+      "legacy": false,
+      "nextId": 6881,
+      "printings": [
+        {
+          "set": "215"
+        }
+      ],
+      "rarity": "C",
+      "rulings": [
+        "When Dark's text imprisons Leia, she is restored to normal (no longer hit or forfeit = 0, etc).",
+        "When Dark's text imprisons Leia, any weapons and other cards on Leia remain on her.",
+        "When Dark's text imprisons Leia from another site, she is placed here but it is not considered movement. It is not blocked by e.g. You Are Beaten.",
+        "Dark's text does not prevent an 'all cards situation', e.g. Program Trap will make Leia go to Lost Pile."
+      ],
+      "set": "215",
+      "side": "Light"
+    },
+    {
+      "abbr": [
+        "EAFP"
+      ],
+      "front": {
+        "darkSideIcons": 0,
+        "destiny": "0",
+        "gametext": "Dark:  Light: Deploys only as a starting location. There Is Another does not cause [Reflections 2] Luke to be lost. If you just chose I Have It on your [Skywalker] Epic Event, deploy Like My Father Before Me from Reserve Deck; reshuffle.",
+        "icons": [
+          "Exterior",
+          "Planet",
+          "Skywalker",
+          "Death Star II",
+          "Set 17"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual17-Light/large/endoranakinsfuneralpyre.gif",
+        "lightSideIcons": 2,
+        "subType": "Site",
+        "title": "•Endor: Anakin's Funeral Pyre",
+        "type": "Location",
+        "uniqueness": "*"
+      },
+      "gempId": "217_34",
+      "id": 40004,
+      "legacy": false,
+      "nextId": 6986,
+      "printings": [
+        {
+          "set": "217"
+        }
+      ],
+      "pulls": [
+        "Like My Father Before Me"
+      ],
+      "rarity": "C2",
+      "rulings": [
+        "Cannot be deployed by another card (such as an Objective or Starting Interrupt)."
+      ],
+      "set": "217",
+      "side": "Light"
+    },
+    {
+      "front": {
+        "darkSideIcons": 1,
+        "destiny": "0",
+        "gametext": "Light:  While a Skywalker here, Prophecy Of The Force may not relocate from here.  Dark:  No starships or vehicles here.",
+        "icons": [
+          "Interior",
+          "Exterior",
+          "Planet",
+          "Set 8"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/endorewokvillage.gif",
+        "lightSideIcons": 1,
+        "subType": "Site",
+        "title": "•Endor: Ewok Village (V)",
+        "type": "Location",
+        "uniqueness": "*"
+      },
+      "gempId": "208_23",
+      "id": 40005,
+      "legacy": false,
+      "nextId": 5236,
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
+      "pulledBy": [
+        "Mindful Of The Future",
+        "The Shield Is Down! (V)",
+        "Wuta"
+      ],
+      "rarity": "U",
+      "set": "208",
+      "side": "Light"
+    },
+    {
+      "cancels": [
+        "Cloud City Occupation",
+        "Rebel Base Occupation",
+        "Tatooine Occupation",
+        "Reacts involving a combat vehicle",
+        "Reacts to or from same site as Leia or Luke"
+      ],
+      "front": {
+        "destiny": "5",
+        "gametext": "Cancel Cloud City Occupation, Rebel Base Occupation, or Tatooine Occupation. (Immune to Sense.) OR During your turn, target opponent's spy (or unpiloted combat vehicle) at a site you control; target is lost. OR Cancel an attempt to deploy or move a combat vehicle as a 'react.' OR Cancel a 'react' to or from same site as Leia or Luke.",
+        "icons": [
+          "Coruscant",
+          "Set 16"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual16-Light/large/freerideendorcelebration.gif",
+        "subType": "Used",
+        "title": "•Free Ride & •Endor Celebration (V)",
+        "type": "Interrupt",
+        "uniqueness": "*"
+      },
+      "gempId": "216_28",
+      "id": 40006,
+      "legacy": false,
+      "nextId": 6931,
+      "printings": [
+        {
+          "set": "216"
+        }
+      ],
+      "pulledBy": [
+        "Paploo",
+        "Yotts Orren"
+      ],
+      "rarity": "R",
+      "rulings": [
+        "This may target an Undercover spy."
+      ],
+      "set": "216",
+      "side": "Light"
+    },
+    {
+      "abbr": [
+        "HITCO/HWBB"
+      ],
+      "back": {
+        "destiny": "7",
+        "gametext": "He Is The Chosen One:Deploy Jedi Council Chamber (with Prophecy Of The Force there), Ewok Village, and I Feel The Conflict.{For} remainder of game, you may not deploy [Episode I] or [Episode VII] characters or locations (except Obi-Wan and Yoda). Luke may not be captured by Bring Him Before Me unless there are two cards stacked on Insignificant Rebellion during any move phase.{While} this side up, you may initiate battles for free.{Flip} this card if Luke or a Jedi at a battleground site (unless an opponent's character of ability > 4 is). He Will Bring Balance:{While} this side up, once during your control phase, may peek at up to X cards from the top of your Reserve Deck, where X = number of battlegrounds you occupy; take one into hand and shuffle your Reserve Deck. During your draw phase, may retrieve any one card; opponent may stack a card from hand on I Feel The Conflict to place that out of play instead.{Flip} this card (unless Vader crossed over) if opponent's character of ability > 4 at a battleground site or you do not have Luke (or a Jedi) at a battleground site.",
+        "icons": [
+          "Set 8"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/hewillbringbalance.gif",
+        "title": "He Is The Chosen One / He Will Bring Balance",
+        "type": "Objective"
+      },
+      "front": {
+        "destiny": "0",
+        "errataSymbol": "E1",
+        "gametext": "He Is The Chosen One:Deploy Jedi Council Chamber (with Prophecy Of The Force there), Ewok Village, and I Feel The Conflict.{For} remainder of game, you may not deploy [Episode I] or [Episode VII] characters or locations (except Obi-Wan and Yoda). Luke may not be captured by Bring Him Before Me unless there are two cards stacked on Insignificant Rebellion during any move phase.{While} this side up, you may initiate battles for free.{Flip} this card if Luke or a Jedi at a battleground site (unless an opponent's character of ability > 4 is). He Will Bring Balance:{While} this side up, once during your control phase, may peek at up to X cards from the top of your Reserve Deck, where X = number of battlegrounds you occupy; take one into hand and shuffle your Reserve Deck. During your draw phase, may retrieve any one card; opponent may stack a card from hand on I Feel The Conflict to place that out of play instead.{Flip} this card (unless Vader crossed over) if opponent's character of ability > 4 at a battleground site or you do not have Luke (or a Jedi) at a battleground site.",
+        "icons": [
+          "Set 8"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual8-Light/large/heisthechosenone.gif",
+        "title": "He Is The Chosen One / He Will Bring Balance",
+        "type": "Objective"
+      },
+      "gempId": "208_25",
+      "id": 40007,
+      "legacy": false,
+      "nextId": 5572,
+      "printings": [
+        {
+          "set": "208"
+        }
+      ],
+      "rarity": "R",
+      "rulings": [
+        "When playing against Bring Him Before Me, Light <u>may</u> select Luke as the card to be retrieved, but Dark <u>may not</u> stack a card from hand on I Feel The Conflict to place that Luke out of play instead."
+      ],
+      "set": "208",
+      "side": "Light"
+    },
+    {
+      "front": {
+        "destiny": "5",
+        "gametext": "If your starting location had 'communing' in game text, deploy Communing and stack a Jedi with 'communing' in game text on it. Deploy up to three Effects that deploy on table and are always immune to Alter. Place Interrupt in Lost Pile.",
+        "icons": [
+          "Episode I",
+          "Set 16"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual16-Light/large/iampartofthelivingforce.gif",
+        "lore": "Blank.",
+        "subType": "Starting",
+        "title": "•I Am Part Of The Living Force",
+        "type": "Interrupt",
+        "uniqueness": "*"
+      },
+      "gempId": "216_39",
+      "id": 40008,
+      "legacy": false,
+      "nextId": 6942,
+      "printings": [
+        {
+          "set": "216"
+        }
+      ],
+      "rarity": "U1",
+      "set": "216",
+      "side": "Light"
+    },
+    {
+      "counterpart": "Sith Fury (V)",
+      "front": {
+        "destiny": "4",
+        "gametext": "USED: If you just drew a character for destiny, take that card into hand to cancel and redraw that destiny.  LOST: Use 3 Force to retrieve a non-[Maintenance] character into hand.",
+        "icons": [
+          "Dagobah",
+          "Set 0"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual0-Light/large/jedilevitation.gif",
+        "lore": "A Jedi can adjust the Force within and around an object, causing it to move as the Jedi wills.",
+        "subType": "Used Or Lost",
+        "title": "Jedi Levitation (V)",
+        "type": "Interrupt"
+      },
+      "gempId": "200_54",
+      "id": 40009,
+      "legacy": false,
+      "nextId": 1385,
+      "printings": [
+        {
+          "set": "200"
+        }
+      ],
+      "pulledBy": [
+        "Yoda's Hope"
+      ],
+      "rarity": "R",
+      "set": "200",
+      "side": "Light"
+    },
+    {
+      "front": {
+        "darkSideIcons": 1,
+        "destiny": "0",
+        "gametext": "Light: Ghost deploys -2 here. While Ghost piloted here, opponent's battle destiny draws are -1 here. Dark: Unless Chimaera or Thrawn here, Force drain -1 here.",
+        "icons": [
+          "Planet",
+          "Set 19"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual19-Light/large/lothal.gif",
+        "lightSideIcons": 2,
+        "parsec": "6",
+        "subType": "System",
+        "title": "•Lothal",
+        "type": "Location",
+        "uniqueness": "*"
+      },
+      "gempId": "219_38",
+      "id": 40010,
+      "legacy": false,
+      "nextId": 7109,
+      "printings": [
+        {
+          "set": "219"
+        }
+      ],
+      "rarity": "U2",
+      "set": "219",
+      "side": "Light"
+    },
+    {
+      "front": {
+        "ability": "7",
+        "deploy": "7",
+        "destiny": "1",
+        "extraText": [
+          "Jedi Master"
+        ],
+        "forfeit": "8",
+        "gametext": "While 'communing': You may not deploy Rebels; Jedi Council members are destiny +1; your total power in battles is +1 for each Jedi 'communing'; once per turn, may place a card from hand on Used Pile to draw top card of Force Pile.",
+        "icons": [
+          "Warrior",
+          "Episode I",
+          "Set 16"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual16-Light/large/masterquigonjinnanoldfriend.gif",
+        "lore": "Blank.",
+        "power": "6",
+        "subType": "Jedi Master",
+        "title": "•Master Qui-Gon Jinn, An Old Friend",
+        "type": "Character",
+        "uniqueness": "*"
+      },
+      "gempId": "216_37",
+      "id": 40011,
+      "legacy": false,
+      "nextId": 6940,
+      "matchingWeapon": [
+        "Qui-Gon Jinn's Lightsaber",
+        "Qui-Gon's Lightsaber"
+      ],
+      "printings": [
+        {
+          "set": "216"
+        }
+      ],
+      "rarity": "U",
+      "rulings": [
+        "You may not persona replace a character if the new version would violate this card's deployment restrictions."
+      ],
+      "set": "216",
+      "side": "Light"
+    },
+    {
+      "front": {
+        "ability": "7",
+        "deploy": "5",
+        "destiny": "1",
+        "extraText": [
+          "Jedi Master"
+        ],
+        "forfeit": "9",
+        "gametext": "While 'communing': You may not deploy Jedi Knights or [Maintenance] cards; [Dagobah] Luke is deploy -1 and power and defense value +1; once per turn, may deploy a battleground with two [Dark Side] from Reserve Deck; reshuffle; once per game, may retrieve 1 Force.",
+        "icons": [
+          "Set 16"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual16-Light/large/masteryoda.gif",
+        "lore": "Blank.",
+        "power": "2",
+        "subType": "Jedi Master",
+        "title": "•Master Yoda",
+        "type": "Character",
+        "uniqueness": "*"
+      },
+      "gempId": "216_38",
+      "id": 40012,
+      "legacy": false,
+      "nextId": 6941,
+      "printings": [
+        {
+          "set": "216"
+        }
+      ],
+      "rarity": "U",
+      "rulings": [
+        "You may not persona replace a character if the new version would violate this card's deployment restrictions."
+      ],
+      "set": "216",
+      "side": "Light"
+    },
+    {
+      "abbr": [
+        "OA/WNYH"
+      ],
+      "back": {
+        "destiny": "7",
+        "errataSymbol": "E1",
+        "gametext": "Old Allies:Deploy Jakku system and Niima Outpost Shipyard (with [Episode VII] Falcon there). May deploy Graveyard Of Giants.{For} remainder of game, you may not deploy Harc Seff, Luke, or Jedi. Your Destiny is suspended. Opponent's [Reflections 2] objective targets Rey instead of Luke. While Rey at a battleground site, Visage Of The Emperor is suspended.{While} this side up, once per turn, may deploy a Jakku location from Reserve Deck; reshuffle.{Flip} this card if you control Jakku system and occupy two Jakku battleground sites (or vice versa).We Need Your Help{While} this side up, once per turn, may deploy a Jakku location from Reserve Deck; reshuffle. Once during opponent's control phase, if you control two Jakku battlegrounds and are about to lose Force (except to a Force drain at a Jakku location), may reduce that Force loss to 1 (may not be further reduced). Once per battle involving your Resistance character, may subtract 2 from a just drawn destiny. While with Han, your [Episode VII] characters and [Episode VII] starships are defense value +2.{Flip} this card if you do not occupy two battlegrounds.",
+        "icons": [
+          "Premium",
+          "Episode VII",
+          "Set 4"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/weneedyourhelp.gif",
+        "title": "Old Allies / We Need Your Help",
+        "type": "Objective"
+      },
+      "front": {
+        "destiny": "0",
+        "errataSymbol": "E1",
+        "gametext": "Old Allies:Deploy Jakku system and Niima Outpost Shipyard (with [Episode VII] Falcon there). May deploy Graveyard Of Giants.{For} remainder of game, you may not deploy Harc Seff, Luke, or Jedi. Your Destiny is suspended. Opponent's [Reflections 2] objective targets Rey instead of Luke. While Rey at a battleground site, Visage Of The Emperor is suspended.{While} this side up, once per turn, may deploy a Jakku location from Reserve Deck; reshuffle.{Flip} this card if you control Jakku system and occupy two Jakku battleground sites (or vice versa).We Need Your Help:{While} this side up, once per turn, may deploy a Jakku location from Reserve Deck; reshuffle. Once during opponent's control phase, if you control two Jakku battlegrounds and are about to lose Force (except to a Force drain at a Jakku location), may reduce that Force loss to 1 (may not be further reduced). Once per battle involving your Resistance character, may subtract 2 from a just drawn destiny. While with Han, your [Episode VII] characters and [Episode VII] starships are defense value +2.{Flip} this card if you do not occupy two battlegrounds.",
+        "icons": [
+          "Premium",
+          "Episode VII",
+          "Set 4"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/oldallies.gif",
+        "title": "Old Allies / We Need Your Help",
+        "type": "Objective"
+      },
+      "gempId": "204_32",
+      "id": 40013,
+      "legacy": false,
+      "nextId": 5776,
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
+      "rarity": "C",
+      "set": "204",
+      "side": "Light"
+    },
+    {
+      "front": {
+        "ability": "2",
+        "deploy": "1",
+        "destiny": "5",
+        "errataSymbol": "E1",
+        "forfeit": "2",
+        "gametext": "If Finn is about to be lost from same site, may place him in Used Pile instead. During your control phase, if present at a battleground site, and another Resistance character on table (or Paige out of play), may retrieve 1 Force.",
+        "icons": [
+          "Pilot",
+          "Warrior",
+          "Episode VII",
+          "Set 9"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/rosetico.gif",
+        "lore": "Female.",
+        "power": "1",
+        "subType": "Resistance",
+        "title": "•Rose Tico",
+        "type": "Character",
+        "uniqueness": "*"
+      },
+      "gempId": "209_11",
+      "id": 40014,
+      "legacy": false,
+      "nextId": 5877,
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
+      "rarity": "C2",
+      "set": "209",
+      "side": "Light"
+    },
+    {
+      "abbr": [
+        "TFISIMF",
+        "Skywalker Saga"
+      ],
+      "counterpart": "Revenge Of The Sith",
+      "front": {
+        "destiny": "0",
+        "errataSymbol": "E1",
+        "gametext": "Deploy on table (only at start of game) and choose: My Father Has It: Anakin (and [Episode I] Obi-Wan) I Have It: Luke (and [Set 1] Obi-Wan) You Have That Power, Too: Rey (and [Episode VII] Luke) [Set 16] Anakin is deploy -1. Your total Force generation is +1. You may not deploy Boss Nass' Chambers or Jedi (except Yoda and the chosen characters). If you just initiated battle involving a Skywalker (or if opponent's Sidious just lost from table), may retrieve 1 Force.",
+        "icons": [
+          "Skywalker",
+          "Episode I",
+          "Death Star II",
+          "Episode VII",
+          "Set 17"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual17-Light/large/theforceisstronginmyfamily.gif",
+        "title": "The Force Is Strong In My Family",
+        "type": "Epic Event"
+      },
+      "gempId": "217_50",
+      "id": 40015,
+      "legacy": false,
+      "nextId": 7003,
+      "printings": [
+        {
+          "set": "217"
+        }
+      ],
+      "pulledBy": [
+        "The Rise Of Skywalker"
+      ],
+      "rarity": "U1",
+      "rulings": [
+        "My Father Has It: To deploy a Jedi, it must be Yoda, Anakin, or Episode I Obi-Wan. May deploy non-Jedi versions of all characters.",
+        "I Have It: To deploy a Jedi, it must be Yoda, Luke, or Set 1 Obi-Wan. May deploy non-Jedi versions of all characters.",
+        "You Have That Power, Too: To deploy a Jedi, it must be Yoda, Rey, or Episode VII Luke. May deploy non-Jedi versions of all characters."
+      ],
+      "set": "217",
+      "side": "Light"
+    },
+    {
+      "abbr": [
+        "TGMNAL/WNLS"
+      ],
+      "back": {
+        "destiny": "7",
+        "errataSymbol": "E1",
+        "gametext": "The Galaxy May Need A Legend:Deploy Ahch-To system and any [Episode VII] battleground.{For} remainder of game, Luke deploys only to Ahch-To. You may not Force drain on Ahch-To. You may not deploy [Episode I] locations or non-[Episode VII] Luke. You may not deploy Jedi while a Jedi on table. Once per game, may take any one card into hand from Force Pile; reshuffle. {While} this side up, once per turn, may use 1 Force to deploy an Ahch-To location or [Episode VII] battleground from Reserve Deck; reshuffle. {May flip} this card if Luke on Ahch-To and a battle was just initiated involving a Resistance character. We Need Luke Skywalker:{Immediately} place Luke out of play (ignore [Death Star II] objective restrictions, if any). For remainder of battle, opponent may not fire weapons.{While} this side up, opponent's immunity to attrition is limited to < 5. Once during your turn, may peek at the top card of your Force Pile and Reserve Deck; place both cards (in any order) on top of one of those piles. Where you have two unique (•) Resistance characters: once per turn, if you just Force drained, opponent loses 1 Force; and once per turn during battle, may cancel an opponent's just drawn destiny to cause a re-draw.",
+        "icons": [
+          "Episode VII",
+          "Set 11"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/weneedlukeskywalker.gif",
+        "title": "The Galaxy May Need A Legend / We Need Luke Skywalker",
+        "type": "Objective"
+      },
+      "front": {
+        "destiny": "0",
+        "errataSymbol": "E1",
+        "gametext": "The Galaxy May Need A Legend:Deploy Ahch-To system and any [Episode VII] battleground.{For} remainder of game, Luke deploys only to Ahch-To. You may not Force drain on Ahch-To. You may not deploy [Episode I] locations or non-[Episode VII] Luke. You may not deploy Jedi while a Jedi on table. Once per game, may take any one card into hand from Force Pile; reshuffle. {While} this side up, once per turn, may use 1 Force to deploy an Ahch-To location or [Episode VII] battleground from Reserve Deck; reshuffle. {May flip} this card if Luke on Ahch-To and a battle was just initiated involving a Resistance character. We Need Luke Skywalker:{Immediately} place Luke out of play (ignore [Death Star II] objective restrictions, if any). For remainder of battle, opponent may not fire weapons.{While} this side up, opponent's immunity to attrition is limited to < 5. Once during your turn, may peek at the top card of your Force Pile and Reserve Deck; place both cards (in any order) on top of one of those piles. Where you have two unique (•) Resistance characters: once per turn, if you just Force drained, opponent loses 1 Force; and once per turn during battle, may cancel an opponent's just drawn destiny to cause a re-draw.",
+        "icons": [
+          "Episode VII",
+          "Set 11"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/thegalaxymayneedalegend.gif",
+        "title": "The Galaxy May Need A Legend / We Need Luke Skywalker",
+        "type": "Objective"
+      },
+      "gempId": "211_36",
+      "id": 40016,
+      "legacy": false,
+      "nextId": 5961,
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
+      "rarity": "R",
+      "rulings": [
+        "While a Jedi on table, also cannot use persona replacement to replace a Jedi with a Jedi, or to replace a non-Jedi with a Jedi.",
+        "Be With Me creates an exception to the above ruling, allowing Set 14 Rey to deploy (and thereby also allowing her to persona replace another Rey).",
+        "(0 side) May flip even if the Resistance character is introduced to the battle during the 'battle just initiated' responses (e.g. Light may deploy Finn as a react, then flip)."
+      ],
+      "set": "211",
+      "side": "Light"
+    },
+    {
+      "front": {
+        "destiny": "0",
+        "gametext": "Plays on Your Destiny unless Leia or Luke has been deployed this game (even as a captive). [Death Star II] Luke and We're The Bait are lost. Opponent's Objective and [Death Star II] Effects target Leia instead of Luke. Force loss from Take Your Father's Place is -1.",
+        "icons": [
+          "Defensive Shield",
+          "Reflections 3",
+          "Set D"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/thereisanother.gif",
+        "lore": "Princess Leia Organa. Alderaanian senator. Targeted by Vader for capture and interrogation. The Datk Lord of the Sith wanted her alive.",
+        "title": "•There Is Another",
+        "type": "Defensive Shield",
+        "uniqueness": "*"
+      },
+      "gempId": "209_15",
+      "id": 40017,
+      "legacy": false,
+      "nextId": 5971,
+      "printings": [
+        {
+          "set": "209"
+        },
+        {
+          "set": "200d"
+        }
+      ],
+      "rarity": "PM",
+      "rulings": [
+        "If the card Luke Skywalker, The Emperor's Prize was successfully deployed at the start of the game, There Is Another may not be played that game."
+      ],
+      "set": "200d",
+      "side": "Light",
+      "sourceType": "character"
+    },
+    {
+      "abbr": [
+        "THNIWC/UWWOTCAS"
+      ],
+      "back": {
+        "destiny": "7",
+        "errataSymbol": "E1",
+        "gametext": "They Have No Idea We're Coming:Deploy Scarif system, Data Vault (with Stardust there), and Massassi War Room.{For} remainder of game, you may not deploy Jedi. Baze, Chirrut, and Rebel troopers are spies.{While} this side up, once per turn, may deploy a Rebel starship (except Home One or [Reflections 3] Falcon) or a Scarif site from Reserve Deck; reshuffle. {Flip} this card if you control two Scarif locations.Until We Win, Or The Chances Are Spent:{While} this side up, your spies are defense value +2 (and power +1 if with Stardust) and are immune to Undercover. While Stardust on your spy, opponent may not cancel your Force drains at battlegrounds. Once per turn, may place a Rebel in your Lost Pile out of play to make a regular move with your Rebel spy during your control phase or cancel an attempt to target your non-Undercover Rebel spy with a weapon.{Flip} this card if you do not occupy two Scarif locations (unless Rogue One at a Scarif site you occupy).",
+        "icons": [
+          "Premium",
+          "Set 9"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/untilwewinorthechancesarespent.gif",
+        "title": "They Have No Idea We're Coming / Until We Win, Or The Chances Are Spent",
+        "type": "Objective"
+      },
+      "front": {
+        "destiny": "0",
+        "errataSymbol": "E1",
+        "gametext": "They Have No Idea We're Coming:Deploy Scarif system, Data Vault (with Stardust there), and Massassi War Room.{For} remainder of game, you may not deploy Jedi. Baze, Chirrut, and Rebel troopers are spies.{While} this side up, once per turn, may deploy a Rebel starship (except Home One or [Reflections 3] Falcon) or a Scarif site from Reserve Deck; reshuffle. {Flip} this card if you control two Scarif locations.Until We Win, Or The Chances Are Spent:{While} this side up, your spies are defense value +2 (and power +1 if with Stardust) and are immune to Undercover. While Stardust on your spy, opponent may not cancel your Force drains at battlegrounds. Once per turn, may place a Rebel in your Lost Pile out of play to make a regular move with your Rebel spy during your control phase or cancel an attempt to target your non-Undercover Rebel spy with a weapon.{Flip} this card if you do not occupy two Scarif locations (unless Rogue One at a Scarif site you occupy).",
+        "icons": [
+          "Premium",
+          "Set 9"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/theyhavenoideawerecoming.gif",
+        "title": "They Have No Idea We're Coming / Until We Win, Or The Chances Are Spent",
+        "type": "Objective"
+      },
+      "gempId": "209_29",
+      "id": 40018,
+      "legacy": false,
+      "nextId": 5974,
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
+      "rarity": "U",
+      "rulings": [
+        "When deploying a starship from Reserve Deck, if the starship is unpiloted, may combine it with a pilot from hand, allowing deployment to a system or sector.",
+        "Once the player initiates the action to deploy a card from Reserve Deck, they must deploy something if possible. Player is <u>required</u> to combine an unpiloted starship with a pilot from hand if that is the only possible option.",
+        "If the attempt to deploy a card from Reserve Deck fails, opponent verifies Reserve Deck (not hand). A judge may be called to review hand and Reserve Deck to confirm that no starship + pilot deployment was possible."
+      ],
+      "set": "209",
+      "side": "Light"
+    }
+  ]
+}

--- a/sets.json
+++ b/sets.json
@@ -502,8 +502,19 @@
     "legacy": false,
     "cycle_code": "full",
     "date_release": "2022-08-15",
-    "position": 218,
+    "position": 219,
     "size": 48
+  },
+  {
+    "id": "220",
+    "name": "Virtual Set 20",
+    "gempName": "Set 20",
+    "abbr": "V20",
+    "legacy": false,
+    "cycle_code": "full",
+    "date_release": "2022-12-12",
+    "position": 220,
+    "size": 8
   },
   {
     "id": "301",


### PR DESCRIPTION
Added new Set 20 cards (image links have been tested)
Applied Set 20 errata to existing cards (including editing their rulings accordingly)
Added the 2020 AIs (image links have been tested)

Added new DarkPreErrata.json and LightPreErrata.json with just the old versions of the cards changed for Set 20. Think of this small sampling as a first draft we can look at and continue to improve.