### PR TITLE
add underlying card data for v22

### DIFF
--- a/Dark.json
+++ b/Dark.json
@@ -3585,7 +3585,13 @@
       ],
       "rarity": "U1",
       "set": "3",
-      "side": "Dark"
+      "side": "Dark",
+      "underlyingCardFor": [
+        {
+          "cardId": 7234,
+          "title": "AT-AT Cannon (V)"
+        }
+      ]
     },
     {
       "front": {
@@ -7093,7 +7099,13 @@
       ],
       "rarity": "PM",
       "set": "108",
-      "side": "Dark"
+      "side": "Dark",
+      "underlyingCardFor": [
+        {
+          "cardId": 7236,
+          "title": "Boba Fett With Blaster Rifle (V)"
+        }
+      ]
     },
     {
       "abbr": [
@@ -7329,7 +7341,13 @@
       ],
       "rarity": "C",
       "set": "4",
-      "side": "Dark"
+      "side": "Dark",
+      "underlyingCardFor": [
+        {
+          "cardId": 7242,
+          "title": "Night Buzzard"
+        }
+      ]
     },
     {
       "front": {
@@ -13765,7 +13783,13 @@
       ],
       "rarity": "U2",
       "set": "2",
-      "side": "Dark"
+      "side": "Dark",
+      "underlyingCardFor": [
+        {
+          "cardId": 7237,
+          "title": "Danz Borin (V)"
+        }
+      ]
     },
     {
       "canceledBy": [
@@ -19946,7 +19970,13 @@
         "(Used) Weapon must be capable of firing and have an eligible target. Not required to have enough Force to fire. If a character with a permanent weapon has had their game text canceled, they cannot fire and therefore cannot use this function."
       ],
       "set": "5",
-      "side": "Dark"
+      "side": "Dark",
+      "underlyingCardFor": [
+        {
+          "cardId": 7247,
+          "title": "Vader's Machination"
+        }
+      ]
     },
     {
       "combo": [
@@ -28385,7 +28415,13 @@
         "If a ♢ site says it may not deploy to a Renegade planet, it may not be deployed by this Objective at start of game."
       ],
       "set": "7",
-      "side": "Dark"
+      "side": "Dark",
+      "underlyingCardFor": [
+        {
+          "cardId": 7261,
+          "title": "The Shield Will Be Down In Moments / Imperial Troops Have Entered The Base!"
+        }
+      ]
     },
     {
       "counterpart": "Rebel Pilot",
@@ -34882,7 +34918,13 @@
       ],
       "rarity": "U1",
       "set": "1",
-      "side": "Dark"
+      "side": "Dark",
+      "underlyingCardFor": [
+        {
+          "cardId": 7241,
+          "title": "Kylo, Master Of The Knights Of Ren"
+        }
+      ]
     },
     {
       "front": {
@@ -39308,7 +39350,13 @@
         "The phrase 'Droid is protected' means that further attempts are not allowed (they are prevented, not canceled)."
       ],
       "set": "3",
-      "side": "Dark"
+      "side": "Dark",
+      "underlyingCardFor": [
+        {
+          "cardId": 7240,
+          "title": "Hoth: Main Power Generators (1st Marker)"
+        }
+      ]
     },
     {
       "combo": [
@@ -40995,7 +41043,13 @@
       ],
       "rarity": "U",
       "set": "11",
-      "side": "Dark"
+      "side": "Dark",
+      "underlyingCardFor": [
+        {
+          "cardId": 7238,
+          "title": "Force Push & Podracer Collision"
+        }
+      ]
     },
     {
       "cancels": [
@@ -41543,7 +41597,13 @@
         "May deploy Naboo Occupation, which is immediately lost, then deploy No Escape to take it into hand. In this case Dark's starting hand will have 1 more card than usual."
       ],
       "set": "9",
-      "side": "Dark"
+      "side": "Dark",
+      "underlyingCardFor": [
+        {
+          "cardId": 7243,
+          "title": "Palpatine, Galactic Emperor"
+        }
+      ]
     },
     {
       "abbr": [
@@ -41834,8 +41894,18 @@
       "set": "3",
       "side": "Dark",
       "underlyingCardFor": [
-        "ID9 Probe Droid",
-        "Probot"
+        {
+          "cardId": 7239,
+          "title": "Holowan Laboratories"
+        },
+        {
+          "cardId": 6796,
+          "title": "ID9 Probe Droid"
+        },
+        {
+          "cardId": 4030,
+          "title": "Probot"
+        }
       ]
     },
     {
@@ -49877,7 +49947,13 @@
       ],
       "rarity": "F",
       "set": "7",
-      "side": "Dark"
+      "side": "Dark",
+      "underlyingCardFor": [
+        {
+          "cardId": 7233,
+          "title": "Ap'lek"
+        }
+      ]
     },
     {
       "front": {
@@ -50183,7 +50259,13 @@
         "This is both an epic event destiny draw and a weapon destiny draw."
       ],
       "set": "3",
-      "side": "Dark"
+      "side": "Dark",
+      "underlyingCardFor": [
+        {
+          "cardId": 7244,
+          "title": "Target The Main Generator (V)"
+        }
+      ]
     },
     {
       "front": {
@@ -54142,7 +54224,13 @@
         "Cards with multiple warrior icons can still only escort one captive at a time."
       ],
       "set": "1",
-      "side": "Dark"
+      "side": "Dark",
+      "underlyingCardFor": [
+        {
+          "cardId": 7246,
+          "title": "Tonnika Sisters (V)"
+        }
+      ]
     },
     {
       "canceledBy": [
@@ -57176,7 +57264,13 @@
       ],
       "rarity": "PM",
       "set": "104",
-      "side": "Dark"
+      "side": "Dark",
+      "underlyingCardFor": [
+        {
+          "cardId": 7248,
+          "title": "Walker Garrison (V)"
+        }
+      ]
     },
     {
       "front": {
@@ -57603,7 +57697,13 @@
       ],
       "rarity": "U",
       "set": "5",
-      "side": "Dark"
+      "side": "Dark",
+      "underlyingCardFor": [
+        {
+          "cardId": 7232,
+          "title": "A Fine Addition To My Collection"
+        }
+      ]
     },
     {
       "front": {
@@ -58586,7 +58686,13 @@
       ],
       "rarity": "R",
       "set": "8",
-      "side": "Dark"
+      "side": "Dark",
+      "underlyingCardFor": [
+        {
+          "cardId": 7235,
+          "title": "Black Krrsantan"
+        }
+      ]
     },
     {
       "cancels": [
@@ -59728,7 +59834,13 @@
       ],
       "rarity": "R1",
       "set": "1",
-      "side": "Dark"
+      "side": "Dark",
+      "underlyingCardFor": [
+        {
+          "cardId": 7249,
+          "title": "Your Powers Are Weak, Old Man (V)"
+        }
+      ]
     },
     {
       "front": {
@@ -68257,7 +68369,7 @@
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual22-Dark/large/hothmainpowergenerators.gif",
         "lightSideIcons": 1,
         "subType": "Site",
-        "title": "•Hoth: Main Power Generators",
+        "title": "•Hoth: Main Power Generators (1st Marker)",
         "type": "Location",
         "uniqueness": "*",
         "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Hoth Main Power Generators (Dark)/image.png",

--- a/Light.json
+++ b/Light.json
@@ -3218,7 +3218,14 @@
       "set": "7",
       "side": "Light",
       "underlyingCardFor": [
-        "Antilles Maneuver (V)"
+        {
+          "cardId": 4001,
+          "title": "Antilles Maneuver (V)"
+        },
+        {
+          "cardId": 7252,
+          "title": "General Poe Dameron"
+        }
       ]
     },
     {
@@ -4415,7 +4422,13 @@
       ],
       "rarity": "U1",
       "set": "3",
-      "side": "Light"
+      "side": "Light",
+      "underlyingCardFor": [
+        {
+          "cardId": 7250,
+          "title": "Attack Pattern Delta (V)"
+        }
+      ]
     },
     {
       "combo": [
@@ -16934,7 +16947,14 @@
       "set": "3",
       "side": "Light",
       "underlyingCardFor": [
-        "Taidu Sefla"
+        {
+          "cardId": 5934,
+          "title": "Taidu Sefla"
+        },
+        {
+          "cardId": 7251,
+          "title": "Echo Base Trooper (V)"
+        }
       ]
     },
     {
@@ -25236,7 +25256,13 @@
         "Also increases any special requirements such as on A Jedi's Strength."
       ],
       "set": "7",
-      "side": "Light"
+      "side": "Light",
+      "underlyingCardFor": [
+        {
+          "cardId": 7258,
+          "title": "The Empire Knows We're Here / Prepare For Ground Assault"
+        }
+      ]
     },
     {
       "front": {
@@ -25568,7 +25594,13 @@
       ],
       "rarity": "C2",
       "set": "3",
-      "side": "Light"
+      "side": "Light",
+      "underlyingCardFor": [
+        {
+          "cardId": 7253,
+          "title": "Hoth: Snow Trench (2nd Marker) (V)"
+        }
+      ]
     },
     {
       "cancels": [
@@ -33538,7 +33570,13 @@
       ],
       "rarity": "PM",
       "set": "104",
-      "side": "Light"
+      "side": "Light",
+      "underlyingCardFor": [
+        {
+          "cardId": 7255,
+          "title": "Lone Rogue (V)"
+        }
+      ]
     },
     {
       "front": {
@@ -39050,7 +39088,13 @@
       ],
       "rarity": "R",
       "set": "9",
-      "side": "Light"
+      "side": "Light",
+      "underlyingCardFor": [
+        {
+          "cardId": 7256,
+          "title": "Nien Nunb, Sullustan Smuggler"
+        }
+      ]
     },
     {
       "canceledBy": [
@@ -43186,7 +43230,14 @@
       "set": "6",
       "side": "Light",
       "underlyingCardFor": [
-        "Force Projection"
+        {
+          "cardId": 5527,
+          "title": "Force Projection"
+        },
+        {
+          "cardId": 7260,
+          "title": "Young Skywalker"
+        }
       ]
     },
     {
@@ -44216,8 +44267,18 @@
       "set": "2",
       "side": "Light",
       "underlyingCardFor": [
-        "Boba",
-        "Quite A Mercenary (V)"
+        {
+          "cardId": 6983,
+          "title": "Boba"
+        },
+        {
+          "cardId": 6586,
+          "title": "Quite A Mercenary (V)"
+        },
+        {
+          "cardId": 7254,
+          "title": "I'm Ready For Anything"
+        }
       ]
     },
     {
@@ -47195,7 +47256,14 @@
       "set": "4",
       "side": "Light",
       "underlyingCardFor": [
-        "General Leia Organa"
+        {
+          "cardId": 5168,
+          "title": "General Leia Organa"
+        },
+        {
+          "cardId": 7257,
+          "title": "Reflection (V)"
+        }
       ]
     },
     {
@@ -53598,7 +53666,10 @@
       "set": "1",
       "side": "Light",
       "underlyingCardFor": [
-        "A Brave Resistance"
+        {
+          "cardId": 5302,
+          "title": "A Brave Resistance"
+        }
       ]
     },
     {
@@ -58582,7 +58653,13 @@
       ],
       "rarity": "R",
       "set": "9",
-      "side": "Light"
+      "side": "Light",
+      "underlyingCardFor": [
+        {
+          "cardId": 7259,
+          "title": "Twilight Is Upon Me (V)"
+        }
+      ]
     },
     {
       "front": {
@@ -73010,7 +73087,7 @@
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual22-Light/large/hothsnowtrench.gif",
         "lightSideIcons": 2,
         "subType": "Site",
-        "title": "•Hoth: Snow Trench (V)",
+        "title": "•Hoth: Snow Trench (2nd Marker) (V)",
         "type": "Location",
         "uniqueness": "*",
         "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Hoth Snow Trench (V)/image.png",


### PR DESCRIPTION
- Add underlying data for all V22 cards
- Update underlying data format for cards are underlying for V22 that were underlying cards for other V cards
- Update text for both V22 Hoth sites to include the Marker designation