### PR TITLE
Tweak Set 2026

### DIFF
--- a/Dark.json
+++ b/Dark.json
@@ -67589,7 +67589,7 @@
       "front": {
         "ability": "7",
         "deploy": "5",
-        "destiny": "1",
+        "destiny": "6",
         "extraText": [
           "Dark Jedi Master"
         ],

--- a/Dark.json
+++ b/Dark.json
@@ -18783,6 +18783,7 @@
       "gempId": "211_19",
       "id": 6262,
       "legacy": false,
+      "previousId": 20074,
       "printings": [
         {
           "set": "211"
@@ -35897,14 +35898,11 @@
         "forfeit": "0",
         "gametext": "{Immediately} 'thaw' Luke (Luke is non-frozen, captured, and seized by Vader). {While} this side up, subtracts 3 from attempts to cross Lule over (even while a captive). {Place} out of play if released or about to leave table.",
         "icons": [
-          "Set 5"
-        ],
-        "imageUrl": "https://res.starwarsccg.org/cards/Virtual5-Dark/large/lukeskywalkertheemperorsprizeback.gif",
-        "icons": [
             "Pilot",
             "Warrior",
             "Set 5"
         ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual5-Dark/large/lukeskywalkertheemperorsprizeback.gif",
         "power": "6",
         "subType": "Rebel",
         "title": "•Luke Skywalker, The Emperor's Prize / •Luke Skywalker, The Emperor's Prize",
@@ -63897,6 +63895,7 @@
       "gempId": "214_12",
       "id": 6854,
       "legacy": false,
+      "previousId": 20068,
       "printings": [
         {
           "set": "214"
@@ -64327,6 +64326,7 @@
       "gempId": "215_25",
       "id": 6899,
       "legacy": false,
+      "previousId": 20069,
       "printings": [
         {
           "set": "215"
@@ -64937,6 +64937,7 @@
       "gempId": "216_11",
       "id": 6914,
       "legacy": false,
+      "previousId": 20064,
       "printings": [
         {
           "set": "216"
@@ -65086,6 +65087,7 @@
       "gempId": "216_15",
       "id": 6918,
       "legacy": false,
+      "previousId": 20061,
       "printings": [
         {
           "set": "216"
@@ -65122,6 +65124,7 @@
       "gempId": "216_16",
       "id": 6919,
       "legacy": false,
+      "previousId": 20062,
       "printings": [
         {
           "set": "216"
@@ -66635,6 +66638,7 @@
       "gempId": "218_9",
       "id": 7049,
       "legacy": false,
+      "previousId": 20063,
       "printings": [
         {
           "set": "218"
@@ -67577,7 +67581,7 @@
     },
     {
       "abbr": [
-        "TEv"
+        "TER"
       ],
       "front": {
         "ability": "7",
@@ -67593,19 +67597,20 @@
           "Death Star II",
           "Set 19"
         ],
-        "imageUrl": "https://res.starwarsccg.org/cards/Virtual19-Dark/large/theemperor.gif",
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual19-Dark/large/theemperorrelentless.gif",
         "lore": "Leader. Secretive manipulator of the galaxy. Played Darth Vader and Prince Xizor off against one another in his relentless pursuit of 'young Skywalker.'",
         "power": "4",
         "subType": "Dark Jedi Master/Imperial",
-        "title": "•The Emperor (V)",
+        "title": "•The Emperor, Relentless",
         "type": "Character",
         "uniqueness": "*",
-        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/The Emperor (V)/image.png",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/The Emperor, Relentless/image.png",
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "219_19",
       "id": 7091,
       "legacy": false,
+      "previousId": 20065,
       "printings": [
         {
           "set": "219"
@@ -67793,6 +67798,7 @@
       "gempId": "219_24",
       "id": 7096,
       "legacy": false,
+      "previousId": 20072,
       "printings": [
         {
           "set": "219"
@@ -68200,6 +68206,7 @@
       "gempId": "220_5",
       "id": 7127,
       "legacy": false,
+      "previousId": 20066,
       "matching": [
         "Mist Hunter"
       ],
@@ -70732,6 +70739,7 @@
       "gempId": "222_18",
       "id": 7249,
       "legacy": false,
+      "previousId": 20073,
       "printings": [
         {
           "set": "222"
@@ -71913,7 +71921,7 @@
       "gempId": "223_19",
       "id": 7307,
       "legacy": false,
-      "previousId": 20050,
+      "previousId": 20067,
       "printings": [
         {
           "set": "223"
@@ -72105,6 +72113,7 @@
       "gempId": "223_25",
       "id": 7313,
       "legacy": false,
+      "previousId": 20071,
       "printings": [
         {
           "set": "223"
@@ -74172,6 +74181,7 @@
       "gempId": "225_32",
       "id": 7416,
       "legacy": false,
+      "previousId": 20075,
       "printings": [
         {
           "set": "225"
@@ -74317,6 +74327,7 @@
       "gempId": "225_36",
       "id": 7420,
       "legacy": false,
+      "previousId": 20070,
       "printings": [
         {
           "set": "225"
@@ -74877,6 +74888,7 @@
       "gempId": "226_12",
       "id": 7456,
       "legacy": false,
+      "previousId": 20076,
       "printings": [
         {
           "set": "226"

--- a/Dark.json
+++ b/Dark.json
@@ -568,6 +568,9 @@
       "side": "Dark"
     },
     {
+      "abbr": [
+        "ABCTTU"
+      ],
       "front": {
         "destiny": "4",
         "gametext": "Deploy on Death Star system or Coruscant system. Target another system. At locations related to target system, opponent's Force drain modifiers are canceled. Effect canceled if opponent controls this system. (Immune to Alter.)",
@@ -5297,7 +5300,7 @@
         "icons": [
           "Interior",
           "Exterior",
-          "Cave",
+          "Creature Site",
           "Planet",
           "Dagobah"
         ],
@@ -53960,7 +53963,7 @@
           "Reflections 2"
         ],
         "imageUrl": "https://res.starwarsccg.org/cards/ReflectionsII-Dark/large/theemperor.gif",
-        "lore": "Leader. Secretive manipulator of the galaxy. Played Darth Vader and Prince Xizor off against one another in his relentless pursuit of 'young Skywalker'.",
+        "lore": "Leader. Secretive manipulator of the galaxy. Played Darth Vader and Prince Xizor off against one another in his relentless pursuit of 'young Skywalker.'",
         "power": "4",
         "subType": "Dark Jedi Master/Imperial",
         "title": "•The Emperor",
@@ -73969,7 +73972,7 @@
           "Scomp Link",
           "Episode VII",
           "First Order",
-          "Permanent Pilot",
+          "Pilot",
           "Nav Computer",
           "Set 25"
         ],
@@ -74974,7 +74977,7 @@
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "204_47",
-      "id": 5101,
+      "id": 7473,
       "legacy": false,
       "printings": [
         {
@@ -75016,7 +75019,7 @@
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "200_109",
-      "id": 1276,
+      "id": 7474,
       "legacy": false,
       "printings": [
         {
@@ -75057,7 +75060,7 @@
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "213_23",
-      "id": 6811,
+      "id": 7475,
       "legacy": false,
       "printings": [
         {
@@ -75096,7 +75099,7 @@
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "211_23",
-      "id": 6419,
+      "id": 7476,
       "legacy": false,
       "printings": [
         {
@@ -75137,7 +75140,7 @@
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "208_35",
-      "id": 5188,
+      "id": 7477,
       "legacy": false,
       "printings": [
         {
@@ -75193,7 +75196,7 @@
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "200_85",
-      "id": 4028,
+      "id": 7478,
       "legacy": false,
       "printings": [
         {
@@ -75243,7 +75246,7 @@
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "200_88",
-      "id": 4030,
+      "id": 7479,
       "legacy": false,
       "printings": [
         {
@@ -75281,7 +75284,7 @@
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "219_27",
-      "id": 7099,
+      "id": 7480,
       "legacy": false,
       "printings": [
         {
@@ -75326,7 +75329,7 @@
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "204_46",
-      "id": 5100,
+      "id": 7481,
       "legacy": false,
       "printings": [
         {

--- a/DarkPreErrata.json
+++ b/DarkPreErrata.json
@@ -2600,6 +2600,664 @@
       "rarity": "U2",
       "set": "208",
       "side": "Dark"
+    },
+    {
+      "front": {
+        "darkSideIcons": 1,
+        "destiny": "0",
+        "gametext": "Dark: If a player just Force drained here, they may raise a converted Scarif location to the top. Light: Unless your spy here, total ability of 6 or more required for you to draw battle destiny here.",
+        "icons": [
+          "Interior",
+          "Planet",
+          "Scomp Link",
+          "Set 16"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual16-Dark/large/scarifcitadeltower.gif",
+        "lightSideIcons": 1,
+        "subType": "Site",
+        "title": "•Scarif: Citadel Tower",
+        "type": "Location",
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Scarif Citadel Tower/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "216_15",
+      "id": 20061,
+      "legacy": false,
+      "nextId": 6918,
+      "printings": [
+        {
+          "set": "216"
+        }
+      ],
+      "pulledBy": [
+        "Neimoidian Advisor",
+        "On The Verge Of Greatness"
+      ],
+      "rarity": "U2",
+      "set": "216",
+      "side": "Dark"
+    },
+    {
+      "front": {
+        "darkSideIcons": 2,
+        "destiny": "0",
+        "gametext": "Dark: If an Imperial leader here, add one destiny to your [Set 9] Epic Event total targeting a Scarif site. Light: If Shield Gate on table, opponent's Force drains here are +1.",
+        "icons": [
+          "Interior",
+          "Planet",
+          "Scomp Link",
+          "Set 16"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual16-Dark/large/scarifcommandcenter.gif",
+        "lightSideIcons": 1,
+        "subType": "Site",
+        "title": "•Scarif: Command Center",
+        "type": "Location",
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Scarif Command Center/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "216_16",
+      "id": 20062,
+      "legacy": false,
+      "nextId": 6919,
+      "printings": [
+        {
+          "set": "216"
+        }
+      ],
+      "pulledBy": [
+        "Neimoidian Advisor",
+        "On The Verge Of Greatness"
+      ],
+      "rarity": "U",
+      "set": "216",
+      "side": "Dark"
+    },
+    {
+      "abbr": [
+        "CTRv",
+        "Crush V"
+      ],
+      "front": {
+        "destiny": "4",
+        "gametext": "If Visage Of The Emperor on table, deploy on table. At Mustafar, Devastator is deploy -3 and immune to attrition < 6. Once per turn, may deploy Devastator, Mustafar, or a private platform from Reserve Deck; reshuffle. [Immune to Alter.]",
+        "icons": [
+          "Premium",
+          "Set 18"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual18-Dark/large/crushtherebellion.gif",
+        "lore": "After dueling his son and seizing control of a city in the clouds, Vader resumed his quest to destroy the Alliance.",
+        "title": "•Crush The Rebellion (V)",
+        "type": "Effect",
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Crush The Rebellion (V)/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "218_9",
+      "id": 20063,
+      "legacy": false,
+      "nextId": 7049,
+      "printings": [
+        {
+          "set": "218"
+        }
+      ],
+      "pulledBy": [
+        "Seal Off The Bridge",
+        "Surface Defense (V)",
+        "Twi'lek Advisor",
+        "We Must Accelerate Our Plans"
+      ],
+      "pulls": [
+        "Coruscant: Private Platform (Docking Bay)",
+        "Devastator",
+        "Devastator (V)",
+        "Mustafar",
+        "Mustafar: Private Platform (Docking Bay)"
+      ],
+      "rarity": "PM",
+      "rulings": [
+        "Either virtual or non-virtual Visage Of The Emperor anywhere on table will allow this card to deploy."
+      ],
+      "set": "218",
+      "side": "Dark"
+    },
+    {
+      "abbr": [
+        "OTVOG/TCOTW",
+        "OVG"
+      ],
+      "back": {
+        "destiny": "7",
+        "gametext": "On The Verge Of Greatness: Deploy [Set 16] Death Star and Scarif systems, Citadel Tower, Commence Primary Ignition, and Shield Gate. {For} remainder of game, you may not deploy characters of ability > 4 (except Vader). Vader is power +2 and he (or a Star Destroyer he is piloting) may make a regular move to a battle just initiated. {While} this side up, once per turn, may deploy a site (or Imperial trooper) to Scarif from Reserve Deck; reshuffle. {Flip} this card if Krennic or Tarkin on Scarif and Death Star orbiting Scarif. Taking Control Of The Weapon: {While} this side up, your Force generation is +2 for each 'blown away' Scarif site. Tarkin Doctrine is immune to Alter and, when it initiates Force loss, may take any one card into hand from Force Pile. Once per turn, if opponent's character just lost from your site, may place it out of play unless opponent loses 1 Force. Tarkin adds 3 to total of Commence Primary Ignition. {Flip} this card if you have no leaders on Scarif. {Place} this card out of play if Shield Gate not on table or if Death Star has been 'blown away.'",
+        "icons": [
+          "Set 16"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual16-Dark/large/takingcontroloftheweapon.gif",
+        "title": "On The Verge Of Greatness / Taking Control Of The Weapon",
+        "type": "Objective",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Taking Control Of The Weapon/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "front": {
+        "destiny": "0",
+        "gametext": "On The Verge Of Greatness: Deploy [Set 16] Death Star and Scarif systems, Citadel Tower, Commence Primary Ignition, and Shield Gate. {For} remainder of game, you may not deploy characters of ability > 4 (except Vader). Vader is power +2 and he (or a Star Destroyer he is piloting) may make a regular move to a battle just initiated. {While} this side up, once per turn, may deploy a site (or Imperial trooper) to Scarif from Reserve Deck; reshuffle. {Flip} this card if Krennic or Tarkin on Scarif and Death Star orbiting Scarif. Taking Control Of The Weapon: {While} this side up, your Force generation is +2 for each 'blown away' Scarif site. Tarkin Doctrine is immune to Alter and, when it initiates Force loss, may take any one card into hand from Force Pile. Once per turn, if opponent's character just lost from your site, may place it out of play unless opponent loses 1 Force. Tarkin adds 3 to total of Commence Primary Ignition. {Flip} this card if you have no leaders on Scarif. {Place} this card out of play if Shield Gate not on table or if Death Star has been 'blown away.'",
+        "icons": [
+          "Set 16"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual16-Dark/large/onthevergeofgreatness.gif",
+        "title": "On The Verge Of Greatness / Taking Control Of The Weapon",
+        "type": "Objective",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/On The Verge Of Greatness/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "216_11",
+      "id": 20064,
+      "legacy": false,
+      "nextId": 6914,
+      "printings": [
+        {
+          "set": "216"
+        }
+      ],
+      "rarity": "U",
+      "rulings": [
+        "Vader can make any type of regular move into battle. Examples include landspeed, shuttling (up or down) and docking bay transit.",
+        "The 'move to a battle' text does <u>not</u> permit an unlimited move, (e.g. it does not allow Vader to disembark Blizzard 4).",
+        "Star Destroyer regular movement includes using hyperspeed, moving between a Death Star and a system it is orbiting, and moving to/from/between asteroid sectors.",
+        "Vader and a Star Destroyer he is piloting can <u>each</u> make one regular move on each turn (including Light's turn), whether the regular move is via this card or not.",
+        "If Vader (or a Star Destroyer he is piloting) has already battled this turn, they can still make a regular move to a battle, but will not participate in that second battle.",
+        "Vader cannot use the text on Vader's Castle to move into battle, nor any other site that specifies that it only works during move phase.",
+        "(7-side) Even if Tarkin Doctrine causes multiple Force loss, it only initiates Force loss once per turn."
+      ],
+      "set": "216",
+      "side": "Dark"
+    },
+    {
+      "abbr": [
+        "TEv"
+      ],
+      "front": {
+        "ability": "7",
+        "deploy": "5",
+        "destiny": "1",
+        "extraText": [
+          "Dark Jedi Master"
+        ],
+        "forfeit": "9",
+        "gametext": "Destiny +1 for each Black Sun agent or Jedi on table (limit +5) when drawn for destiny. Deploys only to Coruscant. Never deploys or moves (even if carried) to a site opponent occupies. May cancel Projection Of A Skywalker here. Immune to attrition.",
+        "icons": [
+          "Reflections II",
+          "Death Star II",
+          "Set 19"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual19-Dark/large/theemperor.gif",
+        "lore": "Leader. Secretive manipulator of the galaxy. Played Darth Vader and Prince Xizor off against one another in his relentless pursuit of 'young Skywalker.'",
+        "power": "4",
+        "subType": "Dark Jedi Master/Imperial",
+        "title": "•The Emperor (V)",
+        "type": "Character",
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/The Emperor (V)/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "219_19",
+      "id": 20065,
+      "legacy": false,
+      "nextId": 7091,
+      "printings": [
+        {
+          "set": "219"
+        }
+      ],
+      "rarity": "PM",
+      "rulings": [
+        "To determine destiny bonus, count up all cards that are either Black Sun agents or Jedi (e.g. if there are 3 Black Sun agents and 1 Jedi, then The Emperor is destiny +4).",
+        "Do not count inactive cards such as a captive Jedi."
+      ],
+      "set": "219",
+      "side": "Dark"
+    },
+    {
+      "front": {
+        "ability": "4",
+        "characteristics": [
+          "Black Sun agent",
+          "bounty hunter",
+          "Gand",
+          "scout"
+        ],
+        "deploy": "3",
+        "destiny": "1",
+        "extraText": [
+          "Force-Sensitive"
+        ],
+        "forfeit": "4",
+        "gametext": "Adds 2 to power of anything he pilots. Power and defense value +2 with 4-LOM. Once during battle, if opponent just drew weapon or battle destiny, may draw destiny; reset opponent's destiny number to your drawn destiny number. Immune to attrition < 3.",
+        "icons": [
+          "Dagobah",
+          "Pilot",
+          "Warrior",
+          "Set 20"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual20-Dark/large/zuckuss.gif",
+        "lore": "Male Gand. Practitioner of ancient religious findsman vocation. Bounty hunter and scout. Gains surprisingly accurate information through mystical visions during meditation.",
+        "power": "3",
+        "subType": "Alien",
+        "title": "•Zuckuss (V)",
+        "type": "Character",
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Zuckuss (V)/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "220_5",
+      "id": 20066,
+      "legacy": false,
+      "nextId": 7127,
+      "matching": [
+        "Mist Hunter"
+      ],
+      "matchingWeapon": [
+        "Zuckuss' Snare Rifle"
+      ],
+      "printings": [
+        {
+          "set": "220"
+        }
+      ],
+      "rarity": "R",
+      "set": "220",
+      "side": "Dark"
+    },
+    {
+      "abbr": [
+        "ORv"
+      ],
+      "front": {
+        "destiny": "5",
+        "errataDate": "2024-12-30",
+        "errataNotes": "Added 'Perimeter Patrol is suspended.' to game text.",
+        "errataSymbol": "E1",
+        "gametext": "Deploy on Bunker; may immediately take any one [Endor] or [Death Star II] card into hand from Force Pile; reshuffle. While an Imperial leader here, your total Force generation is +1. Perimeter Patrol is suspended. If opponent controls Bunker, place Effect in Used Pile. [Immune to Alter.]",
+        "icons": [
+          "Endor",
+          "Set 23"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual23-Dark/large/ominousrumors.gif",
+        "lore": "Rumors of a new 'technological terror' filled the galaxy with dread.",
+        "title": "•Ominous Rumors (V)",
+        "type": "Effect",
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Ominous Rumors (V)/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "223_19",
+      "id": 20067,
+      "legacy": false,
+      "nextId": 7307,
+      "previousId": 20050,
+      "printings": [
+        {
+          "set": "223"
+        }
+      ],
+      "rarity": "R",
+      "rulings": [
+        "In the event that Light controls Bunker when Dark deploys this card, this card goes to Used Pile as an automatic response, leaving Dark unable to take a card into hand from Force Pile."
+      ],
+      "set": "223",
+      "side": "Dark"
+    },
+    {
+      "front": {
+        "destiny": "4",
+        "gametext": "Deploy on table. Your [Episode VII] troopers are forfeit +1. Once per turn, if [Episode VII] Emperor on table, may deploy Kijimi from Reserve Deck (reshuffle) or place any three cards out of play from your Lost Pile to deploy a non-unique [Episode VII] trooper from Lost Pile. (Immune to Alter.)",
+        "icons": [
+          "Episode VII",
+          "Set 14"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual14-Dark/large/thefirstorderwasjustthebeginning.gif",
+        "lore": "Blank.",
+        "title": "•The First Order Was Just The Beginning",
+        "type": "Effect",
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/The First Order Was Just The Beginning/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "214_12",
+      "id": 20068,
+      "legacy": false,
+      "nextId": 6854,
+      "printings": [
+        {
+          "set": "214"
+        }
+      ],
+      "rarity": "R",
+      "set": "214",
+      "side": "Dark"
+    },
+    {
+      "front": {
+        "destiny": "0",
+        "gametext": "If you did not deploy an Objective, deploy on Executor. We're Not Going To Attack?: Your squadrons are destiny = 0. You may not deploy squadrons or non-Imperial starships. Unless you occupy a battleground site, Dreaded Imperial Starfleet is suspended. The Alliance Will Die...: Flagship Operations does not require any Executor sites on table to deploy. ...As Will Your Friends: At battleground systems where you have a piloted capital starship and a piloted TIE, your Force drains = 2. At sites related to systems you control, during battle may add one destiny to total power. If just lost, lose 3 Force.",
+        "icons": [
+          "Set 15"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual15-Dark/large/emperorsorders.gif",
+        "title": "•Emperor's Orders",
+        "type": "Epic Event",
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Emperors Orders/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "215_25",
+      "id": 20069,
+      "legacy": false,
+      "nextId": 6899,
+      "printings": [
+        {
+          "set": "215"
+        }
+      ],
+      "rarity": "C",
+      "rulings": [
+        "May only deploy on the Executor starship card (not on an Executor site).",
+        "A TIE inside a star destroyer is landed/unpiloted so it does not give Force drain = 2.",
+        "When Force drains = 2, they cannot be modified, but the Force loss could be modified by (for example) It Could Be Worse."
+      ],
+      "set": "215",
+      "side": "Dark"
+    },
+    {
+      "abbr": [
+        "WTA"
+      ],
+      "front": {
+        "destiny": "0",
+        "gametext": "Deploy on Galactic Senate. [V17] Passel Argente's game text and your Political Effects are canceled. Twice per turn, may target your agenda here: Blockade: Cancel a 'react.' Taxation: Place a card with no printed destiny number > 4 from hand in Used Pile to activate 1 Force. Trade: During your draw phase, place a card from hand in Lost Pile, shuffle that pile, and take top card into hand. Wealth: Subtract 1 from attrition against you.",
+        "icons": [
+          "Coruscant",
+          "Episode I",
+          "Set 25"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual25-Dark/large/withthunderousapplause.gif",
+        "title": "•With Thunderous Applause",
+        "type": "Epic Event",
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/With Thunderous Applause/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "225_36",
+      "id": 20070,
+      "legacy": false,
+      "nextId": 7420,
+      "printings": [
+        {
+          "set": "225"
+        }
+      ],
+      "rarity": "R",
+      "rulings": [
+        "The same agenda / same character may be targeted twice in the same turn.",
+        "However, note that Wealth's 'subtract 1 from attrition' is not cumulative."
+      ],
+      "set": "225",
+      "side": "Dark"
+    },
+    {
+      "abbr": [
+        "TEBv"
+      ],
+      "front": {
+        "destiny": "3",
+        "gametext": "USED: Deploy Empire's New Order or Overseeing It Personally from Reserve Deck; reshuffle. LOST: Once per game, choose: Place an opponent's just-played Interrupt out of play. OR If Xizor (or two Imperial leaders) in battle, re-circulate.",
+        "icons": [
+          "Set 23"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual23-Dark/large/theempiresback.gif",
+        "lore": "'No star system will dare oppose the Emperor now.'",
+        "subType": "Used Or Lost",
+        "title": "The Empire's Back (V)",
+        "type": "Interrupt",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/The Empire's Back (V)/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "223_25",
+      "id": 20071,
+      "legacy": false,
+      "nextId": 7313,
+      "printings": [
+        {
+          "set": "223"
+        }
+      ],
+      "rarity": "U1",
+      "set": "223",
+      "side": "Dark"
+    },
+    {
+      "abbr": [
+        "UAUAS"
+      ],
+      "front": {
+        "destiny": "4",
+        "gametext": "USED: Target a character in battle. Target and cards that share any characteristic with target are power and forfeit -1. LOST: Once per game, if your [Set 19] objective just `studied' a character, add one battle destiny (two if a character of same species is participating in battle).",
+        "icons": [
+          "Set 19"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual19-Dark/large/understandartunderstandaspecies.gif",
+        "lore": "The Empire considers alien species to be inferior.",
+        "subType": "Used Or Lost",
+        "title": "•Understand Art, Understand A Species",
+        "type": "Interrupt",
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Understand Art Understand A Species/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "219_24",
+      "id": 20072,
+      "legacy": false,
+      "nextId": 7096,
+      "printings": [
+        {
+          "set": "219"
+        }
+      ],
+      "rarity": "C",
+      "rulings": [
+        "(USED) A list of all characteristics is provided in Appendix D of the Advanced Rulebook.",
+        "(USED) For example, if targeting Captain Han Solo, all captains, smugglers, Corellians, and scoundrels in the battle are power and forfeit -1.",
+        "(USED) Change lasts until the end of the battle.",
+        "(USED) The initial target can even belong to Dark player, but all the additional affected characters are still opponent's only.",
+        "(USED) May be used even if no other cards share any characteristic with target.",
+        "(USED) May be used even if the target has no characteristics (in which case, only the target is power and forfeit -1).",
+        "(USED) Only character cards have characteristics, so only character cards can be made power and forfeit -1.",
+        "(LOST) The 'character of same species' may even be an exact duplicate of the studied card."
+      ],
+      "set": "219",
+      "side": "Dark"
+    },
+    {
+      "abbr": [
+        "YPAWOMv"
+      ],
+      "combo": [
+        "Ommni Box & It's Worse (V)"
+      ],
+      "front": {
+        "destiny": "5",
+        "gametext": "If opponent just lost a battle, they lose 2 Force. OR During battle, if Obi-Wan is participating (or 'communing'), add one battle destiny; characters may not be 'revived' this turn. OR Cancel Clash Of Sabers targeting your Dark Jedi.",
+        "icons": [
+          "Set 22"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual22-Dark/large/yourpowersareweakoldman.gif",
+        "lore": "'You should not have come back.'",
+        "subType": "Lost",
+        "title": "Your Powers Are Weak, Old Man (V)",
+        "type": "Interrupt",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Your Powers Are Weak Old Man/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "222_18",
+      "id": 20073,
+      "legacy": false,
+      "nextId": 7249,
+      "printings": [
+        {
+          "set": "222"
+        }
+      ],
+      "rarity": "R1",
+      "rulings": [
+        "Multiple copies of this card may be played after winning a battle, causing 2 Force loss each."
+      ],
+      "set": "222",
+      "side": "Dark"
+    },
+    {
+      "front": {
+        "darkSideIcons": 2,
+        "destiny": "0",
+        "gametext": "Dark: Once per turn, if you just moved a [First Order] starship to here, may activate 2 Force. Light: Unless your Resistance leader here, Force drain -1 here.",
+        "icons": [
+          "Planet",
+          "Episode VII",
+          "Set 11"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Dark/large/dqar.gif",
+        "lightSideIcons": 1,
+        "parsec": "5",
+        "subType": "System",
+        "title": "•D'Qar",
+        "type": "Location",
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/DQar/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "211_19",
+      "id": 20074,
+      "legacy": false,
+      "nextId": 6262,
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
+      "rarity": "U",
+      "set": "211",
+      "side": "Dark"
+    },
+    {
+      "abbr": [
+        "TFOR/TRID"
+      ],
+      "back": {
+        "destiny": "7",
+        "gametext": "The First Order Reigns: Deploy Crait and D'Qar systems, Supremacy: Bridge, and Tracked Fleet. For remainder of game, you may not deploy cards with ability except [Episode VII] cards. Your [Episode VII] characters and starships are power +1. Supremacy is deploy -9 to [Episode VII] systems. Once per turn, may deploy an [Episode VII] battleground from Reserve Deck; reshuffle. While this side up, neither player loses more than 1 Force to Force drains at systems (unless Tracked Fleet there). Flip this card if Tracked Fleet is 'annihilated.' The Resistance Is Doomed: While this side up, once per turn, may deploy a non-unique trooper (or non-unique [First Order] vehicle) from Lost Pile. While you occupy a Crait location, your Force drains at battlegrounds where you have two First Order characters are +1. While Kylo occupies Salt Plateau, opponent may not Force drain where their character or permanent pilot is alone. While you control Salt Plateau, opponent's Force retrieval is canceled. Place out of play if Kylo just forfeited from a battle you lost at Salt Plateau where Han, Leia, or Luke present.",
+        "icons": [
+          "Episode VII",
+          "Set 25"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual25-Dark/large/theresistanceisdoomed.gif",
+        "title": "The First Order Reigns / The Resistance Is Doomed",
+        "type": "Objective",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/The Resistance Is Doomed/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "front": {
+        "destiny": "0",
+        "gametext": "The First Order Reigns: Deploy Crait and D'Qar systems, Supremacy: Bridge, and Tracked Fleet. For remainder of game, you may not deploy cards with ability except [Episode VII] cards. Your [Episode VII] characters and starships are power +1. Supremacy is deploy -9 to [Episode VII] systems. Once per turn, may deploy an [Episode VII] battleground from Reserve Deck; reshuffle. While this side up, neither player loses more than 1 Force to Force drains at systems (unless Tracked Fleet there). Flip this card if Tracked Fleet is 'annihilated.' The Resistance Is Doomed: While this side up, once per turn, may deploy a non-unique trooper (or non-unique [First Order] vehicle) from Lost Pile. While you occupy a Crait location, your Force drains at battlegrounds where you have two First Order characters are +1. While Kylo occupies Salt Plateau, opponent may not Force drain where their character or permanent pilot is alone. While you control Salt Plateau, opponent's Force retrieval is canceled. Place out of play if Kylo just forfeited from a battle you lost at Salt Plateau where Han, Leia, or Luke present.",
+        "icons": [
+          "Episode VII",
+          "Set 25"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual25-Dark/large/thefirstorderreigns.gif",
+        "title": "The First Order Reigns / The Resistance Is Doomed",
+        "type": "Objective",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/The First Order Reigns/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "225_32",
+      "id": 20075,
+      "legacy": false,
+      "nextId": 7416,
+      "printings": [
+        {
+          "set": "225"
+        }
+      ],
+      "rarity": "C",
+      "rulings": [
+        "Dark may deploy [Presence] droids such as P-59.",
+        "(7-side) Light may initiate an action that causes retrieval, but the retrieval result is canceled.",
+        "(7-side) Han, Leia, or Luke must still be present at the Salt Plateau and active (not excluded from battle, captive, missing, Undercover, etc) at the time that Kylo was forfeited from a battle Dark lost there for the Objective to be placed out of play."
+      ],
+      "set": "225",
+      "side": "Dark"
+    },
+    {
+      "abbr": [
+        "TDIGWATT/PIDAIAFv",
+        "TDIGWATTv"
+      ],
+      "back": {
+        "destiny": "7",
+        "gametext": "This Deal Is Getting Worse All The Time: Deploy a Cloud City battleground site and [Cloud City] I'm Sorry. For remainder of game, you may not deploy Admiral's Orders. During your control phase, your Lando may make a regular move. While this side up, once per turn, may take Cloud City Occupation, Dark Deal, Vader's Bounty, or [Special Edition] Bespin into hand from Reserve Deck; reshuffle. Flip this card if you control 3 Bespin locations and opponent controls fewer than 3 Bespin locations. Pray I Don't Alter It Any Further: While this side up, Sense and Alter may not be played. Force drain bonuses at same site as your Lando or your Lobot may not be canceled. While Vader at a Bespin location, game text of Admiral's Orders is canceled and, if a character was just frozen, opponent loses 3 Force. If your alien/Imperial pair in battle, your total battle destiny is +2. If your Lando in battle, may target a character present with him; target is forfeit = 0. Flip this card if opponent controls more Bespin locations than you.",
+        "icons": [
+          "Cloud City",
+          "Premium",
+          "Set 26"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual26-Dark/large/prayidontalteritanyfurther.gif",
+        "title": "This Deal Is Getting Worse All The Time / Pray I Don't Alter It Any Further (V)",
+        "type": "Objective",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Pray I Don't Alter It Any Further (V)/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "cancels": [
+        "Alter",
+        "Sense",
+        "Admiral's Orders game text"
+      ],
+      "front": {
+        "destiny": "0",
+        "gametext": "This Deal Is Getting Worse All The Time: Deploy a Cloud City battleground site and [Cloud City] I'm Sorry. For remainder of game, you may not deploy Admiral's Orders. During your control phase, your Lando may make a regular move. While this side up, once per turn, may take Cloud City Occupation, Dark Deal, Vader's Bounty, or [Special Edition] Bespin into hand from Reserve Deck; reshuffle. Flip this card if you control 3 Bespin locations and opponent controls fewer than 3 Bespin locations. Pray I Don't Alter It Any Further: While this side up, Sense and Alter may not be played. Force drain bonuses at same site as your Lando or your Lobot may not be canceled. While Vader at a Bespin location, game text of Admiral's Orders is canceled and, if a character was just frozen, opponent loses 3 Force. If your alien/Imperial pair in battle, your total battle destiny is +2. If your Lando in battle, may target a character present with him; target is forfeit = 0. Flip this card if opponent controls more Bespin locations than you.",
+        "icons": [
+          "Cloud City",
+          "Premium",
+          "Set 26"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual26-Dark/large/thisdealisgettingworseallthetime.gif",
+        "title": "This Deal Is Getting Worse All The Time / Pray I Don't Alter It Any Further (V)",
+        "type": "Objective",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/This Deal Is Getting Worse All The Time (V)/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "226_12",
+      "id": 20076,
+      "legacy": false,
+      "nextId": 7456,
+      "printings": [
+        {
+          "set": "226"
+        }
+      ],
+      "pulls": [
+        "Bespin (V)",
+        "Cloud City Occupation",
+        "Dark Deal",
+        "Dark Deal (V)",
+        "Vader's Bounty"
+      ],
+      "rarity": "PM",
+      "rulings": [
+        "Multiple alien/Imperial pairs still only gives total battle destiny +2, not +4 or more."
+      ],
+      "set": "226",
+      "side": "Dark"
     }
   ]
 }

--- a/Light.json
+++ b/Light.json
@@ -1,6 +1,9 @@
 {
   "cards": [
     {
+      "abbr": [
+        "21B"
+      ],
       "front": {
         "deploy": "2",
         "destiny": "1",
@@ -151,8 +154,8 @@
       "side": "Light",
       "underlyingCardFor": [
         {
-          "title": "A Close Race (V)",
-          "cardId": 7318
+          "cardId": 7318,
+          "title": "A Close Race (V)"
         }
       ]
     },
@@ -5815,7 +5818,7 @@
         "icons": [
           "Interior",
           "Exterior",
-          "Cave",
+          "Creature Site",
           "Planet",
           "Dagobah"
         ],
@@ -43078,7 +43081,13 @@
         "If not stacked, the destiny from hand still goes to Used Pile."
       ],
       "set": "11",
-      "side": "Light"
+      "side": "Light",
+      "underlyingCardFor": [
+        {
+          "cardId": 7495,
+          "title": "Podrace Prep (V)"
+        }
+      ]
     },
     {
       "conceptBy": "(Image courtesy of Leo Camacho)",
@@ -45495,7 +45504,7 @@
           "A New Hope"
         ],
         "imageUrl": "https://res.starwarsccg.org/cards/ANewHope-Light/large/ra7.gif",
-        "lore": "The RA line of servant droids has fifth-degree primary programming. Low intelligence with capabilities for mental labor only. Common among nobles and high-ranking officials.",
+        "lore": "The RA line of servant droids has fifth-degree primary programming: low intelligence with capabilities for mental labor only. Common among nobles and high-ranking officials.",
         "power": "1",
         "subType": "Droid",
         "title": "RA-7 (Aray-Seven)",
@@ -57303,7 +57312,7 @@
       "gempId": "211_36",
       "id": 5961,
       "legacy": false,
-      "previousId": 40016,
+      "previousId": 40111,
       "printings": [
         {
           "set": "211"
@@ -61391,6 +61400,7 @@
       "gempId": "204_15",
       "id": 5076,
       "legacy": false,
+      "previousId": 40100,
       "printings": [
         {
           "set": "204"
@@ -66818,6 +66828,7 @@
       "gempId": "215_6",
       "id": 6880,
       "legacy": false,
+      "previousId": 40109,
       "printings": [
         {
           "set": "215"
@@ -67156,6 +67167,7 @@
       "gempId": "215_14",
       "id": 6888,
       "legacy": false,
+      "previousId": 40110,
       "printings": [
         {
           "set": "215"
@@ -68893,6 +68905,7 @@
       "gempId": "217_29",
       "id": 6981,
       "legacy": false,
+      "previousId": 40104,
       "printings": [
         {
           "set": "217"
@@ -72659,7 +72672,7 @@
       "gempId": "221_43",
       "id": 7191,
       "legacy": false,
-      "previousId": 40080,
+      "previousId": 40106,
       "printings": [
         {
           "set": "221"
@@ -73158,6 +73171,7 @@
       "gempId": "221_57",
       "id": 7205,
       "legacy": false,
+      "previousId": 40101,
       "printings": [
         {
           "set": "221"
@@ -73230,6 +73244,7 @@
       "gempId": "221_59",
       "id": 7207,
       "legacy": false,
+      "previousId": 40102,
       "printings": [
         {
           "set": "221"
@@ -73816,7 +73831,7 @@
       "gempId": "209_16",
       "id": 5302,
       "legacy": false,
-      "previousId": 40033,
+      "previousId": 40103,
       "printings": [
         {
           "set": "209"
@@ -75687,7 +75702,7 @@
         "errataDate": "2024-07-25",
         "errataNotes": "Changed 'a Grabber card stacks' to 'your Grabber card stacks' and improved WHAAOW! to WHAAAAOW!",
         "errataSymbol": "E1",
-        "gametext": "Once per game, 'BEEP-BOOP' (your [Grabber] card stacks a just played opponent's Interrupt; this does not count towards any [Grabber] card's once per game limit). OR Once per game, 'WHAAAAOW!' (lose your droid at a Scomp link to cancel a battle just initiated at same or related interior site).",
+        "gametext": "Once per game, 'BEEP-BOOP' (your [Grabber] card stacks a just played opponent's Interrupt; this does not count toward any [Grabber] card's once per game limit). OR Once per game, 'WHAAAAOW!' (lose your droid at a Scomp link to cancel a battle just initiated at same or related interior site).",
         "icons": [
           "Set 23"
         ],
@@ -77214,6 +77229,7 @@
       "gempId": "225_9",
       "id": 7393,
       "legacy": false,
+      "previousId": 40108,
       "printings": [
         {
           "set": "225"
@@ -77518,6 +77534,7 @@
       "gempId": "225_42",
       "id": 7426,
       "legacy": false,
+      "previousId": 40107,
       "printings": [
         {
           "set": "225"
@@ -77701,6 +77718,7 @@
       "gempId": "225_47",
       "id": 7431,
       "legacy": false,
+      "previousId": 40105,
       "printings": [
         {
           "set": "225"
@@ -78896,7 +78914,7 @@
       "gempId": "226_28",
       "id": 7472,
       "legacy": false,
-      "previousId": 40099,
+      "previousId": 40112,
       "printings": [
         {
           "set": "226"
@@ -78945,7 +78963,7 @@
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "219_31",
-      "id": 7104,
+      "id": 7482,
       "legacy": false,
       "printings": [
         {
@@ -78989,7 +79007,7 @@
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "217_34",
-      "id": 6986,
+      "id": 7483,
       "legacy": false,
       "previousId": 40004,
       "printings": [
@@ -79025,7 +79043,7 @@
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "209_4",
-      "id": 5533,
+      "id": 7484,
       "legacy": false,
       "printings": [
         {
@@ -79057,7 +79075,7 @@
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "200_39",
-      "id": 890,
+      "id": 7485,
       "legacy": false,
       "printings": [
         {
@@ -79097,7 +79115,7 @@
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "200_41",
-      "id": 1219,
+      "id": 7486,
       "legacy": false,
       "printings": [
         {
@@ -79139,7 +79157,7 @@
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "210_17",
-      "id": 5627,
+      "id": 7487,
       "legacy": false,
       "printings": [
         {
@@ -79167,7 +79185,7 @@
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "211_33",
-      "id": 5631,
+      "id": 7488,
       "legacy": false,
       "printings": [
         {
@@ -79207,7 +79225,7 @@
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "200_20",
-      "id": 1594,
+      "id": 7489,
       "legacy": false,
       "matching": [
         "Artoo-Detoo In Red 5",
@@ -79273,7 +79291,7 @@
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "210_20",
-      "id": 5703,
+      "id": 7490,
       "legacy": false,
       "printings": [
         {
@@ -79324,7 +79342,7 @@
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "218_4",
-      "id": 7044,
+      "id": 7491,
       "legacy": false,
       "matchingWeapon": [
         "Mace Windu's Lightsaber"
@@ -79369,7 +79387,7 @@
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "205_6",
-      "id": 5130,
+      "id": 7492,
       "legacy": false,
       "printings": [
         {
@@ -79417,7 +79435,7 @@
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "218_31",
-      "id": 7072,
+      "id": 7493,
       "legacy": false,
       "matching": [
         "Any Han",
@@ -79461,7 +79479,7 @@
         "printableSlipType": "VIRTUAL"
       },
       "gempId": "217_52",
-      "id": 7005,
+      "id": 7494,
       "legacy": false,
       "printings": [
         {
@@ -79482,6 +79500,42 @@
         "Can only deploy Anakin's Lightsaber from your own Lost Pile, not the opponent's Lost Pile."
       ],
       "set": "217",
+      "side": "Light"
+    },
+    {
+      "abbr": [
+        "PPv"
+      ],
+      "front": {
+        "destiny": "3",
+        "gametext": "If Credits Will Do Fine on table, deploy Podrace Arena, a Podracer, Boonta Eve Podrace, and three Effects that deploy for free and are always immune to Alter. Opponent may deploy a Podracer (or play a Defensive Shield from under their Starting Effect). Place Interrupt in Lost Pile.",
+        "icons": [
+          "Episode I",
+          "Tatooine",
+          "Set 27"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual27-Light/large/podraceprep.gif",
+        "lore": "Advanced preparation in Podracing is usually the key to winning. A little extra work at the start can mean a lot in the long run.",
+        "subType": "Starting",
+        "title": "•Podrace Prep (V)",
+        "type": "Interrupt",
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Podrace Prep (V)/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "227_1",
+      "id": 7495,
+      "legacy": false,
+      "printings": [
+        {
+          "set": "227"
+        }
+      ],
+      "rarity": "U",
+      "rulings": [
+        "If Dark chooses to deploy a Podracer, it must come from their Reserve Deck."
+      ],
+      "set": "227",
       "side": "Light"
     }
   ]

--- a/LightPreErrata.json
+++ b/LightPreErrata.json
@@ -4496,6 +4496,560 @@
       ],
       "set": "226",
       "side": "Light"
+    },
+    {
+      "front": {
+        "destiny": "2",
+        "gametext": "Deploy on table. Once per game, may stack the top card of your Lost Pile beneath Credits Will Do Fine. May examine cards stacked beneath Credits Will Do Fine and place any two in owner's Lost Pile to take a starship into hand from Reserve Deck; reshuffle (or retrieve into hand).",
+        "icons": [
+          "Coruscant",
+          "Episode I",
+          "Set 4"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual4-Light/large/wereleaving.gif",
+        "lore": "Qui-Gon realized that sometimes it's best to just leave, before any more damage is done.",
+        "title": "•We're Leaving (V)",
+        "type": "Effect",
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Were Leaving (V)/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "204_15",
+      "id": 40100,
+      "legacy": false,
+      "nextId": 5076,
+      "printings": [
+        {
+          "set": "204"
+        }
+      ],
+      "pulledBy": [
+        "The Signal",
+        "We Wish To Board At Once"
+      ],
+      "rarity": "C",
+      "set": "204",
+      "side": "Light"
+    },
+    {
+      "abbr": [
+        "EWYWv"
+      ],
+      "front": {
+        "destiny": "4",
+        "gametext": "If [Tatooine] or [Coruscant] Qui-Gon in battle, he is power +1 for each `credit.' OR Once per game, if a battle just initiated at Watto's Junkyard involving Qui-Gon, target a character. Lightsabers may not be fired this battle. Unless target is Watto or a Dark Jedi, cancel target's game text.",
+        "icons": [
+          "Tatooine",
+          "Episode I",
+          "Set 21"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual21-Light/large/eitherwayyouwin.gif",
+        "lore": "'Deal!'",
+        "subType": "Used",
+        "title": "•Either Way, You Win (V)",
+        "type": "Interrupt",
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Either Way, You Win (V)/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "221_57",
+      "id": 40101,
+      "legacy": false,
+      "nextId": 7205,
+      "printings": [
+        {
+          "set": "221"
+        }
+      ],
+      "rarity": "U",
+      "set": "221",
+      "side": "Light"
+    },
+    {
+      "abbr": [
+        "EYLv"
+      ],
+      "front": {
+        "destiny": "4",
+        "gametext": "USED: If The Hyperdrive Generator's Gone on table, take Skywalker Hut or Jar Jar into hand from Reserve Deck; reshuffle. LOST: If opponent's card was just stacked on Credits Will Do Fine, for remainder of turn, your Force drains may not be reduced.",
+        "icons": [
+          "Tatooine",
+          "Episode I",
+          "Set 21"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual21-Light/large/eventuallyyoulllose.gif",
+        "lore": "In the end, Watto finally came to understand the agony of defeat.",
+        "subType": "Used Or Lost",
+        "title": "•Eventually You'll Lose (V)",
+        "type": "Interrupt",
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Eventually You'll Lose (V)/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "221_59",
+      "id": 40102,
+      "legacy": false,
+      "nextId": 7207,
+      "printings": [
+        {
+          "set": "221"
+        }
+      ],
+      "rarity": "U",
+      "set": "221",
+      "side": "Light"
+    },
+    {
+      "abbr": [
+        "ABR"
+      ],
+      "front": {
+        "destiny": "5",
+        "errataDate": "2023-10-02",
+        "errataNotes": "This card was blanked (removed from the game) from July 15, 2023 until October 2, 2023. Before being blanked, this was the E1 text: If Jakku on table, deploy on table. Your Force generation is +1 at Jakku battlegrounds you occupy. During your deploy phase, may place a Resistance character from hand on top of Used Pile to take a Resistance character of equal or lesser ability into hand from Reserve Deck; reshuffle. [Immune to Alter.]",
+        "errataSymbol": "E2",
+        "gametext": "If Jakku on table, deploy on table (only at start of game). Twice per game, may take a Resistance leader into hand from Reserve Deck (reshuffle). Resistance characters with printed forfeit < 6 are forfeit +1. Where you have a Resistance Agent, your total power is +3. Strike Planning is canceled. [Immune to Alter].",
+        "icons": [
+          "Episode VII",
+          "Set 9"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual9-Light/large/abraveresistance.gif",
+        "lore": "Blank.",
+        "title": "•A Brave Resistance",
+        "type": "Effect",
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/A Brave Resistance/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "209_16",
+      "id": 40103,
+      "legacy": false,
+      "nextId": 5302,
+      "previousId": 40033,
+      "printings": [
+        {
+          "set": "209"
+        }
+      ],
+      "pulls": [
+        "Admiral U.O. Statura",
+        "Fleet Admiral Gial Ackbar",
+        "General Leia Organa",
+        "Lando, Hero Of The Rebellion",
+        "Larma D'Acy",
+        "Lor San Tekka",
+        "Poe Dameron",
+        "Vice Admiral Holdo"
+      ],
+      "rarity": "C1",
+      "set": "209",
+      "side": "Light"
+    },
+    {
+      "abbr": [
+        "BWM"
+      ],
+      "front": {
+        "destiny": "0",
+        "gametext": "Deploy on an Ahch-To location. Opponent generates no Force here. A Thousand Generations Live In You Now: Rey is power and forfeit +1 for each Jedi out of play. Bring Back The Balance, Rey, As I Did: While [Set 14] Rey in battle, your battle destiny draws and Rey's weapon destiny draws are +1. Feel The Force Flowing Through You: [Set 14] Rey and characters with her may not add battle destiny draws. Rey, The Force Will Be With You, Always: [Set 14] Rey ignores your [Episode VII] objective deployment restrictions.",
+        "icons": [
+          "Episode VII",
+          "Set 17"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual17-Light/large/bewithme.gif",
+        "title": "•Be With Me",
+        "type": "Epic Event",
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Be With Me/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "217_29",
+      "id": 40104,
+      "legacy": false,
+      "nextId": 6981,
+      "printings": [
+        {
+          "set": "217"
+        }
+      ],
+      "pulledBy": [
+        "The Destiny Of A Jedi"
+      ],
+      "rarity": "C",
+      "rulings": [
+        "Jedi stacked on Communing are counted as Jedi out of play.",
+        "(3rd section) A non-character card can add battle destinies (e.g. I'm Getting Pretty Good At This) but cannot cause a character to add battle destinies (e.g. Meditation).",
+        "(3rd section) Characters that draw multiple battle destiny 'if unable to otherwise' still do so while with Set 14 Rey.",
+        "(4th section) When using the Legend objective, Light can deploy Set 14 Rey even if they have a Jedi on table. But they cannot deploy a Jedi if they have Set 14 Rey on table."
+      ],
+      "set": "217",
+      "side": "Light"
+    },
+    {
+      "abbr": [
+        "HLD"
+      ],
+      "front": {
+        "destiny": "0",
+        "gametext": "Deploy on Galactic Senate. Your Political Effects are canceled. Twice per turn, may target your agenda here: Justice: During battle, subtract 1 from a just drawn weapon destiny. Order: During any move phase, peek at the top 2 cards of any Reserve Deck and replace in any order. Peace: Subtract 1 from attrition against you. Taxation: Place a card with no printed destiny number > 4 from hand in Used Pile to activate 1 Force.",
+        "icons": [
+          "Coruscant",
+          "Episode I",
+          "Set 25"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual25-Light/large/howlibertydies.gif",
+        "title": "•How Liberty Dies",
+        "type": "Epic Event",
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/How Liberty Dies/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "225_47",
+      "id": 40105,
+      "legacy": false,
+      "nextId": 7431,
+      "printings": [
+        {
+          "set": "225"
+        }
+      ],
+      "rarity": "R",
+      "rulings": [
+        "The same agenda / same character may be targeted twice in the same turn.",
+        "However, note that Peace's 'subtract 1 from attrition' is not cumulative.",
+        "Justice's 'subtract 1 from a weapon destiny' is not cumulative on the same weapon destiny, but would be effective against a weapon that draws two weapon destiny (by subtracting 1 from each draw)."
+      ],
+      "set": "225",
+      "side": "Light"
+    },
+    {
+      "abbr": [
+        "AJF"
+      ],
+      "front": {
+        "destiny": "5",
+        "errataDate": "2024-12-30",
+        "errataNotes": "Previous text: If His Destiny on table, choose: USED: If a character of ability > 4 was just 'hit' during battle, opponent loses 1 Force. OR Peek at the bottom card of your Force Pile; may move it to the top of that pile. LOST: Cancel game text of a Dark Jedi with Luke for remainder of turn.",
+        "errataSymbol": "E1",
+        "gametext": "USED: Peek at the bottom card of your Force Pile; may move it to the top of that pile. LOST: Steal Luke's Lightsaber into hand (immune to Weapon Of A Sith). OR If His Destiny on table, cancel game text of a Dark Jedi with Luke for remainder of turn.",
+        "icons": [
+          "Death Star II",
+          "Set 21"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual21-Light/large/ajedisfury.gif",
+        "lore": "It had been decades since Vader had felt the sting of an enemy's blade.",
+        "subType": "Used Or Lost",
+        "title": "•A Jedi's Fury",
+        "type": "Interrupt",
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/A Jedi's Fury/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "221_43",
+      "id": 40106,
+      "legacy": false,
+      "nextId": 7191,
+      "previousId": 40080,
+      "printings": [
+        {
+          "set": "221"
+        }
+      ],
+      "rarity": "R",
+      "rulings": [
+        "May only steal Luke's Lightsaber into hand from table, not from opponent's hand, Lost Pile, etc.",
+        "May steal back a stolen Luke's Lightsaber from table even if it is inactive (e.g. carried by a Vader who cannot use it)."
+      ],
+      "set": "221",
+      "side": "Light"
+    },
+    {
+      "abbr": [
+        "COASv"
+      ],
+      "front": {
+        "destiny": "2",
+        "gametext": "If a [Skywalker] Effect on table, destiny +2 when drawn for destiny. Take a lightsaber into hand from Force Pile; reshuffle. OR Retrieve Anakin's Lightsaber. OR Once per game, during a battle or duel involving a Skywalker and a Dark Jedi, make a just drawn destiny = 2.",
+        "icons": [
+          "Cloud City",
+          "Set 25"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual25-Light/large/courageofaskywalker.gif",
+        "lore": "Despite being alone, trapped and desperately outmatched, Luke continued his battle with the Dark Lord of the Sith.",
+        "subType": "Lost",
+        "title": "•Courage Of A Skywalker (V)",
+        "type": "Interrupt",
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Courage Of A Skywalker (V)/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "225_42",
+      "id": 40107,
+      "legacy": false,
+      "nextId": 7426,
+      "printings": [
+        {
+          "set": "225"
+        }
+      ],
+      "rarity": "R",
+      "rulings": [
+        "A destiny draw that has been reset = 2 ignores all modifiers (additions and subtrations). It could be reset again, but only to a lower number."
+      ],
+      "set": "225",
+      "side": "Light"
+    },
+    {
+      "abbr": [
+        "MSHI"
+      ],
+      "combo": [
+        "Leia With Blaster Rifle or Princess Leia (V) + any Han + I Know = 4 battle destiny that cannot be limited",
+        "[Skywalker] Effects: Best Starpilot In The Galaxy and A Cunning Warrior"
+      ],
+      "front": {
+        "destiny": "5",
+        "gametext": "During battle involving Rebel Leia, the number of battle destiny draws may not be limited. OR Subtract 1 from a just drawn Force Lightning or 'choke' destiny (unless targeting an Undercover spy). OR If a [Skywalker] Effect on table, take Chief Chirpa's Hut or Guest Quarters into hand from Reserve Deck; reshuffle.",
+        "icons": [
+          "Skywalker",
+          "Set 25"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual25-Light/large/mysisterhasit.gif",
+        "lore": "'He's my brother.'",
+        "subType": "Used",
+        "title": "•My Sister Has It",
+        "type": "Interrupt",
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/My Sister Has It/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "225_9",
+      "id": 40108,
+      "legacy": false,
+      "nextId": 7393,
+      "printings": [
+        {
+          "set": "225"
+        }
+      ],
+      "pulls": [
+        "Cloud City: Guest Quarters",
+        "Endor: Chief Chirpa's Hut",
+        "Endor: Chief Chirpa's Hut (V)"
+      ],
+      "rarity": "R",
+      "rulings": [
+        "First function: Players may still initiate an action that would limit battle destiny draws, such as taking a card off I Don't Like Sand or playing the limiting function on Imperial Command & In Range. The limit is simply ignored.",
+        "Second function: The phrase 'unless targeting an Undercover spy' applies to both Force Lightning and 'choke' destiny draws.",
+        "Examples of 'choke' destiny draws: Darth Vader Dark Lord Of The Sith, Physical Choke, and Vader."
+      ],
+      "set": "225",
+      "side": "Light"
+    },
+    {
+      "counterpart": "Death Star: Central Core",
+      "front": {
+        "darkSideIcons": 1,
+        "destiny": "0",
+        "gametext": "Light: If A Power Loss 'shut down' this game, Force drain +1 here and Death Star Tractor Beam lost. Dark: If you occupy, opponent must first use 1 Force to move a character from here.",
+        "icons": [
+          "Interior",
+          "Mobile",
+          "Scomp Link",
+          "Set 15"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual15-Light/large/deathstarcentralcore.gif",
+        "lightSideIcons": 2,
+        "subType": "Site",
+        "title": "•Death Star: Central Core",
+        "type": "Location",
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Death Star Central Core/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "215_6",
+      "id": 40109,
+      "legacy": false,
+      "nextId": 6880,
+      "printings": [
+        {
+          "set": "215"
+        }
+      ],
+      "pulledBy": [
+        "Mindful Of The Future"
+      ],
+      "rarity": "C",
+      "rulings": [
+        "For Dark's text, pay the additional cost even if the movement is free.",
+        "For group movement (e.g. Nabrun Leids) pay 1 per character.",
+        "Pay the additional cost when movement costs are normally paid."
+      ],
+      "set": "215",
+      "side": "Light"
+    },
+    {
+      "front": {
+        "darkSideIcons": 1,
+        "destiny": "0",
+        "gametext": "Light: Once per turn, if you occupy with a Wookiee, may deploy a Kashyyyk location from Reserve Deck; reshuffle. Dark: Total ability of 6 or more required for you to draw battle destiny here.",
+        "icons": [
+          "Exterior",
+          "Planet",
+          "Episode I",
+          "Set 15"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual15-Light/large/kashyyykkachirho.gif",
+        "lightSideIcons": 2,
+        "subType": "Site",
+        "title": "•Kashyyyk: Kachirho",
+        "type": "Location",
+        "uniqueness": "*",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Kashyyyk Kachirho/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "215_14",
+      "id": 40110,
+      "legacy": false,
+      "nextId": 6888,
+      "printings": [
+        {
+          "set": "215"
+        }
+      ],
+      "pulledBy": [
+        "Kashyyyk Operative",
+        "Let The Wookiee Win (V)"
+      ],
+      "pulls": [
+        "Kashyyyk",
+        "Kashyyyk: Forest Depths"
+      ],
+      "rarity": "U",
+      "rulings": [
+        "If Dark has less than 6 ability, cards that 'add a battle destiny' won't work, but cards that 'draw if unable to otherwise' will work."
+      ],
+      "set": "215",
+      "side": "Light"
+    },
+    {
+      "abbr": [
+        "TGMNAL/WNLS"
+      ],
+      "back": {
+        "destiny": "7",
+        "errataDate": "2022-12-12",
+        "errataNotes": "Previous version only prevented opponent from firing weapons, limited immunity to < 5, and instead of Force drain +1, caused 1 direct damage per turn when Force draining with two unique Resistance characters.",
+        "errataSymbol": "E1",
+        "gametext": "The Galaxy May Need A Legend: Deploy Ahch-To system and any [Episode VII] battleground. For remainder of game, Luke deploys only to Ahch-To. You may not Force drain on Ahch-To. You may not deploy [Episode I] locations or non-[Episode VII] Luke. You may not deploy Jedi while a Jedi on table. Once per game, may take any one card into hand from Force Pile; reshuffle. While this side up, once per turn, may use 1 Force to deploy an Ahch-To location or [Episode VII] battleground from Reserve Deck; reshuffle. May flip this card if Luke on Ahch-To and a battle was just initiated involving a Resistance character. We Need Luke Skywalker: Immediately place Luke out of play (ignore [Death Star II] objective restrictions, if any). For remainder of battle, weapons may not be fired. While this side up, opponent's immunity to attrition is limited to < 6. Once during your turn, may peek at the top card of your Force Pile and Reserve Deck; place both cards (in any order) on top of one of those piles. Where you have two unique (•) Resistance characters, your Force drains are +1 and, once per turn during battle, may cancel an opponent's just drawn destiny to cause a redraw.",
+        "icons": [
+          "Episode VII",
+          "Set 11"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/weneedlukeskywalker.gif",
+        "title": "The Galaxy May Need A Legend / We Need Luke Skywalker",
+        "type": "Objective",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/We Need Luke Skywalker/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "front": {
+        "destiny": "0",
+        "errataSymbol": "E1",
+        "gametext": "The Galaxy May Need A Legend: Deploy Ahch-To system and any [Episode VII] battleground. For remainder of game, Luke deploys only to Ahch-To. You may not Force drain on Ahch-To. You may not deploy [Episode I] locations or non-[Episode VII] Luke. You may not deploy Jedi while a Jedi on table. Once per game, may take any one card into hand from Force Pile; reshuffle. While this side up, once per turn, may use 1 Force to deploy an Ahch-To location or [Episode VII] battleground from Reserve Deck; reshuffle. May flip this card if Luke on Ahch-To and a battle was just initiated involving a Resistance character. We Need Luke Skywalker: Immediately place Luke out of play (ignore [Death Star II] objective restrictions, if any). For remainder of battle, weapons may not be fired. While this side up, opponent's immunity to attrition is limited to < 6. Once during your turn, may peek at the top card of your Force Pile and Reserve Deck; place both cards (in any order) on top of one of those piles. Where you have two unique (•) Resistance characters, your Force drains are +1 and, once per turn during battle, may cancel an opponent's just drawn destiny to cause a redraw.",
+        "icons": [
+          "Episode VII",
+          "Set 11"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual11-Light/large/thegalaxymayneedalegend.gif",
+        "title": "The Galaxy May Need A Legend / We Need Luke Skywalker",
+        "type": "Objective",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/The Galaxy May Need A Legend/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "211_36",
+      "id": 40111,
+      "legacy": false,
+      "nextId": 5961,
+      "previousId": 40016,
+      "printings": [
+        {
+          "set": "211"
+        }
+      ],
+      "rarity": "R",
+      "rulings": [
+        "While a Jedi on table, also cannot use persona replacement to replace a Jedi with a Jedi, or to replace a non-Jedi with a Jedi.",
+        "Be With Me creates an exception to the above ruling, allowing Set 14 Rey to deploy (and thereby also allowing her to persona replace another Rey).",
+        "(0 side) May flip even if the Resistance character is introduced to the battle during the 'battle just initiated' responses (e.g. Light may deploy Finn as a react, then flip).",
+        "(7-side) When calculating immunity to attrition, start with the base immunity and apply any modifiers. Finally, apply the limit of < 6 from this Objective last."
+      ],
+      "set": "211",
+      "side": "Light"
+    },
+    {
+      "abbr": [
+        "THP/GAAT"
+      ],
+      "combo": [
+        "Jedi Lightsaber (V)"
+      ],
+      "back": {
+        "destiny": "7",
+        "errataDate": "2025-12-26",
+        "errataNotes": "(Back Errata) Original text did not have the deploy -1 modifier. Also, original text had 'your lightsaber Force drain bonuses may not be canceled.' Original text had the relocation being free, and did not require battlegrounds to ping.",
+        "errataSymbol": "E1",
+        "gametext": "The Hidden Path: Deploy Mining Village, Safehouse, Underground Corridor, and Fallen Order. For remainder of game, you may not deploy <> locations or Jedi (except Jedi survivors). Weapon Levitation may not steal weapons. Once per turn, may deploy a Jabiim location from Reserve Deck; reshuffle. While this side up, you may not play Nabrun Leids. Your Force drains at Mapuzo sites are -1. Once per turn, may deploy a holocron from Reserve Deck; reshuffle. Flip this card if Jedi occupy two non-Mapuzo sites. Gather Allies And Train: While this side up, Jedi survivors are deploy -1. if your holocron is about to leave table, place it in Used Pile. Opponent's total battle destiny where they have a character of ability > 4 is -1. During your move phase, may use 2 Force to relocate a Jedi between a Jabiim site and a battleground site as a regular move. At the end of your turn, if Jedi occupy two battleground sites, opponent loses 1 Force. Flip this card if Jedi do not occupy two sites.",
+        "icons": [
+          "Set 26"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual26-Light/large/gatheralliesandtrain.gif",
+        "title": "The Hidden Path / Gather Allies And Train",
+        "type": "Objective",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/Gather Allies And Train/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "front": {
+        "destiny": "0",
+        "errataDate": "2025-12-26",
+        "errataNotes": "(Front Errata) Original did not have the Weapon Levitation restriction. Original version could pull 'a Jabiim site or a battleground (except a Kamino, Tatooine, or [Reflections III] location)'.",
+        "errataSymbol": "E1",
+        "gametext": "The Hidden Path: Deploy Mining Village, Safehouse, Underground Corridor, and Fallen Order. For remainder of game, you may not deploy <> locations or Jedi (except Jedi survivors). Weapon Levitation may not steal weapons. Once per turn, may deploy a Jabiim location from Reserve Deck; reshuffle. While this side up, you may not play Nabrun Leids. Your Force drains at Mapuzo sites are -1. Once per turn, may deploy a holocron from Reserve Deck; reshuffle. Flip this card if Jedi occupy two non-Mapuzo sites. Gather Allies And Train: While this side up, Jedi survivors are deploy -1. if your holocron is about to leave table, place it in Used Pile. Opponent's total battle destiny where they have a character of ability > 4 is -1. During your move phase, may use 2 Force to relocate a Jedi between a Jabiim site and a battleground site as a regular move. At the end of your turn, if Jedi occupy two battleground sites, opponent loses 1 Force. Flip this card if Jedi do not occupy two sites.",
+        "icons": [
+          "Set 26"
+        ],
+        "imageUrl": "https://res.starwarsccg.org/cards/Virtual26-Light/large/thehiddenpath.gif",
+        "title": "The Hidden Path / Gather Allies And Train",
+        "type": "Objective",
+        "printableSlipUrl": "https://res.starwarsccg.org/vkit/cards/standard/The Hidden Path/image.png",
+        "printableSlipType": "VIRTUAL"
+      },
+      "gempId": "226_28",
+      "id": 40112,
+      "legacy": false,
+      "nextId": 7472,
+      "previousId": 40099,
+      "printings": [
+        {
+          "set": "226"
+        }
+      ],
+      "pulls": [
+        "Fallen Order",
+        "Mapuzo: Mining Village",
+        "Mapuzo: Safehouse",
+        "Mapuzo: Underground Corridor",
+        "Jabiim: Path Operations Center",
+        "Jabiim: Starship Hangar",
+        "Jedi Holocron",
+        "Most battleground locations"
+      ],
+      "rarity": "U",
+      "rulings": [
+        "Mapuzo's layout requires the Safehouse as the middle site.",
+        "Relocating a Jedi between a Jabiim site and a battleground site is once per turn, and works in both directions."
+      ],
+      "set": "226",
+      "side": "Light"
     }
   ]
 }

--- a/sets.json
+++ b/sets.json
@@ -583,6 +583,17 @@
     "size": 28
   },
   {
+    "id": "227",
+    "name": "Virtual Set 27",
+    "gempName": "Set 27",
+    "abbr": "V27",
+    "legacy": false,
+    "cycle_code": "full",
+    "date_release": "2026-03-09",
+    "position": 227,
+    "size": 1
+  },
+  {
     "id": "301",
     "name": "Demo Deck",
     "gempName": "Virtual Premium Set",


### PR DESCRIPTION
So far this PR does not implement most of the errata such as game text changes.

This first pass archives away the previous versions to the PreErrata files.

It also adds the one new card, Podrace Prep (V), and does some of the updating for the one title change card, The Emperor, Relentless.

There are some random minor fixes included here as well.

If time permits, I will get the actual errata added to this PR before launch, otherwise it will be done in a separate PR shortly after launch.