### PR TITLE
printableSlipUrl fixes

### DIFF
--- a/Light.json
+++ b/Light.json
@@ -27960,7 +27960,7 @@
         "title": "•Jakku",
         "type": "Location",
         "uniqueness": "*",
-        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Jakku (DS)/image.png",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Jakku (LS)/image.png",
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "204_26",
@@ -28228,7 +28228,7 @@
         "title": "•Jakku: Tuanul Village",
         "type": "Location",
         "uniqueness": "*",
-        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Jakku Tuanul Village (DS)/image.png",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Jakku Tuanul Village (LS)/image.png",
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "204_31",


### PR DESCRIPTION
A couple lines in the Light file were pointing to the DS slips instead of LS slips.  Affects Jakku system and Jakku Tuanul Village.