### PR TITLE
Vkit slip fixes

### DIFF
--- a/Dark.json
+++ b/Dark.json
@@ -8734,7 +8734,7 @@
         "title": "•Captain Phasma",
         "type": "Character",
         "uniqueness": "*",
-        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Captain Phasma (AI - Hologram)/image.png",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Captain Phasma/image.png",
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "204_38",
@@ -8784,7 +8784,9 @@
         "subType": "First Order",
         "title": "•Captain Phasma (AI)",
         "type": "Character",
-        "uniqueness": "*"
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Captain Phasma (AI - Hologram)/image.png",
+        "printableSlipType": "VIRTUAL"
       },
       "gempId": "204_38",
       "id": 7007,
@@ -23708,7 +23710,7 @@
         "title": "•General Grievous",
         "type": "Character",
         "uniqueness": "*",
-        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/General Grievous (AI - Hologram)/image.png",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/General Grievous/image.png",
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "203_27",
@@ -23759,7 +23761,9 @@
         "subType": "Republic",
         "title": "•General Grievous (Holo AI)",
         "type": "Character",
-        "uniqueness": "*"
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/General Grievous (AI - Hologram)/image.png",
+        "printableSlipType": "VIRTUAL"
       },
       "gempId": "203_27",
       "id": 6321,
@@ -49624,7 +49628,7 @@
         "title": "•Supreme Leader Snoke",
         "type": "Character",
         "uniqueness": "*",
-        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Supreme Leader Snoke (AI - Hologram)/image.png",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Supreme Leader Snoke/image.png",
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "209_39",
@@ -49665,7 +49669,9 @@
         "subType": "Dark Jedi Master/First Order",
         "title": "•Supreme Leader Snoke (AI)",
         "type": "Character",
-        "uniqueness": "*"
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Supreme Leader Snoke (AI - Hologram)/image.png",
+        "printableSlipType": "VIRTUAL"
       },
       "gempId": "209_39",
       "id": 7019,

--- a/Light.json
+++ b/Light.json
@@ -941,7 +941,7 @@
         "title": "•Aayla Secura",
         "type": "Character",
         "uniqueness": "*",
-        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Aayla Secura (AI - Hologram)/image.png",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Aayla Secura/image.png",
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "200_1",
@@ -985,7 +985,9 @@
         "subType": "Alien",
         "title": "•Aayla Secura (AI)",
         "type": "Character",
-        "uniqueness": "*"
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Aayla Secura (AI - Hologram)/image.png",
+        "printableSlipType": "VIRTUAL"
       },
       "gempId": "200_1",
       "id": 5312,
@@ -8308,7 +8310,7 @@
         "title": "•Captain Rex, 501st Legion",
         "type": "Character",
         "uniqueness": "*",
-        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Captain Rex 501st Legion (AI - Hologram)/image.png",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Captain Rex 501st Legion/image.png",
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "200_3",
@@ -11097,7 +11099,7 @@
         "title": "•Commander Cody",
         "type": "Character",
         "uniqueness": "*",
-        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Commander Cody (AI - Hologram)/image.png",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Commander Cody/image.png",
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "200_6",
@@ -11141,7 +11143,9 @@
         "subType": "Republic",
         "title": "•Commander Cody (AI)",
         "type": "Character",
-        "uniqueness": "*"
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Commander Cody (AI - Hologram)/image.png",
+        "printableSlipType": "VIRTUAL"
       },
       "gempId": "200_6",
       "id": 7025,
@@ -30429,7 +30433,7 @@
         "title": "•Kit Fisto",
         "type": "Character",
         "uniqueness": "*",
-        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Kit Fisto (AI - Hologram)/image.png",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Kit Fisto/image.png",
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "210_19",
@@ -30470,7 +30474,9 @@
         "subType": "Jedi Master",
         "title": "•Kit Fisto (AI)",
         "type": "Character",
-        "uniqueness": "*"
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Kit Fisto (AI - Hologram)/image.png",
+        "printableSlipType": "VIRTUAL"
       },
       "gempId": "210_19",
       "id": 7032,
@@ -71680,7 +71686,9 @@
         "subType": "Republic",
         "title": "•Captain Rex, 501st Legion (Holo AI)",
         "type": "Character",
-        "uniqueness": "*"
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Captain Rex 501st Legion (AI - Hologram)/image.png",
+        "printableSlipType": "VIRTUAL"
       },
       "gempId": "200_3",
       "id": 7147,


### PR DESCRIPTION
Fixing many instances where the regular card vkit slip linked to a Hologram AI, and the Hologram AI was missing a vkit slip.

Now the regular card links to the regular slip and the hologram AI links to the hologram AI slip.