### PR TITLE
Fix scomp workflow

### DIFF
--- a/.github/workflows/update-scomp.yml
+++ b/.github/workflows/update-scomp.yml
@@ -31,10 +31,13 @@ jobs:
         id: target
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "repo=jetsaredim/swccg-scomp" >> "$GITHUB_OUTPUT"
             echo "branch=${{ github.event.inputs.target_branch }}" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.ref_name }}" = "main" ]; then
+            echo "repo=swccgpc/swccg-scomp" >> "$GITHUB_OUTPUT"
             echo "branch=main" >> "$GITHUB_OUTPUT"
           else
+            echo "repo=jetsaredim/swccg-scomp" >> "$GITHUB_OUTPUT"
             echo "branch=test/update-scomp-workflow" >> "$GITHUB_OUTPUT"
           fi
 
@@ -49,9 +52,10 @@ jobs:
       - name: Clone swccg-scomp
         env:
           GIT_SSH_COMMAND: ssh -i swccg-card-json.pem
+          SCOMP_TARGET_REPO: ${{ steps.target.outputs.repo }}
           SCOMP_TARGET_BRANCH: ${{ steps.target.outputs.branch }}
         run: |
-          git clone git@github.com:swccgpc/swccg-scomp.git swccg-scomp
+          git clone "git@github.com:${SCOMP_TARGET_REPO}.git" swccg-scomp
           cd swccg-scomp
           if git show-ref --verify --quiet "refs/remotes/origin/${SCOMP_TARGET_BRANCH}"; then
             git checkout -B "$SCOMP_TARGET_BRANCH" "origin/$SCOMP_TARGET_BRANCH"

--- a/.github/workflows/update-scomp.yml
+++ b/.github/workflows/update-scomp.yml
@@ -6,7 +6,6 @@ on:
   push: 
     branches: 
       - main
-      - fix/update-action-workflow
     paths:
       - '*.json'
   workflow_dispatch:
@@ -31,14 +30,9 @@ jobs:
         id: target
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "repo=jetsaredim/swccg-scomp" >> "$GITHUB_OUTPUT"
             echo "branch=${{ github.event.inputs.target_branch }}" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.ref_name }}" = "main" ]; then
-            echo "repo=swccgpc/swccg-scomp" >> "$GITHUB_OUTPUT"
-            echo "branch=main" >> "$GITHUB_OUTPUT"
           else
-            echo "repo=jetsaredim/swccg-scomp" >> "$GITHUB_OUTPUT"
-            echo "branch=test/update-scomp-workflow" >> "$GITHUB_OUTPUT"
+            echo "branch=main" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Configure SSH
@@ -52,10 +46,9 @@ jobs:
       - name: Clone swccg-scomp
         env:
           GIT_SSH_COMMAND: ssh -i swccg-card-json.pem
-          SCOMP_TARGET_REPO: ${{ steps.target.outputs.repo }}
           SCOMP_TARGET_BRANCH: ${{ steps.target.outputs.branch }}
         run: |
-          git clone "git@github.com:${SCOMP_TARGET_REPO}.git" swccg-scomp
+          git clone git@github.com:swccgpc/swccg-scomp.git swccg-scomp
           cd swccg-scomp
           if git show-ref --verify --quiet "refs/remotes/origin/${SCOMP_TARGET_BRANCH}"; then
             git checkout -B "$SCOMP_TARGET_BRANCH" "origin/$SCOMP_TARGET_BRANCH"

--- a/.github/workflows/update-scomp.yml
+++ b/.github/workflows/update-scomp.yml
@@ -40,10 +40,11 @@ jobs:
 
       - name: Configure SSH
         run: |
-          echo "${{ secrets.SWCCG_CARD_JSON }}" > swccg-card-json.pem
+          printf '%s\n' "${{ secrets.SWCCG_CARD_JSON }}" | tr -d '\r' > swccg-card-json.pem
           chmod 0600 swccg-card-json.pem
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts
+          ssh-keygen -y -f swccg-card-json.pem > /dev/null
 
       - name: Clone swccg-scomp
         env:

--- a/.github/workflows/update-scomp.yml
+++ b/.github/workflows/update-scomp.yml
@@ -6,66 +6,84 @@ on:
   push: 
     branches: 
       - main
+      - fix/update-action-workflow
+    paths:
+      - '*.json'
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: "Branch to update in swccg-scomp"
+        required: true
+        default: "test/update-scomp-workflow"
 
 jobs:
   update-scomp:
     runs-on: "ubuntu-latest"
+
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 1
           path: swccg-card-json
 
-
-      - name: Commit json files
+      - name: Select swccg-scomp target branch
+        id: target
         run: |
-          echo
-          echo
-          echo "ls"
-          ls -al
-          echo
-          echo "git: [$(which git)]: $(git --version)"
-          echo
-          echo "should be in /home/runner/work/swccg-card-json: [$(pwd)]"
-          echo
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "branch=${{ github.event.inputs.target_branch }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.ref_name }}" = "main" ]; then
+            echo "branch=main" >> "$GITHUB_OUTPUT"
+          else
+            echo "branch=test/update-scomp-workflow" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure SSH
+        run: |
           echo "${{ secrets.SWCCG_CARD_JSON }}" > swccg-card-json.pem
           chmod 0600 swccg-card-json.pem
-          echo "swccg-card-json.pem info:"
-          ls -al swccg-card-json.pem
-          echo
-          echo "Setting GIT_SSH_COMMAND"
-          export GIT_SSH_COMMAND="ssh -i swccg-card-json.pem -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-          echo "git clone swccg-scomp"
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+      - name: Clone swccg-scomp
+        env:
+          GIT_SSH_COMMAND: ssh -i swccg-card-json.pem
+          SCOMP_TARGET_BRANCH: ${{ steps.target.outputs.branch }}
+        run: |
           git clone git@github.com:swccgpc/swccg-scomp.git swccg-scomp
-          echo
-          echo "ls"
-          ls -al
-          echo
-          ls swccg-scomp
-          echo
-          ls swccg-card-json
-          echo
-          echo "copy json files to swccg-scomp"
-          cp swccg-card-json/*.json swccg-scomp/
-          echo "commit json files to scomp repo"
           cd swccg-scomp
-          echo "should be in swccg-scomp: [$(pwd)]"
+          if git show-ref --verify --quiet "refs/remotes/origin/${SCOMP_TARGET_BRANCH}"; then
+            git checkout -B "$SCOMP_TARGET_BRANCH" "origin/$SCOMP_TARGET_BRANCH"
+          else
+            git checkout -B "$SCOMP_TARGET_BRANCH"
+          fi
+
+      - name: Copy JSON files
+        run: cp swccg-card-json/*.json swccg-scomp/
+
+      - name: Commit JSON files
+        id: commit
+        working-directory: swccg-scomp
+        run: |
           git config --local user.email "devon+github-actions[bot]@hubner.org"
           git config --local user.name "github-actions[bot]"
-          git add -A *.json ; true
-          git commit -m "Updating card json files to latest" -a ; true
-          export GIT_SSH_COMMAND="ssh -i ../swccg-card-json.pem -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-          GIT_SSH_COMMAND="ssh -i ../swccg-card-json.pem -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" git push
-          rm ../swccg-card-json.pem
+          git add -A *.json
+          if git diff --cached --quiet; then
+            echo "No JSON changes to commit."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            git commit -m "Updating card json files to latest"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
 
+      - name: Push changes
+        if: steps.commit.outputs.changed == 'true'
+        working-directory: swccg-scomp
+        env:
+          GIT_SSH_COMMAND: ssh -i ../swccg-card-json.pem
+          SCOMP_TARGET_BRANCH: ${{ steps.target.outputs.branch }}
+        run: git push origin "HEAD:$SCOMP_TARGET_BRANCH"
 
-
-
-
-
-
-
-
-
-
+      - name: Cleanup SSH key
+        if: always()
+        run: rm -f swccg-card-json.pem

--- a/.github/workflows/update-scomp.yml
+++ b/.github/workflows/update-scomp.yml
@@ -36,8 +36,10 @@ jobs:
           fi
 
       - name: Configure SSH
+        env:
+          SWCCG_CARD_JSON_KEY: ${{ secrets.SWCCG_CARD_JSON }}
         run: |
-          printf '%s\n' "${{ secrets.SWCCG_CARD_JSON }}" | tr -d '\r' > swccg-card-json.pem
+          printf '%s\n' "$SWCCG_CARD_JSON_KEY" | tr -d '\r' > swccg-card-json.pem
           chmod 0600 swccg-card-json.pem
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts
@@ -48,6 +50,7 @@ jobs:
           GIT_SSH_COMMAND: ssh -i swccg-card-json.pem
           SCOMP_TARGET_BRANCH: ${{ steps.target.outputs.branch }}
         run: |
+          echo "Target branch: $SCOMP_TARGET_BRANCH"
           git clone git@github.com:swccgpc/swccg-scomp.git swccg-scomp
           cd swccg-scomp
           if git show-ref --verify --quiet "refs/remotes/origin/${SCOMP_TARGET_BRANCH}"; then
@@ -57,7 +60,9 @@ jobs:
           fi
 
       - name: Copy JSON files
-        run: cp swccg-card-json/*.json swccg-scomp/
+        run: |
+          echo "Copying $(find swccg-card-json -maxdepth 1 -name '*.json' | wc -l) JSON files."
+          cp swccg-card-json/*.json swccg-scomp/
 
       - name: Commit JSON files
         id: commit
@@ -71,6 +76,7 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             git commit -m "Updating card json files to latest"
+            echo "Created commit $(git rev-parse --short HEAD)."
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -80,7 +86,9 @@ jobs:
         env:
           GIT_SSH_COMMAND: ssh -i ../swccg-card-json.pem
           SCOMP_TARGET_BRANCH: ${{ steps.target.outputs.branch }}
-        run: git push origin "HEAD:$SCOMP_TARGET_BRANCH"
+        run: |
+          echo "Pushing $(git rev-parse --short HEAD) to $SCOMP_TARGET_BRANCH."
+          git push origin "HEAD:$SCOMP_TARGET_BRANCH"
 
       - name: Cleanup SSH key
         if: always()

--- a/rarity.json
+++ b/rarity.json
@@ -9,7 +9,7 @@
   "PM3": "Premium (3 copies)",
   "PM5": "Premium (5 copies)",
   "PV": "Preview",
-  "R": "Rare",
+  "R" : "Rare",
   "R1": "Rare 1",
   "R2": "Rare 2",
   "U": "Uncommon",

--- a/rarity.json
+++ b/rarity.json
@@ -11,7 +11,7 @@
   "PV": "Preview",
   "R" : "Rare",
   "R1" : "Rare 1",
-  "R2": "Rare 2",
+  "R2" : "Rare 2",
   "U": "Uncommon",
   "U1": "Uncommon 1",
   "U2": "Uncommon 2",

--- a/rarity.json
+++ b/rarity.json
@@ -10,7 +10,7 @@
   "PM5": "Premium (5 copies)",
   "PV": "Preview",
   "R" : "Rare",
-  "R1": "Rare 1",
+  "R1" : "Rare 1",
   "R2": "Rare 2",
   "U": "Uncommon",
   "U1": "Uncommon 1",

--- a/rarity.json
+++ b/rarity.json
@@ -14,7 +14,7 @@
   "R2" : "Rare 2",
   "U" : "Uncommon",
   "U1" : "Uncommon 1",
-  "U2": "Uncommon 2",
+  "U2" : "Uncommon 2",
   "UR": "Ultra-Rare",
   "XR": "Exclusive Rare"
 }

--- a/rarity.json
+++ b/rarity.json
@@ -9,12 +9,12 @@
   "PM3": "Premium (3 copies)",
   "PM5": "Premium (5 copies)",
   "PV": "Preview",
-  "R" : "Rare",
-  "R1" : "Rare 1",
-  "R2" : "Rare 2",
-  "U" : "Uncommon",
-  "U1" : "Uncommon 1",
-  "U2" : "Uncommon 2",
+  "R": "Rare",
+  "R1": "Rare 1",
+  "R2": "Rare 2",
+  "U": "Uncommon",
+  "U1": "Uncommon 1",
+  "U2": "Uncommon 2",
   "UR": "Ultra-Rare",
   "XR": "Exclusive Rare"
 }

--- a/rarity.json
+++ b/rarity.json
@@ -13,7 +13,7 @@
   "R1" : "Rare 1",
   "R2" : "Rare 2",
   "U" : "Uncommon",
-  "U1": "Uncommon 1",
+  "U1" : "Uncommon 1",
   "U2": "Uncommon 2",
   "UR": "Ultra-Rare",
   "XR": "Exclusive Rare"

--- a/rarity.json
+++ b/rarity.json
@@ -12,7 +12,7 @@
   "R" : "Rare",
   "R1" : "Rare 1",
   "R2" : "Rare 2",
-  "U": "Uncommon",
+  "U" : "Uncommon",
   "U1": "Uncommon 1",
   "U2": "Uncommon 2",
   "UR": "Ultra-Rare",


### PR DESCRIPTION
  Refactored the `Update Scomp` workflow to make it easier to test, debug, and operate safely.

  What changed:
  - Added a `*.json` path filter so the workflow only runs when root JSON files change.
  - Split the previous single large shell script into focused steps:
    - checkout source JSON repo
    - select target branch
    - configure SSH
    - clone `swccg-scomp`
    - copy JSON files
    - commit only when changes exist
    - push only when a commit was created
    - always clean up the temporary SSH key
  - Replaced `StrictHostKeyChecking=no` with `ssh-keyscan github.com`.
  - Added SSH key normalization/validation before cloning.
  - Updated `actions/checkout` from `@main` to `@v4`.
  - Added `workflow_dispatch` with a configurable target branch for manual testing or recovery runs.

  Validation:
  - Tested the refactored workflow from the feature branch using a forked `swccg-scomp` target branch.
  - Confirmed clone, copy, commit, and push all succeeded.
  - Removed the temporary test trigger/fork routing and JSON test changes before finalizing the branch.

  Production behavior:
  - Pushes to this repo’s `main` that modify root `*.json` files still update `swccgpc/swccg-scomp:main`.