### PR TITLE
Vkit fixes

### DIFF
--- a/Dark.json
+++ b/Dark.json
@@ -40116,7 +40116,8 @@
       "front": {
         "ability": "2",
         "characteristics": [
-          "Gamorrean"
+          "Gamorrean",
+          "guard"
         ],
         "deploy": "4",
         "destiny": "3",
@@ -40131,9 +40132,7 @@
         "subType": "Alien",
         "title": "•Ortugg",
         "type": "Character",
-        "uniqueness": "*",
-        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Ortugg/image.png",
-        "printableSlipType": "ERRATA"
+        "uniqueness": "*"
       },
       "gempId": "6_118",
       "id": 1862,
@@ -40156,7 +40155,8 @@
       "front": {
         "ability": "2",
         "characteristics": [
-          "Gamorrean"
+          "Gamorrean",
+          "guard"
         ],
         "deploy": "3",
         "destiny": "3",
@@ -40174,7 +40174,9 @@
         "subType": "Alien",
         "title": "•Ortugg (V)",
         "type": "Character",
-        "uniqueness": "*"
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Ortugg/image.png",
+        "printableSlipType": "VIRTUAL"
       },
       "gempId": "203_28",
       "id": 5025,

--- a/Light.json
+++ b/Light.json
@@ -64618,7 +64618,9 @@
         "subType": "Alien",
         "title": "•Han... Solo",
         "type": "Character",
-        "uniqueness": "*"
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Han Solo/image.png",
+        "printableSlipType": "VIRTUAL"
       },
       "gempId": "213_37",
       "id": 6828,


### PR DESCRIPTION
Added missing vkit slip for Han... Solo
Moved Ortugg's vkit slip from an errata on the original to a v-slip on the virtual
Noted that Ortugg and Ortugg (V) are guards