### PR TITLE
add Black Sun agent convenience targets where appropriate

### DIFF
--- a/Dark.json
+++ b/Dark.json
@@ -4152,7 +4152,8 @@
         "characteristics": [
           "information broker",
           "gangster",
-          "leader"
+          "leader",
+          "Black Sun agent"
         ],
         "deploy": "3",
         "destiny": "2",
@@ -62150,7 +62151,8 @@
         "characteristics": [
           "assassin",
           "bounty hunter",
-          "female"
+          "female",
+          "Black Sun agent"
         ],
         "deploy": "4",
         "destiny": "2",
@@ -62200,7 +62202,8 @@
         "characteristics": [
           "assassin",
           "bounty hunter",
-          "female"
+          "female",
+          "Black Sun agent"
         ],
         "deploy": "4",
         "destiny": "2",
@@ -62249,7 +62252,8 @@
         "characteristics": [
           "assassin",
           "bounty hunter",
-          "female"
+          "female",
+          "Black Sun agent"
         ],
         "deploy": "4",
         "destiny": "2",
@@ -70290,7 +70294,8 @@
         "characteristics": [
           "bounty hunter",
           "guard",
-          "Wookiee"
+          "Wookiee",
+          "Black Sun agent"
         ],
         "armor": "5",
         "deploy": "4",
@@ -70379,7 +70384,8 @@
         "ability": "2",
         "characteristics": [
           "bounty hunter",
-          "gunner"
+          "gunner",
+          "Black Sun agent"
         ],
         "deploy": "3",
         "destiny": "3",
@@ -71512,7 +71518,8 @@
         "characteristics": [
           "bounty hunter",
           "Gand",
-          "scout"
+          "scout",
+          "Black Sun agent"
         ],
         "deploy": "4",
         "destiny": "1",
@@ -71787,7 +71794,8 @@
         "characteristics": [
           "Abyssin",
           "gambler",
-          "information broker"
+          "information broker",
+          "Black Sun agent"
         ],
         "deploy": "3",
         "destiny": "3",
@@ -72501,7 +72509,8 @@
         "characteristics": [
           "assassin",
           "information broker",
-          "r-unit"
+          "r-unit",
+          "Black Sun agent"
         ],
         "deploy": "5",
         "destiny": "3",


### PR DESCRIPTION
## Black Sun Agent `characteristics` Consistency

`Black Sun agent` appears to be used in `characteristics` in two ways:

1. **Printed/static characteristic**
   - The card lore explicitly says `Black Sun agent`.
   - These should have `Black Sun agent` in `front.characteristics`.

2. **Convenience/search characteristic for `Agents Of Black Sun`**
   - The card is not printed as a Black Sun Agent, but qualifies while the Dark Side objective `Agents Of Black Sun` is active.
   - This is useful for deckbuilding/search.

`Agents Of Black Sun` says:

> your aliens with 'Black Sun' in lore, bounty hunters, and information brokers are Black Sun Agents

So for **Dark Side character cards**, `Black Sun agent` should be included if either:

- lore contains `Black Sun agent`
- or the card qualifies under `Agents Of Black Sun`:
  - subtype includes `Alien` and lore contains `Black Sun`
  - or `characteristics` includes `bounty hunter`
  - or `characteristics` includes `information broker`

## Printed Black Sun Agents

These have lore that explicitly says `Black Sun agent` and already include the characteristic:

| gempId | title |
|---|---|
| `10_41` | •Guri |
| `10_45` | •Prince Xizor |
| `10_53` | •••Vigo |
| `200_91` | •••Vigo (V) |
| `226_5` | •Guri (V) |

## Existing Inferred Black Sun Agent Examples

These 50 Dark Side cards already include `Black Sun agent` as an inferred/convenience characteristic because they are `bounty hunter` and/or `information broker` cards:

<details>
<summary>50 existing inferred entries</summary>

| gempId | title | basis |
|---|---|---|
| `4_91` | •4-LOM | bounty hunter, information broker |
| `109_6` | •4-LOM With Concussion Rifle | bounty hunter, information broker |
| `200_71` | •4-LOM With Concussion Rifle (V) | bounty hunter, information broker |
| `11_51` | •Aurra Sing | bounty hunter |
| `11_52` | •Aurra Sing (AI) | bounty hunter |
| `6_95` | •Bane Malar | bounty hunter |
| `203_23` | •Baniss Keeg, Pilot Instructor | information broker |
| `6_97` | •Beedo | bounty hunter |
| `5_91` | •Boba Fett | bounty hunter |
| `7_167` | •Boba Fett | bounty hunter |
| `206_9` | •Boba Fett (V) | bounty hunter |
| `108_5` | •Boba Fett With Blaster Rifle | bounty hunter |
| `13_59` | •Boba Fett, Bounty Hunter | bounty hunter |
| `4_92` | •Bossk | bounty hunter |
| `200_75` | •Bossk (V) | bounty hunter |
| `110_5` | •Bossk With Mortar Gun | bounty hunter |
| `203_24` | •Cad Bane | bounty hunter |
| `2_85` | •Danz Borin | bounty hunter |
| `202_9` | •Daroe (V) | information broker |
| `4_100` | •Dengar | bounty hunter |
| `205_23` | •Dengar (V) | bounty hunter |
| `110_7` | •Dengar With Blaster Carbine | bounty hunter |
| `200_79` | •Dengar With Blaster Carbine (V) | bounty hunter |
| `1_171` | •Djas Puhr | bounty hunter |
| `201_24` | •Djas Puhr (V) | bounty hunter |
| `7_176` | •Dodo Bodonawieedo | information broker |
| `1_176` | •Feltipern Trevagg | bounty hunter |
| `2_89` | •Greedo | bounty hunter |
| `204_42` | •Greedo (V) | bounty hunter |
| `12_107` | •Grotto Werribee | information broker |
| `4_101` | •IG-88 | bounty hunter |
| `200_83` | •IG-88 (V) | bounty hunter |
| `109_11` | •IG-88 With Riot Gun | bounty hunter |
| `201_25` | •Jango Fett | bounty hunter |
| `201_25` | •Jango Fett (AI) | bounty hunter |
| `110_9` | •Jodo Kast | bounty hunter |
| `1_184` | •Labria | information broker |
| `11_59` | •Lathe | information broker |
| `6_114` | •Murttoc Yine | information broker |
| `6_121` | •Ree-Yees | bounty hunter |
| `211_5` | •Ree-Yees (V) | bounty hunter |
| `10_48` | •Snoova | bounty hunter |
| `12_120` | •Televan Koreyy | information broker |
| `204_46` | •Zam Wesell | bounty hunter |
| `4_107` | •Zuckuss | bounty hunter |
| `220_5` | •Zuckuss (V) | bounty hunter |
| `200_71` | •4-LOM With Concussion Rifle (V) (AI) | bounty hunter, information broker |
| `222_5` | •Boba Fett With Blaster Rifle (V) | bounty hunter |
| `202_9` | •Daroe (V) (AI) | information broker |
| `204_46` | •Zam Wesell (ALT) | bounty hunter |

</details>

## Missing Inferred Black Sun Agent Characteristics

These Dark Side cards appear to qualify under `Agents Of Black Sun`, but do not currently include `Black Sun agent` in `front.characteristics`:

| gempId | title | basis |
|---|---|---|
| `209_33` | •Bala-Tik | information broker |
| `212_3` | •Aurra Sing With Blaster Rifle | bounty hunter |
| `212_3` | •Aurra Sing With Blaster Rifle (AI) | bounty hunter |
| `212_3` | •Aurra Sing With Blaster Rifle (C-Slip AI) | bounty hunter |
| `222_4` | •Black Krrsantan | bounty hunter |
| `222_6` | •Danz Borin (V) | bounty hunter |
| `223_3` | •Zuckuss With Snare Rifle | bounty hunter |
| `223_13` | •Gor Koresh | information broker |
| `224_3` | •BT-1 & •Triple Zero | information broker |

## Suggested Update

Add `Black Sun agent` to `front.characteristics` for the missing Dark Side cards above.

This matches the existing convention already used by 50 Dark Side `bounty hunter` / `information broker` entries, where `Black Sun agent` is included as a convenience/search characteristic for `Agents Of Black Sun` deckbuilding.
