### PR TITLE
Add personas to card JSON

### DIFF
--- a/Dark.json
+++ b/Dark.json
@@ -314,7 +314,10 @@
         "Canceling 4-LOM's game text or excluding him from battle could result in a battle ending immediately (in cases where his game text is required for the battle to occur)."
       ],
       "set": "4",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "4-LOM"
+      ]
     },
     {
       "abbr": [
@@ -382,6 +385,10 @@
           "title": "4-LOM With Concussion Rifle (V) (AI)",
           "cardId": 7133
         }
+      ],
+      "personas": [
+        "4-LOM",
+        "4-LOM's Concussion Rifle"
       ]
     },
     {
@@ -437,7 +444,11 @@
         "This weapon is not a blaster."
       ],
       "set": "200",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "4-LOM",
+        "4-LOM's Concussion Rifle"
+      ]
     },
     {
       "front": {
@@ -479,7 +490,10 @@
         "This weapon is not a blaster."
       ],
       "set": "4",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "4-LOM's Concussion Rifle"
+      ]
     },
     {
       "combo": [
@@ -1549,6 +1563,9 @@
           "title": "Admiral Motti (V)",
           "cardId": 61
         }
+      ],
+      "personas": [
+        "Motti"
       ]
     },
     {
@@ -1605,7 +1622,10 @@
       ],
       "rarity": "R2",
       "set": "200",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Motti"
+      ]
     },
     {
       "combo": [
@@ -1660,6 +1680,9 @@
           "title": "Admiral Ozzel (V)",
           "cardId": 6789
         }
+      ],
+      "personas": [
+        "Ozzel"
       ]
     },
     {
@@ -1743,6 +1766,9 @@
           "title": "Admiral Piett (V)",
           "cardId": 6896
         }
+      ],
+      "personas": [
+        "Piett"
       ]
     },
     {
@@ -1867,7 +1893,10 @@
         "A character is only an ISB agent if the ISB Operations objective is being used."
       ],
       "set": "203",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Kallus"
+      ]
     },
     {
       "front": {
@@ -1911,7 +1940,10 @@
         "A character is only an ISB agent if the ISB Operations objective is being used."
       ],
       "set": "203",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Kallus"
+      ]
     },
     {
       "abbr": [
@@ -3301,6 +3333,9 @@
           "title": "Arica (V)",
           "cardId": 4021
         }
+      ],
+      "personas": [
+        "Mara Jade"
       ]
     },
     {
@@ -3355,7 +3390,10 @@
       ],
       "rarity": "PM",
       "set": "200",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Mara Jade"
+      ]
     },
     {
       "combo": [
@@ -3451,7 +3489,11 @@
         "Canceling the targeting of one character (e.g. Blaster Deflection) cancels the entire action."
       ],
       "set": "301",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Ventress",
+        "Asajj's Lightsabers"
+      ]
     },
     {
       "abbr": [
@@ -3506,7 +3548,11 @@
         "Canceling the targeting of one character (e.g. Blaster Deflection) cancels the entire action."
       ],
       "set": "301",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Ventress",
+        "Asajj's Lightsabers"
+      ]
     },
     {
       "front": {
@@ -3872,6 +3918,9 @@
           "cardId": 6874,
           "title": "Aurra Sing With Blaster Rifle (AI)"
         }
+      ],
+      "personas": [
+        "Aurra"
       ]
     },
     {
@@ -3918,6 +3967,9 @@
           "cardId": 6783,
           "title": "Aurra Sing With Blaster Rifle"
         }
+      ],
+      "personas": [
+        "Aurra"
       ]
     },
     {
@@ -3966,6 +4018,9 @@
           "title": "Aurra Sing With Blaster Rifle (C-Slip AI)",
           "cardId": 7228
         }
+      ],
+      "personas": [
+        "Aurra Sing's Blaster Rifle"
       ]
     },
     {
@@ -4923,7 +4978,10 @@
       ],
       "rarity": "R",
       "set": "6",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Beedo"
+      ]
     },
     {
       "counterpart": "Security Control",
@@ -5222,6 +5280,9 @@
           "title": "Margo",
           "cardId": 6798
         }
+      ],
+      "personas": [
+        "Bib Fortuna"
       ]
     },
     {
@@ -5257,7 +5318,10 @@
       ],
       "rarity": "PM",
       "set": "13",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Bib Fortuna"
+      ]
     },
     {
       "counterpart": "Big One",
@@ -5568,6 +5632,9 @@
           "cardId": 248,
           "title": "Black 2 (V)"
         }
+      ],
+      "personas": [
+        "Black 2"
       ]
     },
     {
@@ -5623,7 +5690,10 @@
       ],
       "rarity": "R1",
       "set": "200",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Black 2"
+      ]
     },
     {
       "front": {
@@ -5670,6 +5740,9 @@
           "cardId": 6125,
           "title": "Black 3 (V)"
         }
+      ],
+      "personas": [
+        "Black 3"
       ]
     },
     {
@@ -5705,7 +5778,10 @@
       ],
       "rarity": "U1",
       "set": "210",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Black 3"
+      ]
     },
     {
       "front": {
@@ -6267,6 +6343,9 @@
           "cardId": 6956,
           "title": "Blizzard 1 (V)"
         }
+      ],
+      "personas": [
+        "Blizzard 1"
       ]
     },
     {
@@ -6736,7 +6815,10 @@
         "The once per game action may deploy a Neimoidian pilot to a Blockade Flagship site."
       ],
       "set": "14",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Blockade Flagship"
+      ]
     },
     {
       "combo": [
@@ -6773,7 +6855,10 @@
       ],
       "rarity": "R",
       "set": "12",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Blockade Flagship"
+      ]
     },
     {
       "counterpart": "Blockade Flagship: Docking Bay",
@@ -6826,6 +6911,9 @@
           "cardId": 6421,
           "title": "Invisible Hand: Docking Bay"
         }
+      ],
+      "personas": [
+        "Blockade Flagship"
       ]
     },
     {
@@ -6870,6 +6958,9 @@
           "cardId": 6422,
           "title": "Invisible Hand: Hallway 328"
         }
+      ],
+      "personas": [
+        "Blockade Flagship"
       ]
     },
     {
@@ -7052,6 +7143,9 @@
           "cardId": 6138,
           "title": "Boba Fett (V)"
         }
+      ],
+      "personas": [
+        "Boba Fett"
       ]
     },
     {
@@ -7111,7 +7205,10 @@
       ],
       "rarity": "R",
       "set": "7",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Boba Fett"
+      ]
     },
     {
       "front": {
@@ -7151,7 +7248,10 @@
       ],
       "rarity": "R",
       "set": "206",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Boba Fett"
+      ]
     },
     {
       "combo": [
@@ -7202,6 +7302,10 @@
           "cardId": 4055,
           "title": "Boba Fett In Slave I (V)"
         }
+      ],
+      "personas": [
+        "Slave I",
+        "Boba Fett"
       ]
     },
     {
@@ -7250,7 +7354,11 @@
       ],
       "rarity": "PM",
       "set": "200",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Slave I",
+        "Boba Fett"
+      ]
     },
     {
       "abbr": [
@@ -7314,6 +7422,10 @@
           "cardId": 7236,
           "title": "Boba Fett With Blaster Rifle (V)"
         }
+      ],
+      "personas": [
+        "Boba Fett",
+        "Boba Fett's Blaster Rifle"
       ]
     },
     {
@@ -7376,7 +7488,10 @@
       ],
       "rarity": "PM",
       "set": "13",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Boba Fett"
+      ]
     },
     {
       "canceledBy": [
@@ -7428,6 +7543,9 @@
           "cardId": 5123,
           "title": "Boba Fett's Blaster Rifle (V)"
         }
+      ],
+      "personas": [
+        "Boba Fett's Blaster Rifle"
       ]
     },
     {
@@ -7472,7 +7590,10 @@
       ],
       "rarity": "R",
       "set": "205",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Boba Fett's Blaster Rifle"
+      ]
     },
     {
       "combo": [
@@ -7779,6 +7900,9 @@
           "cardId": 309,
           "title": "Bossk (V)"
         }
+      ],
+      "personas": [
+        "Bossk"
       ]
     },
     {
@@ -7827,7 +7951,10 @@
       ],
       "rarity": "R",
       "set": "200",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Bossk"
+      ]
     },
     {
       "abbr": [
@@ -7876,6 +8003,10 @@
           "cardId": 4056,
           "title": "Bossk In Hound's Tooth (V)"
         }
+      ],
+      "personas": [
+        "Hound's Tooth",
+        "Bossk"
       ]
     },
     {
@@ -7922,7 +8053,11 @@
       ],
       "rarity": "R",
       "set": "200",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Hound's Tooth",
+        "Bossk"
+      ]
     },
     {
       "abbr": [
@@ -7972,7 +8107,11 @@
         "May not target inactive cards or owner's cards."
       ],
       "set": "110",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Bossk",
+        "Bossk's Mortar Gun"
+      ]
     },
     {
       "front": {
@@ -8010,7 +8149,10 @@
         "May not target inactive cards or owner's cards."
       ],
       "set": "4",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Bossk's Mortar Gun"
+      ]
     },
     {
       "combo": [
@@ -8369,7 +8511,10 @@
       ],
       "rarity": "C",
       "set": "203",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Cad"
+      ]
     },
     {
       "counterpart": "Caller",
@@ -8581,7 +8726,10 @@
       ],
       "rarity": "R",
       "set": "14",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Dofine"
+      ]
     },
     {
       "front": {
@@ -8753,7 +8901,11 @@
       ],
       "rarity": "U",
       "set": "205",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Scimitar 2",
+        "Jonus"
+      ]
     },
     {
       "front": {
@@ -8802,6 +8954,9 @@
           "cardId": 6875,
           "title": "Captain Khurgee (V)"
         }
+      ],
+      "personas": [
+        "Khurgee"
       ]
     },
     {
@@ -9103,7 +9258,10 @@
       ],
       "rarity": "R2",
       "set": "3",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Piett"
+      ]
     },
     {
       "combo": [
@@ -9720,6 +9878,9 @@
           "title": "Chimaera (V) (AI)",
           "cardId": 7361
         }
+      ],
+      "personas": [
+        "Chimaera"
       ]
     },
     {
@@ -11057,7 +11218,10 @@
       "pulledBy": [],
       "rarity": "R",
       "set": "9",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Jendon"
+      ]
     },
     {
       "conceptBy": "(Original concept by Jeremy Gardner - PC Volunteer Award 2009)",
@@ -11110,7 +11274,11 @@
       ],
       "rarity": "R",
       "set": "200",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Onyx 1",
+        "Jendon"
+      ]
     },
     {
       "front": {
@@ -11156,6 +11324,9 @@
           "cardId": 4096,
           "title": "Colonel Wullf Yularen (V)"
         }
+      ],
+      "personas": [
+        "Yularen"
       ]
     },
     {
@@ -11194,7 +11365,10 @@
       ],
       "rarity": "U1",
       "set": "201",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Yularen"
+      ]
     },
     {
       "front": {
@@ -12096,6 +12270,9 @@
           "title": "Commander Praji (V)",
           "cardId": 7160
         }
+      ],
+      "personas": [
+        "Praji"
       ]
     },
     {
@@ -12806,7 +12983,10 @@
       ],
       "rarity": "R",
       "set": "7",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Grenwick"
+      ]
     },
     {
       "front": {
@@ -13692,7 +13872,10 @@
         "When using this text, treat all instances of the word 'Emperor' on Force Lightning as 'Dooku' instead."
       ],
       "set": "200",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Dooku"
+      ]
     },
     {
       "canceledBy": [
@@ -14138,6 +14321,9 @@
           "cardId": 6898,
           "title": "Dannik Jerriko (V)"
         }
+      ],
+      "personas": [
+        "Dannik Jerriko"
       ]
     },
     {
@@ -14867,7 +15053,10 @@
         "If a character of ability > 3 is excluded and this causes Maul's text to make Dark control the location, the excluded character is still active for the purposes of Objective flip conditions (e.g. Quiet Mining Colony) and for the purposes of preventing cards like Haven from leaving table."
       ],
       "set": "11",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Maul"
+      ]
     },
     {
       "front": {
@@ -14903,7 +15092,10 @@
       ],
       "rarity": "R",
       "set": "11",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Maul"
+      ]
     },
     {
       "abbr": [
@@ -14961,7 +15153,11 @@
       ],
       "rarity": "R",
       "set": "14",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Maul",
+        "Maul's Double-Bladed Lightsaber"
+      ]
     },
     {
       "abbr": [
@@ -15025,7 +15221,10 @@
         "Cancels game text of any version of the Amidala persona, including Padme."
       ],
       "set": "203",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Maul"
+      ]
     },
     {
       "abbr": [
@@ -15083,6 +15282,9 @@
           "title": "Darth Maul, Lone Hunter (C-Slip AI)",
           "cardId": 7225
         }
+      ],
+      "personas": [
+        "Maul"
       ]
     },
     {
@@ -15128,6 +15330,9 @@
           "title": "Darth Maul, Lone Hunter (C-Slip AI 2)",
           "cardId": 7229
         }
+      ],
+      "personas": [
+        "Maul"
       ]
     },
     {
@@ -15170,7 +15375,10 @@
       ],
       "rarity": "R",
       "set": "14",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Sidious"
+      ]
     },
     {
       "front": {
@@ -15205,7 +15413,10 @@
       ],
       "rarity": "R",
       "set": "14",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Sidious"
+      ]
     },
     {
       "abbr": [
@@ -15275,6 +15486,9 @@
           "cardId": 635,
           "title": "Darth Vader (V)"
         }
+      ],
+      "personas": [
+        "Vader"
       ]
     },
     {
@@ -15348,7 +15562,10 @@
         "Vader only looks for <u>your</u> Black Squadron pilot, not an opponent's Black Squadron pilot."
       ],
       "set": "200",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Vader"
+      ]
     },
     {
       "abbr": [
@@ -15406,7 +15623,11 @@
       ],
       "rarity": "PM",
       "set": "108",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Vader",
+        "Vader's Lightsaber"
+      ]
     },
     {
       "abbr": [
@@ -15465,7 +15686,10 @@
       ],
       "rarity": "R",
       "set": "7",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Vader"
+      ]
     },
     {
       "front": {
@@ -15524,7 +15748,10 @@
         "'Immune to Sorry About The Mess' prevents the control phase firing function and prevents the place in Lost Pile function of the combo card. It does not prevent the 3 being added to weapon destiny function of the combo card."
       ],
       "set": "208",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Vader"
+      ]
     },
     {
       "front": {
@@ -15572,6 +15799,9 @@
           "cardId": 5211,
           "title": "Darth Vader's Lightsaber (V)"
         }
+      ],
+      "personas": [
+        "Vader's Lightsaber"
       ]
     },
     {
@@ -15617,7 +15847,10 @@
       ],
       "rarity": "R",
       "set": "208",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Vader's Lightsaber"
+      ]
     },
     {
       "front": {
@@ -15758,6 +15991,9 @@
           "cardId": 7075,
           "title": "Daultay Dofine (V)"
         }
+      ],
+      "personas": [
+        "Dofine"
       ]
     },
     {
@@ -16067,7 +16303,15 @@
         "Vader provides 6 ability. DS-61-2 and DS-61-3 each provide 2 ability."
       ],
       "set": "7",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Vader's Custom TIE",
+        "Black 2",
+        "Black 3",
+        "Vader",
+        "DS-61-2",
+        "DS-61-3"
+      ]
     },
     {
       "front": {
@@ -17219,6 +17463,9 @@
           "cardId": 5112,
           "title": "Dengar (V)"
         }
+      ],
+      "personas": [
+        "Dengar"
       ]
     },
     {
@@ -17279,7 +17526,10 @@
         "Pulls any weapon with the blaster attribute, but only pulls the bounty card with the exact card title 'Bounty' (e.g. not Tarkin's Bounty)."
       ],
       "set": "205",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Dengar"
+      ]
     },
     {
       "abbr": [
@@ -17328,7 +17578,11 @@
       ],
       "rarity": "PM",
       "set": "109",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Punishing One",
+        "Dengar"
+      ]
     },
     {
       "abbr": [
@@ -17387,6 +17641,10 @@
           "cardId": 4023,
           "title": "Dengar With Blaster Carbine (V)"
         }
+      ],
+      "personas": [
+        "Dengar",
+        "Dengar's Blaster Carbine"
       ]
     },
     {
@@ -17441,7 +17699,11 @@
       ],
       "rarity": "PM",
       "set": "200",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Dengar",
+        "Dengar's Blaster Carbine"
+      ]
     },
     {
       "front": {
@@ -17481,7 +17743,10 @@
       ],
       "rarity": "R",
       "set": "4",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Dengar's Blaster Carbine"
+      ]
     },
     {
       "front": {
@@ -18160,7 +18425,10 @@
       ],
       "rarity": "U",
       "set": "207",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Krennic"
+      ]
     },
     {
       "canceledBy": [
@@ -18570,7 +18838,10 @@
       ],
       "rarity": "U",
       "set": "200",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Dooku's Lightsaber"
+      ]
     },
     {
       "canceledBy": [
@@ -18850,7 +19121,10 @@
         "Unoccupied means neither player occupies AND neither player has an undercover spy there (not even an undercover droid)."
       ],
       "set": "209",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Aphra"
+      ]
     },
     {
       "abbr": [
@@ -18892,7 +19166,10 @@
         "Unoccupied means neither player occupies AND neither player has an undercover spy there (not even an undercover droid)."
       ],
       "set": "209",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Aphra"
+      ]
     },
     {
       "abbr": [
@@ -19620,6 +19897,9 @@
           "cardId": 6500,
           "title": "Lt. Poldin Lehuse"
         }
+      ],
+      "personas": [
+        "DS-61-2"
       ]
     },
     {
@@ -19669,6 +19949,9 @@
           "title": "DS-61-3 (V)",
           "cardId": 7402
         }
+      ],
+      "personas": [
+        "DS-61-3"
       ]
     },
     {
@@ -20298,7 +20581,10 @@
       ],
       "rarity": "PM",
       "set": "200",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Elis"
+      ]
     },
     {
       "front": {
@@ -20426,7 +20712,10 @@
         "May deploy, move, or persona replace to a <u>system or sector</u> opponent occupies."
       ],
       "set": "9",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Sidious"
+      ]
     },
     {
       "combo": [
@@ -20475,7 +20764,10 @@
       ],
       "rarity": "U",
       "set": "205",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Sidious"
+      ]
     },
     {
       "abbr": [
@@ -21816,6 +22108,9 @@
           "cardId": 7011,
           "title": "Finalizer (AI)"
         }
+      ],
+      "personas": [
+        "Executor"
       ]
     },
     {
@@ -21856,6 +22151,9 @@
           "cardId": 6919,
           "title": "Scarif: Command Center"
         }
+      ],
+      "personas": [
+        "Executor"
       ]
     },
     {
@@ -21900,6 +22198,9 @@
           "cardId": 6420,
           "title": "Invisible Hand: Bridge"
         }
+      ],
+      "personas": [
+        "Executor"
       ]
     },
     {
@@ -21945,7 +22246,10 @@
         "The above rulings apply to Flagship Executor as well."
       ],
       "set": "7",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Executor"
+      ]
     },
     {
       "front": {
@@ -21981,7 +22285,10 @@
       ],
       "rarity": "R",
       "set": "4",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Executor"
+      ]
     },
     {
       "front": {
@@ -22021,6 +22328,9 @@
           "cardId": 6423,
           "title": "Invisible Hand: Observatory Entrance"
         }
+      ],
+      "personas": [
+        "Executor"
       ]
     },
     {
@@ -22055,7 +22365,10 @@
       ],
       "rarity": "R",
       "set": "4",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Executor"
+      ]
     },
     {
       "front": {
@@ -23160,7 +23473,10 @@
       ],
       "rarity": "R",
       "set": "9",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Executor"
+      ]
     },
     {
       "combo": [
@@ -24400,6 +24716,9 @@
           "cardId": 7448,
           "title": "Garindan, Imperial Spy"
         }
+      ],
+      "personas": [
+        "Garindan"
       ]
     },
     {
@@ -24494,7 +24813,10 @@
         "A stolen lightsaber deploying on Grievous must still obey uniqueness rules."
       ],
       "set": "203",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Grievous"
+      ]
     },
     {
       "abbr": [
@@ -24549,7 +24871,10 @@
         "A stolen lightsaber deploying on Grievous must still obey uniqueness rules."
       ],
       "set": "203",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Grievous"
+      ]
     },
     {
       "conceptBy": "(Original concept by Jeremy Gardner)",
@@ -24601,7 +24926,10 @@
         "A stolen lightsaber deploying on Grievous must still obey uniqueness rules."
       ],
       "set": "203",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Grievous"
+      ]
     },
     {
       "front": {
@@ -24807,6 +25135,9 @@
           "cardId": 1030,
           "title": "General Veers (V)"
         }
+      ],
+      "personas": [
+        "Veers"
       ]
     },
     {
@@ -24866,7 +25197,10 @@
         "The 'immunity to attrition +2' text allows permanent pilots, so (for example) it can work while piloting Blizzard 2."
       ],
       "set": "200",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Veers"
+      ]
     },
     {
       "cancels": [
@@ -25148,6 +25482,9 @@
           "cardId": 6522,
           "title": "Mitth'raw'nuruodo"
         }
+      ],
+      "personas": [
+        "Thrawn"
       ]
     },
     {
@@ -25201,7 +25538,10 @@
       ],
       "rarity": "PM",
       "set": "207",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Thrawn"
+      ]
     },
     {
       "abbr": [
@@ -25266,6 +25606,9 @@
           "cardId": 4026,
           "title": "Grand Moff Tarkin (V)"
         }
+      ],
+      "personas": [
+        "Tarkin"
       ]
     },
     {
@@ -25315,7 +25658,10 @@
         "This card is not a commander ('commanded' doesn't count)."
       ],
       "set": "200",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Tarkin"
+      ]
     },
     {
       "front": {
@@ -26803,6 +27149,9 @@
           "cardId": 1186,
           "title": "Hound's Tooth (V)"
         }
+      ],
+      "personas": [
+        "Hound's Tooth"
       ]
     },
     {
@@ -26849,7 +27198,10 @@
       ],
       "rarity": "R",
       "set": "200",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Hound's Tooth"
+      ]
     },
     {
       "front": {
@@ -27936,7 +28288,10 @@
       ],
       "rarity": "R",
       "set": "4",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "IG-2000"
+      ]
     },
     {
       "front": {
@@ -27999,6 +28354,9 @@
           "cardId": 1246,
           "title": "IG-88 (V)"
         }
+      ],
+      "personas": [
+        "IG-88"
       ]
     },
     {
@@ -28058,7 +28416,10 @@
         "Cards with multiple warrior icons can still only escort one captive at a time."
       ],
       "set": "200",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "IG-88"
+      ]
     },
     {
       "front": {
@@ -28099,7 +28460,11 @@
         "Canceling IG-2000's game text or excluding it from battle could result in a battle ending immediately (in cases where its game text is required for the battle to occur)."
       ],
       "set": "110",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "IG-2000",
+        "IG-88"
+      ]
     },
     {
       "abbr": [
@@ -28153,7 +28518,10 @@
         "Canceling IG-88's game text or excluding him from battle could result in a battle ending immediately (in cases where his game text is required for the battle to occur)."
       ],
       "set": "109",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "IG-88"
+      ]
     },
     {
       "front": {
@@ -30206,7 +30574,10 @@
       ],
       "rarity": "PM",
       "set": "211",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Invisible Hand"
+      ]
     },
     {
       "front": {
@@ -30243,7 +30614,10 @@
       ],
       "rarity": "U",
       "set": "211",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Invisible Hand"
+      ]
     },
     {
       "front": {
@@ -30287,7 +30661,10 @@
         "If Invisible Hand is lost from table, this site remains on table."
       ],
       "set": "211",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Invisible Hand"
+      ]
     },
     {
       "front": {
@@ -30324,7 +30701,10 @@
       ],
       "rarity": "PM",
       "set": "211",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Invisible Hand"
+      ]
     },
     {
       "front": {
@@ -30358,7 +30738,10 @@
       ],
       "rarity": "C",
       "set": "211",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Invisible Hand"
+      ]
     },
     {
       "canceledBy": [
@@ -30651,7 +31034,10 @@
       ],
       "rarity": "R",
       "set": "7",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Jabba"
+      ]
     },
     {
       "combo": [
@@ -30695,7 +31081,10 @@
       ],
       "rarity": "PM",
       "set": "13",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Jabba"
+      ]
     },
     {
       "combo": [
@@ -30752,6 +31141,9 @@
           "cardId": 1347,
           "title": "Jabba The Hutt (V)"
         }
+      ],
+      "personas": [
+        "Jabba"
       ]
     },
     {
@@ -30812,7 +31204,10 @@
         "The player is not required to say 'OH-HO-HO!' out loud, although it is encouraged."
       ],
       "set": "200",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Jabba"
+      ]
     },
     {
       "counterpart": "Seeking an Audience (V)",
@@ -31231,7 +31626,10 @@
         "If freed while You Can Either Profit By This... on table, Light flips that objective first, then retrieves 10 Force for the 0 power Han, and then finally may replace Jabba's Prize with a Han card."
       ],
       "set": "10",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Han"
+      ]
     },
     {
       "front": {
@@ -31281,6 +31679,9 @@
           "cardId": 5135,
           "title": "Jabba's Sail Barge (V)"
         }
+      ],
+      "personas": [
+        "Jabba's Sail Barge"
       ]
     },
     {
@@ -31327,7 +31728,10 @@
         "May deploy Passenger Deck or a skiff even if Jabba's Sail Barge is unpiloted."
       ],
       "set": "204",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Jabba's Sail Barge"
+      ]
     },
     {
       "front": {
@@ -31368,7 +31772,10 @@
         "This site does <u>not</u> take on the name of the planet (e.g. it is not a Tatooine site, a character here is not 'on Tatooine' or 'on Cloud City' even if the Sail Barge is, etc)."
       ],
       "set": "6",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Jabba's Sail Barge"
+      ]
     },
     {
       "front": {
@@ -31804,7 +32211,10 @@
         "'May be targeted by Hidden Weapons' means he may be used instead of Boba Fett or your character with Mandalorian Armor. Other conditions must still be met."
       ],
       "set": "201",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Jango"
+      ]
     },
     {
       "canceledBy": [
@@ -31855,7 +32265,10 @@
         "'May be targeted by Hidden Weapons' means he may be used instead of Boba Fett or your character with Mandalorian Armor. Other conditions must still be met."
       ],
       "set": "201",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Jango"
+      ]
     },
     {
       "combo": [
@@ -33210,7 +33623,10 @@
       ],
       "rarity": "U",
       "set": "209",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Krennic"
+      ]
     },
     {
       "front": {
@@ -33417,7 +33833,10 @@
       ],
       "rarity": "PM",
       "set": "204",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Kylo"
+      ]
     },
     {
       "abbr": [
@@ -33462,7 +33881,11 @@
         "If something prevents the target from being hit (e.g. Theed Palace Generator Core) neither player loses 1 Force."
       ],
       "set": "209",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Kylo",
+        "Kylo's Lightsaber"
+      ]
     },
     {
       "abbr": [
@@ -33507,7 +33930,11 @@
         "If something prevents the target from being hit (e.g. Theed Palace Generator Core) neither player loses 1 Force."
       ],
       "set": "209",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Kylo",
+        "Kylo's Lightsaber"
+      ]
     },
     {
       "front": {
@@ -33594,7 +34021,10 @@
       ],
       "rarity": "R2",
       "set": "204",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Kylo's Lightsaber"
+      ]
     },
     {
       "front": {
@@ -33720,7 +34150,10 @@
         "If there are only 1 or 2 cards in Reserve Deck, Proxima can still reveal them, but she cannot take an alien into hand."
       ],
       "set": "211",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Proxima"
+      ]
     },
     {
       "front": {
@@ -33893,6 +34326,9 @@
           "cardId": 6965,
           "title": "Lando Calrissian, Vader's Broker"
         }
+      ],
+      "personas": [
+        "Lando"
       ]
     },
     {
@@ -35271,6 +35707,9 @@
           "title": "Lobot, Lando's Broker",
           "cardId": 7304
         }
+      ],
+      "personas": [
+        "Lobot"
       ]
     },
     {
@@ -35475,7 +35914,10 @@
       ],
       "rarity": "PM",
       "set": "13",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Maul"
+      ]
     },
     {
       "front": {
@@ -35522,7 +35964,11 @@
       ],
       "rarity": "R",
       "set": "208",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Maul",
+        "Maul's Double-Bladed Lightsaber"
+      ]
     },
     {
       "front": {
@@ -35578,7 +36024,10 @@
       ],
       "rarity": "U",
       "set": "208",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Sidious"
+      ]
     },
     {
       "combo": [
@@ -35638,7 +36087,10 @@
       ],
       "rarity": "R",
       "set": "9",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Vader"
+      ]
     },
     {
       "front": {
@@ -35730,7 +36182,10 @@
       ],
       "rarity": "R",
       "set": "12",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Lott"
+      ]
     },
     {
       "front": {
@@ -35926,9 +36381,9 @@
         "forfeit": "0",
         "gametext": "{Immediately} 'thaw' Luke (Luke is non-frozen, captured, and seized by Vader). {While} this side up, subtracts 3 from attempts to cross Lule over (even while a captive). {Place} out of play if released or about to leave table.",
         "icons": [
-            "Pilot",
-            "Warrior",
-            "Set 5"
+          "Pilot",
+          "Warrior",
+          "Set 5"
         ],
         "imageUrl": "https://res.starwarsccg.org/cards/Virtual5-Dark/large/lukeskywalkertheemperorsprizeback.gif",
         "power": "6",
@@ -35975,7 +36430,10 @@
         "Despite being a captive, all of this card's text is applicable whenever appropriate."
       ],
       "set": "205",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Luke"
+      ]
     },
     {
       "combo": [
@@ -36103,7 +36561,10 @@
       ],
       "rarity": "R",
       "set": "200",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Maarek Stele"
+      ]
     },
     {
       "front": {
@@ -36271,7 +36732,10 @@
         "This card is the same Marquand persona seen on Marquand In Blizzard 6. Both cannot be on table at the same time, and neither card may persona replace the other."
       ],
       "set": "8",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Marquand"
+      ]
     },
     {
       "front": {
@@ -36617,7 +37081,10 @@
       ],
       "rarity": "PM",
       "set": "208",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Mara Jade"
+      ]
     },
     {
       "abbr": [
@@ -36672,7 +37139,11 @@
         "When Mara moves for free using Elis Helrot, Elis Helrot is Used (not Lost) as payment was not declined; it was accepted and made free."
       ],
       "set": "200",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Mara Jade",
+        "Mara Jade's Lightsaber"
+      ]
     },
     {
       "abbr": [
@@ -36768,6 +37239,9 @@
           "cardId": 4029,
           "title": "Mara Jade With Lightsaber"
         }
+      ],
+      "personas": [
+        "Mara Jade"
       ]
     },
     {
@@ -36809,7 +37283,10 @@
       ],
       "rarity": "PM",
       "set": "110",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Mara Jade's Lightsaber"
+      ]
     },
     {
       "front": {
@@ -36847,7 +37324,10 @@
         "This card is the same Marquand persona as the Major Marquand character card. Both cannot be on table at the same time, and neither card may persona replace the other."
       ],
       "set": "210",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Marquand"
+      ]
     },
     {
       "front": {
@@ -37070,7 +37550,10 @@
       ],
       "rarity": "PM",
       "set": "13",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Maul's Double-Bladed Lightsaber"
+      ]
     },
     {
       "combo": [
@@ -37149,6 +37632,9 @@
           "cardId": 5187,
           "title": "Lord Maul With Lightsaber"
         }
+      ],
+      "personas": [
+        "Maul's Double-Bladed Lightsaber"
       ]
     },
     {
@@ -37200,7 +37686,10 @@
       ],
       "rarity": "R",
       "set": "12",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Maul's Sith Infiltrator"
+      ]
     },
     {
       "front": {
@@ -37234,7 +37723,10 @@
       ],
       "rarity": "R",
       "set": "12",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Maul's Sith Infiltrator"
+      ]
     },
     {
       "front": {
@@ -37406,7 +37898,10 @@
       ],
       "rarity": "PM",
       "set": "112",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Jabba"
+      ]
     },
     {
       "canceledBy": [
@@ -37530,6 +38025,9 @@
           "title": "Zuckuss And 4-LOM In Mist Hunter",
           "cardId": 7190
         }
+      ],
+      "personas": [
+        "Mist Hunter"
       ]
     },
     {
@@ -37580,7 +38078,10 @@
         "Counts as Thrawn for the purposes of Thrawn's Art Collection, A Great Tactician Creates Plans, etc."
       ],
       "set": "211",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Thrawn"
+      ]
     },
     {
       "abbr": [
@@ -38068,7 +38569,10 @@
       ],
       "rarity": "PM",
       "set": "102",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Motti"
+      ]
     },
     {
       "canceledBy": [
@@ -39234,7 +39738,10 @@
       ],
       "rarity": "R",
       "set": "8",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Fenson"
+      ]
     },
     {
       "front": {
@@ -40090,6 +40597,9 @@
           "cardId": 6547,
           "title": "Nute Gunray (V)"
         }
+      ],
+      "personas": [
+        "Gunray"
       ]
     },
     {
@@ -40127,7 +40637,10 @@
       ],
       "rarity": "R",
       "set": "210",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Gunray"
+      ]
     },
     {
       "front": {
@@ -40173,7 +40686,10 @@
       ],
       "rarity": "R",
       "set": "14",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Gunray"
+      ]
     },
     {
       "front": {
@@ -40207,7 +40723,10 @@
       ],
       "rarity": "R",
       "set": "14",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Gunray"
+      ]
     },
     {
       "front": {
@@ -40765,6 +41284,9 @@
           "cardId": 4057,
           "title": "Colonel Jendon In Onyx 1"
         }
+      ],
+      "personas": [
+        "Onyx 1"
       ]
     },
     {
@@ -41423,7 +41945,10 @@
         "Rep is defined on the Objective card My Kind Of Scum."
       ],
       "set": "203",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Ortugg's Ax"
+      ]
     },
     {
       "front": {
@@ -41463,7 +41988,10 @@
       ],
       "rarity": "R",
       "set": "7",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "OS-72-1"
+      ]
     },
     {
       "front": {
@@ -41541,7 +42069,10 @@
       ],
       "rarity": "R",
       "set": "7",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "OS-72-2"
+      ]
     },
     {
       "canceledBy": [
@@ -43448,6 +43979,9 @@
           "cardId": 5160,
           "title": "Punishing One (V)"
         }
+      ],
+      "personas": [
+        "Punishing One"
       ]
     },
     {
@@ -43494,7 +44028,10 @@
       ],
       "rarity": "R",
       "set": "207",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Punishing One"
+      ]
     },
     {
       "abbr": [
@@ -45459,7 +45996,10 @@
       ],
       "rarity": "R",
       "set": "12",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Haako"
+      ]
     },
     {
       "front": {
@@ -45502,7 +46042,10 @@
       ],
       "rarity": "R",
       "set": "14",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Haako"
+      ]
     },
     {
       "front": {
@@ -45536,7 +46079,10 @@
       ],
       "rarity": "R",
       "set": "14",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Haako"
+      ]
     },
     {
       "front": {
@@ -46322,6 +46868,9 @@
           "title": "Maul In Scimitar",
           "cardId": 7305
         }
+      ],
+      "personas": [
+        "Scimitar 2"
       ]
     },
     {
@@ -47619,7 +48168,10 @@
         "This card is not a commander ('commanded' doesn't count)."
       ],
       "set": "7",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Narthax"
+      ]
     },
     {
       "abbr": [
@@ -47661,7 +48213,10 @@
       ],
       "rarity": "C1",
       "set": "211",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Narthax"
+      ]
     },
     {
       "front": {
@@ -48843,6 +49398,9 @@
           "cardId": 6649,
           "title": "Slave I, Symbol Of Fear (AI)"
         }
+      ],
+      "personas": [
+        "Slave I"
       ]
     },
     {
@@ -48895,7 +49453,10 @@
       ],
       "rarity": "R",
       "set": "201",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Slave I"
+      ]
     },
     {
       "front": {
@@ -48932,7 +49493,10 @@
       ],
       "rarity": "R",
       "set": "201",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Slave I"
+      ]
     },
     {
       "counterpart": "Nudj",
@@ -51162,7 +51726,10 @@
         "Kylo globally gains the power +3, even affecting a Kylo card deployed after Snoke was lost."
       ],
       "set": "209",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Snoke"
+      ]
     },
     {
       "abbr": [
@@ -51207,7 +51774,10 @@
         "Kylo globally gains the power +3, even affecting a Kylo card deployed after Snoke was lost."
       ],
       "set": "209",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Snoke"
+      ]
     },
     {
       "abbr": [
@@ -51873,6 +52443,9 @@
           "cardId": 5098,
           "title": "Tarkin (V)"
         }
+      ],
+      "personas": [
+        "Tarkin"
       ]
     },
     {
@@ -51920,7 +52493,10 @@
       ],
       "rarity": "PM",
       "set": "204",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Tarkin"
+      ]
     },
     {
       "front": {
@@ -54016,6 +54592,9 @@
           "cardId": 7091,
           "title": "The Emperor, Relentess"
         }
+      ],
+      "personas": [
+        "Sidious"
       ]
     },
     {
@@ -54230,7 +54809,10 @@
       ],
       "rarity": "C",
       "set": "210",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "The Grand Inquisitor"
+      ]
     },
     {
       "cancels": [
@@ -57583,6 +58165,9 @@
           "cardId": 7098,
           "title": "Vader (V)"
         }
+      ],
+      "personas": [
+        "Vader"
       ]
     },
     {
@@ -57775,6 +58360,9 @@
           "cardId": 5143,
           "title": "Vader's Custom TIE (V)"
         }
+      ],
+      "personas": [
+        "Vader's Custom TIE"
       ]
     },
     {
@@ -57829,7 +58417,10 @@
         "An astromech slot counts as a type of passenger slot. For example if the character card R2-D2 is in the astromech slot of the starship card Red 5, Vader's Custom TIE (V) can cancel R2-D2's game text."
       ],
       "set": "206",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Vader's Custom TIE"
+      ]
     },
     {
       "front": {
@@ -57906,6 +58497,9 @@
           "cardId": 7099,
           "title": "Vader's Lightsaber (V)"
         }
+      ],
+      "personas": [
+        "Vader's Lightsaber"
       ]
     },
     {
@@ -58008,6 +58602,9 @@
           "cardId": 4060,
           "title": "Vader's Personal Shuttle (V)"
         }
+      ],
+      "personas": [
+        "Vader's Personal Shuttle"
       ]
     },
     {
@@ -58066,7 +58663,10 @@
       ],
       "rarity": "R",
       "set": "200",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Vader's Personal Shuttle"
+      ]
     },
     {
       "front": {
@@ -58109,7 +58709,10 @@
         "A card with 'Vader' in title can be plural or possessive (e.g. Vader's Cape or Vader's Castle is allowed) but not part of a larger word (e.g. Evader is not allowed)."
       ],
       "set": "209",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Vanee"
+      ]
     },
     {
       "front": {
@@ -58190,6 +58793,9 @@
           "cardId": 5142,
           "title": "Veers (V)"
         }
+      ],
+      "personas": [
+        "Veers"
       ]
     },
     {
@@ -58244,7 +58850,10 @@
       ],
       "rarity": "PM",
       "set": "206",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Veers"
+      ]
     },
     {
       "counterpart": "Vehicle Mine",
@@ -60620,6 +61229,9 @@
           "title": "Wuher (V)",
           "cardId": 7289
         }
+      ],
+      "personas": [
+        "Wuher"
       ]
     },
     {
@@ -61957,6 +62569,9 @@
           "cardId": 7127,
           "title": "Zuckuss (V)"
         }
+      ],
+      "personas": [
+        "Zuckuss"
       ]
     },
     {
@@ -62005,7 +62620,11 @@
       ],
       "rarity": "PM",
       "set": "110",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Mist Hunter",
+        "Zuckuss"
+      ]
     },
     {
       "front": {
@@ -62043,7 +62662,10 @@
       ],
       "rarity": "R",
       "set": "4",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Zuckuss' Snare Rifle"
+      ]
     },
     {
       "front": {
@@ -62140,7 +62762,10 @@
         "The limit of +3 is only a limit on how much Pryde can add, not other cards."
       ],
       "set": "212",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Pryde"
+      ]
     },
     {
       "abbr": [
@@ -62191,7 +62816,11 @@
       ],
       "rarity": "R",
       "set": "212",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Aurra",
+        "Aurra Sing's Blaster Rifle"
+      ]
     },
     {
       "abbr": [
@@ -62240,7 +62869,11 @@
       ],
       "rarity": "R",
       "set": "212",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Aurra",
+        "Aurra Sing's Blaster Rifle"
+      ]
     },
     {
       "abbr": [
@@ -62292,7 +62925,11 @@
       ],
       "rarity": "PM",
       "set": "212",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Aurra",
+        "Aurra Sing's Blaster Rifle"
+      ]
     },
     {
       "front": {
@@ -62340,7 +62977,10 @@
         "May deploy Sergeant Narthax With E-web Blaster (deploys -2)."
       ],
       "set": "212",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Gideon"
+      ]
     },
     {
       "front": {
@@ -62496,7 +63136,10 @@
       ],
       "rarity": "R1",
       "set": "213",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Ozzel"
+      ]
     },
     {
       "front": {
@@ -62548,7 +63191,10 @@
         "Immunity to attrition is determined only at the start of the Damage Segment and does not change if Qi'ra is subsequently forfeited."
       ],
       "set": "213",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Vos"
+      ]
     },
     {
       "front": {
@@ -62711,7 +63357,10 @@
         "'Immune to Sorry About The Mess' prevents the control phase firing function and prevents the place in Lost Pile function of the combo card. It does not prevent the 3 being added to weapon destiny function of the combo card."
       ],
       "set": "213",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Dooku"
+      ]
     },
     {
       "front": {
@@ -62866,7 +63515,10 @@
       ],
       "rarity": "C",
       "set": "213",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Margo"
+      ]
     },
     {
       "front": {
@@ -62907,7 +63559,10 @@
       ],
       "rarity": "C",
       "set": "213",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Seventh Sister"
+      ]
     },
     {
       "front": {
@@ -62959,7 +63614,10 @@
         "However, if Maul does happen to be at the battle location, then he must be participating in the battle (not excluded) in order to add or subtract 1."
       ],
       "set": "213",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Maul"
+      ]
     },
     {
       "front": {
@@ -63348,7 +64006,10 @@
       ],
       "rarity": "U",
       "set": "213",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Executor"
+      ]
     },
     {
       "front": {
@@ -63381,7 +64042,10 @@
       ],
       "rarity": "U2",
       "set": "213",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "First Light"
+      ]
     },
     {
       "front": {
@@ -63414,7 +64078,10 @@
       ],
       "rarity": "U2",
       "set": "213",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "First Light"
+      ]
     },
     {
       "front": {
@@ -63447,7 +64114,10 @@
       ],
       "rarity": "U2",
       "set": "213",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "First Light"
+      ]
     },
     {
       "front": {
@@ -63748,7 +64418,10 @@
         "When Khurgee reveals a card to cause Light to lose 1 Force, Light may choose to lose the revealed card."
       ],
       "set": "301",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Khurgee"
+      ]
     },
     {
       "front": {
@@ -63793,7 +64466,10 @@
         "To cause Force loss, the character must be placed out of play from the Lost Pile, or from an active or inactive state on the table."
       ],
       "set": "214",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Ochi"
+      ]
     },
     {
       "abbr": [
@@ -63843,7 +64519,10 @@
         "A Light Side Force icon could be added to the same location as Palpatine, Emperor Returned (e.g. due to Presence Of The Force). This does not violate Palpatine's text or cause him to be removed from table."
       ],
       "set": "214",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Sidious"
+      ]
     },
     {
       "front": {
@@ -64100,7 +64779,10 @@
       ],
       "rarity": "C2",
       "set": "214",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Bestoon Legacy"
+      ]
     },
     {
       "front": {
@@ -64181,7 +64863,10 @@
       ],
       "rarity": "C",
       "set": "214",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Steadfast"
+      ]
     },
     {
       "front": {
@@ -64275,7 +64960,10 @@
         "Does not cause an already attached starfighter to detach."
       ],
       "set": "215",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Piett"
+      ]
     },
     {
       "front": {
@@ -64358,7 +65046,10 @@
         "Only prevents characters being removed from lost pile while they are in a 'just lost' state."
       ],
       "set": "215",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Dannik Jerriko"
+      ]
     },
     {
       "abbr": [
@@ -64445,7 +65136,10 @@
         "Rukh peeks at the top 2 cards - he does not enable each of your assassins and leaders there to peek."
       ],
       "set": "215",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Rukh"
+      ]
     },
     {
       "front": {
@@ -64788,7 +65482,10 @@
         "Even if persona replacing a Vader whose gametext is already being canceled by Amidala, this card's game text will not be canceled by Amidala."
       ],
       "set": "216",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Vader"
+      ]
     },
     {
       "abbr": [
@@ -65531,7 +66228,10 @@
         "Immune to Under Attack and attrition < 4 does not require Veers piloting (but does require Blizzard 1 be piloted)."
       ],
       "set": "217",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Blizzard 1"
+      ]
     },
     {
       "front": {
@@ -65992,7 +66692,10 @@
         "The phrase 'on Cloud City' means at a Cloud City site, not the Bespin: Cloud City sector."
       ],
       "set": "217",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Lando"
+      ]
     },
     {
       "abbr": [
@@ -66225,7 +66928,10 @@
         "Doubles X on Secret Plans means (for example) to retrieve 2 Force, Light must use 4 Force (instead of 2)."
       ],
       "set": "217",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Qi'ra"
+      ]
     },
     {
       "abbr": [
@@ -66363,7 +67069,10 @@
         "If a destiny draw cannot be modified (e.g. I Don't Like Sand) then this card does not modify its own destiny value, and is destiny 0."
       ],
       "set": "217",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Sidious' Lightsaber"
+      ]
     },
     {
       "abbr": [
@@ -67063,7 +67772,10 @@
         "If General Leia Organa is currently suspending WIAPN, and then Dark uses Alert My Star Destroyer (V) to deploy Chimaera (V) with Thrawn aboard simultaneously, the discount from WIAPN is not applied (Dark pays the deploy cost first, before WIAPN gets un-suspended)."
       ],
       "set": "219",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Chimaera"
+      ]
     },
     {
       "abbr": [
@@ -67107,7 +67819,10 @@
         "If a [Presence] droid attempts to fire its permanent weapon and the firing is canceled, then the weapon did not fire, so Dofine gives +1 to total battle destiny."
       ],
       "set": "219",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Dofine"
+      ]
     },
     {
       "abbr": [
@@ -67181,7 +67896,10 @@
       ],
       "rarity": "U",
       "set": "219",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Vanto"
+      ]
     },
     {
       "abbr": [
@@ -67222,7 +67940,10 @@
       ],
       "rarity": "U1",
       "set": "219",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Fennec Shand"
+      ]
     },
     {
       "abbr": [
@@ -67262,7 +67983,10 @@
         "If Pryce is with (for example) Emperor Palpatine and Dark is facing 5 attrition (so Pryce is not immune), Dark must satisfy the attrition, but cannot forfeit Pryce; therefore Dark must forfeit Emperor Palpatine in this scenario."
       ],
       "set": "219",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Pryce"
+      ]
     },
     {
       "abbr": [
@@ -67711,7 +68435,10 @@
         "Total battle destiny +1 only applies while Agents Of Black Sun is on its 0-side."
       ],
       "set": "219",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Sidious"
+      ]
     },
     {
       "abbr": [
@@ -67979,7 +68706,10 @@
       ],
       "rarity": "PM",
       "set": "219",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Vader"
+      ]
     },
     {
       "abbr": [
@@ -68014,7 +68744,10 @@
         "If targeting Obi-Wan Kenobi, Padawan Learner, both the -1 and the +1 are applied (effectively canceling out)."
       ],
       "set": "219",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Vader's Lightsaber"
+      ]
     },
     {
       "front": {
@@ -68092,7 +68825,10 @@
       ],
       "rarity": "PM",
       "set": "207",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Thrawn"
+      ]
     },
     {
       "abbr": [
@@ -68136,7 +68872,10 @@
         "The phrase 'may activate 1 Force' means Dark may activate, not the opponent."
       ],
       "set": "220",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Bib Fortuna"
+      ]
     },
     {
       "front": {
@@ -68314,7 +69053,10 @@
         "Canceled weapon destiny draws do not count. For a weapon destiny that is canceled and redrawn, count only the redraw."
       ],
       "set": "220",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Zuckuss"
+      ]
     },
     {
       "combo": [
@@ -68368,7 +69110,11 @@
         "This weapon is not a blaster."
       ],
       "set": "200",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "4-LOM",
+        "4-LOM's Concussion Rifle"
+      ]
     },
     {
       "front": {
@@ -68522,7 +69268,10 @@
         "When using this text, treat all instances of the word 'Emperor' on Force Lightning as 'Dooku' instead."
       ],
       "set": "200",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Dooku"
+      ]
     },
     {
       "cancels": [
@@ -68583,7 +69332,10 @@
         "Cancels game text of any version of the Amidala persona, including Padme."
       ],
       "set": "203",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Maul"
+      ]
     },
     {
       "abbr": [
@@ -68648,7 +69400,10 @@
         "Cancels game text of any version of the Amidala persona, including Padme."
       ],
       "set": "203",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Maul"
+      ]
     },
     {
       "abbr": [
@@ -68711,7 +69466,10 @@
         "Cancels game text of any version of the Amidala persona, including Padme."
       ],
       "set": "203",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Maul"
+      ]
     },
     {
       "front": {
@@ -68752,7 +69510,10 @@
       ],
       "rarity": "U",
       "set": "200",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Dooku's Lightsaber"
+      ]
     },
     {
       "abbr": [
@@ -68848,7 +69609,11 @@
       ],
       "rarity": "R",
       "set": "221",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Vader's Personal Shuttle",
+        "Jendon"
+      ]
     },
     {
       "abbr": [
@@ -68954,7 +69719,10 @@
       ],
       "rarity": "U1",
       "set": "221",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Ventress"
+      ]
     },
     {
       "abbr": [
@@ -68989,7 +69757,10 @@
       ],
       "rarity": "C",
       "set": "221",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Asajj's Lightsabers"
+      ]
     },
     {
       "abbr": [
@@ -69109,7 +69880,10 @@
       ],
       "rarity": "U2",
       "set": "221",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Praji"
+      ]
     },
     {
       "abbr": [
@@ -69376,7 +70150,10 @@
       ],
       "rarity": "R1",
       "set": "221",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "First Light"
+      ]
     },
     {
       "abbr": [
@@ -70174,7 +70951,12 @@
       ],
       "rarity": "R",
       "set": "221",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Mist Hunter",
+        "Zuckuss",
+        "4-LOM"
+      ]
     },
     {
       "abbr": [
@@ -70374,7 +71156,11 @@
       ],
       "rarity": "PM",
       "set": "222",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Boba Fett",
+        "Boba Fett's Blaster Rifle"
+      ]
     },
     {
       "abbr": [
@@ -70560,7 +71346,10 @@
       ],
       "rarity": "U1",
       "set": "222",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Kylo"
+      ]
     },
     {
       "abbr": [
@@ -70601,7 +71390,10 @@
       ],
       "rarity": "C",
       "set": "222",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Kuruk"
+      ]
     },
     {
       "abbr": [
@@ -70643,7 +71435,10 @@
       ],
       "rarity": "C",
       "set": "222",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Sidious"
+      ]
     },
     {
       "abbr": [
@@ -71025,7 +71820,10 @@
         "'Immune to Sorry About The Mess' prevents the control phase firing function and prevents the place in Lost Pile function of the combo card. It does not prevent the 3 being added to weapon destiny function of the combo card."
       ],
       "set": "208",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Vader"
+      ]
     },
     {
       "front": {
@@ -71068,7 +71866,10 @@
       ],
       "rarity": "U",
       "set": "207",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Krennic"
+      ]
     },
     {
       "front": {
@@ -71233,7 +72034,10 @@
         "A Light Side Force icon could be added to the same location as Palpatine, Emperor Returned (e.g. due to Presence Of The Force). This does not violate Palpatine's text or cause him to be removed from table."
       ],
       "set": "214",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Sidious"
+      ]
     },
     {
       "front": {
@@ -71272,7 +72076,10 @@
       ],
       "rarity": "C",
       "set": "214",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Steadfast"
+      ]
     },
     {
       "abbr": [
@@ -71317,7 +72124,10 @@
       ],
       "rarity": "C",
       "set": "210",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "The Grand Inquisitor"
+      ]
     },
     {
       "front": {
@@ -71360,7 +72170,10 @@
         "A card with 'Vader' in title can be plural or possessive (e.g. Vader's Cape or Vader's Castle is allowed) but not part of a larger word (e.g. Evader is not allowed)."
       ],
       "set": "209",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Vanee"
+      ]
     },
     {
       "abbr": [
@@ -71416,7 +72229,10 @@
         "However, if Maul does happen to be at the battle location, then he must be participating in the battle (not excluded) in order to add or subtract 1."
       ],
       "set": "213",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Maul"
+      ]
     },
     {
       "abbr": [
@@ -71503,7 +72319,10 @@
         "If there are two battles here in the same turn (e.g. via Counterattack), players may fire one weapon in each battle (does not have to be the same weapon)."
       ],
       "set": "223",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Wuher"
+      ]
     },
     {
       "abbr": [
@@ -71562,7 +72381,11 @@
       ],
       "rarity": "U",
       "set": "223",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Zuckuss",
+        "Zuckuss' Snare Rifle"
+      ]
     },
     {
       "abbr": [
@@ -71783,7 +72606,10 @@
       ],
       "rarity": "PM",
       "set": "223",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Vanto"
+      ]
     },
     {
       "abbr": [
@@ -71945,7 +72771,10 @@
       ],
       "rarity": "R",
       "set": "223",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Lobot"
+      ]
     },
     {
       "abbr": [
@@ -71986,7 +72815,11 @@
       ],
       "rarity": "U",
       "set": "223",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Maul's Sith Infiltrator",
+        "Maul"
+      ]
     },
     {
       "abbr": [
@@ -72028,7 +72861,10 @@
       ],
       "rarity": "C",
       "set": "223",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Gideon"
+      ]
     },
     {
       "abbr": [
@@ -72768,7 +73604,10 @@
         "If General Leia Organa is currently suspending WIAPN, and then Dark uses Alert My Star Destroyer (V) to deploy Chimaera (V) with Thrawn aboard simultaneously, the discount from WIAPN is not applied (Dark pays the deploy cost first, before WIAPN gets un-suspended)."
       ],
       "set": "219",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Chimaera"
+      ]
     },
     {
       "counterpart": "Coruscant",
@@ -72947,7 +73786,10 @@
         "'Immune to Sorry About The Mess' prevents the control phase firing function and prevents the place in Lost Pile function of the combo card. It does not prevent the 3 being added to weapon destiny function of the combo card."
       ],
       "set": "213",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Dooku"
+      ]
     },
     {
       "front": {
@@ -73008,7 +73850,10 @@
         "Even if persona replacing a Vader whose gametext is already being canceled by Amidala, this card's game text will not be canceled by Amidala."
       ],
       "set": "216",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Vader"
+      ]
     },
     {
       "abbr": [
@@ -73232,7 +74077,10 @@
         "The last sentence means that I Must Be Allowed To Speak (V) will not take a card into hand for characters deploying here."
       ],
       "set": "225",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Bib Fortuna"
+      ]
     },
     {
       "abbr": [
@@ -73581,7 +74429,10 @@
         "The phrase 'two characters' means 'at least two characters'."
       ],
       "set": "225",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Baylan"
+      ]
     },
     {
       "abbr": [
@@ -73669,7 +74520,10 @@
         "Works with any [Episode VII] objective, including the opponent's."
       ],
       "set": "225",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Arm Cannon"
+      ]
     },
     {
       "front": {
@@ -73813,7 +74667,10 @@
       ],
       "rarity": "R1",
       "set": "225",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "DS-61-3"
+      ]
     },
     {
       "abbr": [
@@ -73991,7 +74848,10 @@
         "Dark's 'apprentice' is defined on Revenge Of The Sith."
       ],
       "set": "225",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Sidious"
+      ]
     },
     {
       "abbr": [
@@ -74170,7 +75030,10 @@
         "If Snoke aboard and Supremacy also with Tracked Fleet, the greater immunity is used."
       ],
       "set": "225",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Supremacy"
+      ]
     },
     {
       "abbr": [
@@ -74210,7 +75073,10 @@
         "The piloted [Resistance] starship can be at any system."
       ],
       "set": "225",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Supremacy"
+      ]
     },
     {
       "abbr": [
@@ -74250,7 +75116,10 @@
         "The attrition +1 requires Snoke to be participating in the battle and Rey to not be participating in the battle (or not be there at all)."
       ],
       "set": "225",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Supremacy"
+      ]
     },
     {
       "abbr": [
@@ -74700,7 +75569,10 @@
         "Prevents playing None Shall Pass."
       ],
       "set": "226",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Garindan"
+      ]
     },
     {
       "front": {
@@ -74907,7 +75779,10 @@
         "Even without Revenge Of The Sith, Mara is your apprentice, e.g. works with Master Sidious."
       ],
       "set": "226",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Mara Jade"
+      ]
     },
     {
       "abbr": [
@@ -75313,7 +76188,10 @@
       ],
       "rarity": "PM",
       "set": "211",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Invisible Hand"
+      ]
     },
     {
       "front": {
@@ -75369,7 +76247,10 @@
       ],
       "rarity": "U",
       "set": "208",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Sidious"
+      ]
     },
     {
       "front": {
@@ -75420,7 +76301,10 @@
       ],
       "rarity": "R",
       "set": "200",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Maarek Stele"
+      ]
     },
     {
       "front": {
@@ -75501,7 +76385,10 @@
         "If targeting Obi-Wan Kenobi, Padawan Learner, both the -1 and the +1 are applied (effectively canceling out)."
       ],
       "set": "219",
-      "side": "Dark"
+      "side": "Dark",
+      "personas": [
+        "Vader's Lightsaber"
+      ]
     },
     {
       "front": {

--- a/Light.json
+++ b/Light.json
@@ -1175,6 +1175,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Admiral Ackbar (V)"
+      ],
+      "personas": [
+        "Ackbar"
       ]
     },
     {
@@ -1229,7 +1232,10 @@
       ],
       "rarity": "XR",
       "set": "203",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Ackbar"
+      ]
     },
     {
       "front": {
@@ -1731,7 +1737,10 @@
       ],
       "rarity": "C",
       "set": "211",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Ahsoka"
+      ]
     },
     {
       "abbr": [
@@ -1785,7 +1794,11 @@
         "Canceling the targeting of one character (e.g. Force Field) cancels the entire action."
       ],
       "set": "301",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Ahsoka",
+        "Ahsoka's Lightsabers"
+      ]
     },
     {
       "abbr": [
@@ -1839,7 +1852,11 @@
         "Canceling the targeting of one character (e.g. Force Field) cancels the entire action."
       ],
       "set": "301",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Ahsoka",
+        "Ahsoka's Lightsabers"
+      ]
     },
     {
       "combo": [
@@ -2680,7 +2697,10 @@
       ],
       "rarity": "C2",
       "set": "200",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Anakin"
+      ]
     },
     {
       "front": {
@@ -2722,7 +2742,10 @@
       ],
       "rarity": "C2",
       "set": "200",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Anakin"
+      ]
     },
     {
       "front": {
@@ -2801,6 +2824,9 @@
           "title": "Anakin's Lightsaber (V) (AI)",
           "cardId": 7373
         }
+      ],
+      "personas": [
+        "Anakin's Lightsaber"
       ]
     },
     {
@@ -2861,7 +2887,10 @@
       ],
       "rarity": "R1",
       "set": "210",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Anakin's Lightsaber"
+      ]
     },
     {
       "front": {
@@ -3757,6 +3786,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Artoo (V)"
+      ],
+      "personas": [
+        "R2-D2"
       ]
     },
     {
@@ -3826,7 +3858,11 @@
         "Canceling Artoo & Threepio's game text or excluding them from battle could result in a battle ending immediately (in cases where their game text is required for the battle to occur)."
       ],
       "set": "10",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "R2-D2",
+        "C-3PO"
+      ]
     },
     {
       "abbr": [
@@ -3883,7 +3919,10 @@
         "This card is <u>not</u> a maintenance droid (e.g. for Echo Base Garrison)."
       ],
       "set": "14",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "R2-D2"
+      ]
     },
     {
       "abbr": [
@@ -3921,7 +3960,10 @@
       ],
       "rarity": "R",
       "set": "14",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "R2-D2"
+      ]
     },
     {
       "front": {
@@ -4051,7 +4093,11 @@
         "Any Luke pilot character card is a matching pilot, including Luke cards with 5 or more ability."
       ],
       "set": "111",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Red 5",
+        "R2-D2"
+      ]
     },
     {
       "canceledBy": [
@@ -5240,7 +5286,11 @@
         "May fire during battle and then fire again when about to be lost from that same battle (whether being lost during the weapons segment, forfeited during the damage segment, or at any other time)."
       ],
       "set": "207",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Baze",
+        "Baze's Cannon"
+      ]
     },
     {
       "front": {
@@ -5293,7 +5343,10 @@
         "BB-8 may be placed in Used Pile even if there are no Undercover spies there."
       ],
       "set": "204",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "BB-8"
+      ]
     },
     {
       "front": {
@@ -5333,7 +5386,11 @@
       ],
       "rarity": "U",
       "set": "211",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Black 1",
+        "BB-8"
+      ]
     },
     {
       "canceledBy": [
@@ -5563,7 +5620,10 @@
         "The revived character could even battle again this turn (e.g. by moving to another site with Nabrun Leids and battling there)."
       ],
       "set": "7",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Obi-Wan"
+      ]
     },
     {
       "front": {
@@ -6267,7 +6327,10 @@
         "If Blockade Flagship is 'blown away' (see Bravo Fighter), this site and all cards here are lost, and Blockade Flagship sites cannot be deployed for remainder of game."
       ],
       "set": "14",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Blockade Flagship"
+      ]
     },
     {
       "front": {
@@ -6302,7 +6365,10 @@
       ],
       "rarity": "R",
       "set": "209",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Blue 11"
+      ]
     },
     {
       "cancels": [
@@ -6376,7 +6442,10 @@
         "Canceling a Force drain is an optional response, occurring after automatic responses such as Restore Freedom To The Galaxy."
       ],
       "set": "210",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Blue Squadron 1"
+      ]
     },
     {
       "front": {
@@ -6764,7 +6833,11 @@
       ],
       "rarity": "PM",
       "set": "200",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Pulsar Skate",
+        "Booster"
+      ]
     },
     {
       "front": {
@@ -6806,6 +6879,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "BoShek, Gritty Smuggler"
+      ],
+      "personas": [
+        "BoShek"
       ]
     },
     {
@@ -6853,7 +6929,10 @@
         "Both of BoShek's actions (subtracing 1 or canceling an attempt) cost 1 Force to use, and BoShek may only use one of them once per battle, not once each."
       ],
       "set": "210",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "BoShek"
+      ]
     },
     {
       "front": {
@@ -7128,6 +7207,9 @@
           "title": "Boushh (V)",
           "cardId": 7320
         }
+      ],
+      "personas": [
+        "Leia"
       ]
     },
     {
@@ -7769,6 +7851,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "C-3PO (See-Threepio) (V)"
+      ],
+      "personas": [
+        "C-3PO"
       ]
     },
     {
@@ -7813,7 +7898,10 @@
       ],
       "rarity": "R1",
       "set": "208",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Chopper"
+      ]
     },
     {
       "front": {
@@ -7856,6 +7944,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Cal Alder (V)"
+      ],
+      "personas": [
+        "Cal"
       ]
     },
     {
@@ -7896,7 +7987,10 @@
       ],
       "rarity": "U2",
       "set": "206",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Cal"
+      ]
     },
     {
       "front": {
@@ -8086,7 +8180,10 @@
       ],
       "rarity": "C2",
       "set": "206",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Cassian"
+      ]
     },
     {
       "combo": [
@@ -8154,6 +8251,9 @@
           "title": "Captain Han Solo (V)",
           "cardId": 7422
         }
+      ],
+      "personas": [
+        "Han"
       ]
     },
     {
@@ -8296,7 +8396,10 @@
       ],
       "rarity": "R",
       "set": "12",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Madakor"
+      ]
     },
     {
       "combo": [
@@ -8345,7 +8448,10 @@
       ],
       "rarity": "R",
       "set": "12",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Panaka"
+      ]
     },
     {
       "front": {
@@ -8652,7 +8758,10 @@
       ],
       "rarity": "U",
       "set": "8",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Yutani"
+      ]
     },
     {
       "abbr": [
@@ -8698,7 +8807,10 @@
       ],
       "rarity": "C1",
       "set": "200",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Yutani"
+      ]
     },
     {
       "cancels": [
@@ -8907,7 +9019,10 @@
         "If the destiny is not a whole number (e.g. Brainiac), it is neither even nor odd, so Odd Ball may not add or subtract 1."
       ],
       "set": "208",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Odd ball"
+      ]
     },
     {
       "canceledBy": [
@@ -9143,6 +9258,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Chewbacca (V)"
+      ],
+      "personas": [
+        "Chewie"
       ]
     },
     {
@@ -9200,6 +9318,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Chewbacca, Defender Of Kashyyyk"
+      ],
+      "personas": [
+        "Chewie"
       ]
     },
     {
@@ -9255,7 +9376,10 @@
         "If Leia is inactive (such as being an imprisoned or an escorted captive) then Chewie won't deploy -3."
       ],
       "set": "10",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Chewie"
+      ]
     },
     {
       "combo": [
@@ -9297,7 +9421,10 @@
       ],
       "rarity": "R",
       "set": "8",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Chewbacca's Bowcaster"
+      ]
     },
     {
       "abbr": [
@@ -9334,6 +9461,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Chewie (V)"
+      ],
+      "personas": [
+        "Chewie"
       ]
     },
     {
@@ -9391,7 +9521,10 @@
       ],
       "rarity": "PM",
       "set": "200",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Chewie"
+      ]
     },
     {
       "abbr": [
@@ -9455,6 +9588,9 @@
           "title": "Chewie With Bowcaster (AI)",
           "cardId": 7140
         }
+      ],
+      "personas": [
+        "Chewie"
       ]
     },
     {
@@ -9511,7 +9647,11 @@
       ],
       "rarity": "PM",
       "set": "204",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Chewie",
+        "Chewbacca's Bowcaster"
+      ]
     },
     {
       "abbr": [
@@ -9566,7 +9706,10 @@
       ],
       "rarity": "PM",
       "set": "13",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Chewie"
+      ]
     },
     {
       "combo": [
@@ -11063,6 +11206,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "General Airen Cracken"
+      ],
+      "personas": [
+        "Cracken"
       ]
     },
     {
@@ -11422,6 +11568,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Commander Luke Skywalker (V)"
+      ],
+      "personas": [
+        "Luke"
       ]
     },
     {
@@ -11506,7 +11655,10 @@
       ],
       "rarity": "R1",
       "set": "200",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Luke"
+      ]
     },
     {
       "front": {
@@ -11588,7 +11740,10 @@
       ],
       "rarity": "U",
       "set": "209",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Melshi"
+      ]
     },
     {
       "cancels": [
@@ -11736,6 +11891,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Commander Wedge Antilles (V)"
+      ],
+      "personas": [
+        "Wedge"
       ]
     },
     {
@@ -11792,7 +11950,10 @@
         "May cancel any opponent's battle destiny except the first one. This works even if the first destiny was substituted (e.g. by Watch Your Back!)."
       ],
       "set": "205",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Wedge"
+      ]
     },
     {
       "front": {
@@ -12665,7 +12826,10 @@
       ],
       "rarity": "U",
       "set": "8",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Janse"
+      ]
     },
     {
       "combo": [
@@ -12705,7 +12869,10 @@
       ],
       "rarity": "R",
       "set": "8",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Kensaric"
+      ]
     },
     {
       "combo": [
@@ -12876,6 +13043,9 @@
           "title": "Corran Horn, Jedi",
           "cardId": 7323
         }
+      ],
+      "personas": [
+        "Corran Horn"
       ]
     },
     {
@@ -12920,7 +13090,10 @@
         "This card does not inherit any game text or attributes from the Corran Horn character card (e.g. the pilot is not a spy)."
       ],
       "set": "202",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Corran Horn"
+      ]
     },
     {
       "counterpart": "Corulag",
@@ -13880,7 +14053,10 @@
       ],
       "rarity": "R2",
       "set": "3",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Dack Ralter"
+      ]
     },
     {
       "counterpart": "Dagobah",
@@ -14476,7 +14652,10 @@
         "Dash is a matching pilot, so this vehicle is immune to attrition < 6 with Echo Base Garrison."
       ],
       "set": "201",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Dash"
+      ]
     },
     {
       "combo": [
@@ -14529,6 +14708,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Dash Rendar (V)"
+      ],
+      "personas": [
+        "Dash"
       ]
     },
     {
@@ -14576,7 +14758,10 @@
         "Dash's action subtracts from attrition against his owner (Light)."
       ],
       "set": "210",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Dash"
+      ]
     },
     {
       "abbr": [
@@ -14650,6 +14835,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Daughter Of Skywalker (V)"
+      ],
+      "personas": [
+        "Leia"
       ]
     },
     {
@@ -14712,7 +14900,10 @@
         "'Immune to Sniper' prevents the control phase sniping function and prevents the place in Lost Pile function of the combo card. It does not prevent the 3 being added to weapon destiny function of the combo card."
       ],
       "set": "200",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Leia"
+      ]
     },
     {
       "combo": [
@@ -16129,7 +16320,10 @@
         "Also increases any special requirements such as on A Jedi's Strength."
       ],
       "set": "2",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Doikk Na'ts"
+      ]
     },
     {
       "abbr": [
@@ -17043,6 +17237,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Dutch (V)"
+      ],
+      "personas": [
+        "Dutch"
       ]
     },
     {
@@ -17077,7 +17274,10 @@
       ],
       "rarity": "R1",
       "set": "210",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Dutch"
+      ]
     },
     {
       "front": {
@@ -19526,7 +19726,10 @@
         "To determine power bonus, count up all cards that are either Dark Jedi or Jedi (e.g. if there are 2 Dark Jedi and 1 Jedi, then Ezra Bridger is power +3)."
       ],
       "set": "210",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Ezra"
+      ]
     },
     {
       "counterpart": "Forced Servitude",
@@ -19849,7 +20052,10 @@
       ],
       "rarity": "U2",
       "set": "1",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Figrin D'an"
+      ]
     },
     {
       "front": {
@@ -19901,7 +20107,10 @@
         "May even deploy as a 'react' to same location as Light's permanent pilot such as on a vehicle or starship (even a landed starship)."
       ],
       "set": "204",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Finn"
+      ]
     },
     {
       "cancels": [
@@ -20965,7 +21174,10 @@
         "If with [Tatooine] Darth Maul, setting Light's total ability = 0, Light would still check all their individual cards with ability there and if they are all scouts and/or spies, Cracken's text would still work."
       ],
       "set": "200",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Cracken"
+      ]
     },
     {
       "front": {
@@ -21020,7 +21232,10 @@
       ],
       "rarity": "R",
       "set": "9",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Lando"
+      ]
     },
     {
       "cancels": [
@@ -21355,7 +21570,10 @@
       ],
       "rarity": "R",
       "set": "14",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Jar Jar"
+      ]
     },
     {
       "front": {
@@ -21390,7 +21608,10 @@
       ],
       "rarity": "R",
       "set": "14",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Jar Jar"
+      ]
     },
     {
       "abbr": [
@@ -21444,7 +21665,10 @@
         "The 'during battle' sentence is once per battle."
       ],
       "set": "209",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Obi-Wan"
+      ]
     },
     {
       "front": {
@@ -21495,7 +21719,10 @@
         "The 'during battle' sentence is once per battle."
       ],
       "set": "209",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Obi-Wan"
+      ]
     },
     {
       "front": {
@@ -21546,7 +21773,10 @@
       ],
       "rarity": "R",
       "set": "207",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Leia"
+      ]
     },
     {
       "combo": [
@@ -21593,7 +21823,10 @@
         "Also increases any special requirements such as on A Jedi's Strength."
       ],
       "set": "7",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "McQuarrie"
+      ]
     },
     {
       "combo": [
@@ -21658,6 +21891,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "General Solo (V)"
+      ],
+      "personas": [
+        "Han"
       ]
     },
     {
@@ -21727,7 +21963,10 @@
       ],
       "rarity": "R",
       "set": "200",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Han"
+      ]
     },
     {
       "combo": [
@@ -22181,7 +22420,10 @@
       ],
       "rarity": "R2",
       "set": "1",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Gold 1"
+      ]
     },
     {
       "front": {
@@ -22449,6 +22691,10 @@
       "side": "Light",
       "underlyingCardFor": [
         "Gold Leader In Gold 1 (V)"
+      ],
+      "personas": [
+        "Gold 1",
+        "Dutch"
       ]
     },
     {
@@ -22503,7 +22749,11 @@
         "<b>In brief, how can I avoid paying?!</b> The <u>only</u> way to avoid paying is to have 0 Force remaining while using 'draw x battle destiny if unable to otherwise' text."
       ],
       "set": "200",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Gold 1",
+        "Dutch"
+      ]
     },
     {
       "abbr": [
@@ -22573,6 +22823,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "The Falcon"
+      ],
+      "personas": [
+        "Falcon"
       ]
     },
     {
@@ -23085,7 +23338,10 @@
       ],
       "rarity": "R",
       "set": "9",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Green Leader"
+      ]
     },
     {
       "abbr": [
@@ -23132,7 +23388,11 @@
         "The permanent pilot <u>is</u> the same persona as the character card Green Leader, so both cannot be on table at same time."
       ],
       "set": "201",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Green Squadron 1",
+        "Green Leader"
+      ]
     },
     {
       "abbr": [
@@ -23179,7 +23439,11 @@
         "The permanent pilot <u>is</u> the same persona as the character card Green Leader, so both cannot be on table at same time."
       ],
       "set": "201",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Green Squadron 1",
+        "Green Leader"
+      ]
     },
     {
       "combo": [
@@ -23224,7 +23488,10 @@
       ],
       "rarity": "R",
       "set": "9",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Green Squadron 1"
+      ]
     },
     {
       "combo": [
@@ -23272,6 +23539,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Tycho In Green Squadron 3"
+      ],
+      "personas": [
+        "Green Squadron 3"
       ]
     },
     {
@@ -23440,7 +23710,10 @@
       ],
       "rarity": "R",
       "set": "7",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Grondorn"
+      ]
     },
     {
       "front": {
@@ -23731,6 +24004,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Han (V)"
+      ],
+      "personas": [
+        "Han"
       ]
     },
     {
@@ -23787,7 +24063,10 @@
       ],
       "rarity": "PM",
       "set": "200",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Han"
+      ]
     },
     {
       "cancels": [
@@ -23859,6 +24138,9 @@
           "title": "Han Solo (V)",
           "cardId": 7353
         }
+      ],
+      "personas": [
+        "Han"
       ]
     },
     {
@@ -23918,7 +24200,11 @@
       ],
       "rarity": "PM",
       "set": "108",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Han",
+        "Han's Heavy Blaster Pistol"
+      ]
     },
     {
       "abbr": [
@@ -23976,6 +24262,11 @@
       "side": "Light",
       "underlyingCardFor": [
         "Han, Chewie, And The Falcon (V)"
+      ],
+      "personas": [
+        "Falcon",
+        "Han",
+        "Chewie"
       ]
     },
     {
@@ -24037,7 +24328,12 @@
         "Cannot be taken into hand with Life Debt."
       ],
       "set": "205",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Falcon",
+        "Han",
+        "Chewie"
+      ]
     },
     {
       "canceledBy": [
@@ -24150,6 +24446,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Han's Heavy Blaster Pistol (V)"
+      ],
+      "personas": [
+        "Han's Heavy Blaster Pistol"
       ]
     },
     {
@@ -24205,7 +24504,10 @@
         "This weapon will not prevent Greedo (V) from deploying as a react. He deploys as a react, and then it will cancel his game text as soon as he arrives."
       ],
       "set": "200",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Han's Heavy Blaster Pistol"
+      ]
     },
     {
       "canceledBy": [
@@ -24918,7 +25220,10 @@
         "If game text is canceled, the asterisk is treated as an unmodifiable zero."
       ],
       "set": "2",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Het"
+      ]
     },
     {
       "abbr": [
@@ -25315,7 +25620,10 @@
       ],
       "rarity": "R",
       "set": "9",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Home One"
+      ]
     },
     {
       "front": {
@@ -25361,6 +25669,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Profundity: Docking Bay"
+      ],
+      "personas": [
+        "Home One"
       ]
     },
     {
@@ -25392,7 +25703,10 @@
       ],
       "rarity": "R",
       "set": "9",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Home One"
+      ]
     },
     {
       "abbr": [
@@ -26839,7 +27153,10 @@
       ],
       "rarity": "U2",
       "set": "2",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Ickabel G'ont"
+      ]
     },
     {
       "front": {
@@ -28712,6 +29029,9 @@
           "cardId": 7462,
           "title": "Kelleran Beq"
         }
+      ],
+      "personas": [
+        "Jar Jar"
       ]
     },
     {
@@ -29378,7 +29698,10 @@
       ],
       "rarity": "U",
       "set": "14",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Jerus"
+      ]
     },
     {
       "front": {
@@ -29528,7 +29851,10 @@
         "Text to 'draw one battle destiny if unable to otherwise' does not work while Jyn is Undercover."
       ],
       "set": "206",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Jyn Erso"
+      ]
     },
     {
       "front": {
@@ -29957,7 +30283,10 @@
       ],
       "rarity": "PM",
       "set": "203",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Kanan"
+      ]
     },
     {
       "conceptBy": "(Original concept by Jarad Konsker)",
@@ -29998,7 +30327,10 @@
       ],
       "rarity": "PM",
       "set": "203",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Kanan"
+      ]
     },
     {
       "combo": [
@@ -31316,6 +31648,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Lando Calrissian (V)"
+      ],
+      "personas": [
+        "Lando"
       ]
     },
     {
@@ -31386,7 +31721,10 @@
       ],
       "rarity": "R",
       "set": "201",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Lando"
+      ]
     },
     {
       "abbr": [
@@ -31438,7 +31776,10 @@
       ],
       "rarity": "PM",
       "set": "13",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Lando"
+      ]
     },
     {
       "front": {
@@ -31488,7 +31829,11 @@
       ],
       "rarity": "PM",
       "set": "109",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Falcon",
+        "Lando"
+      ]
     },
     {
       "abbr": [
@@ -31548,7 +31893,10 @@
         "The phrase 'on Cloud City' means at a Cloud City site, not the Bespin: Cloud City sector."
       ],
       "set": "109",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Lando"
+      ]
     },
     {
       "abbr": [
@@ -31613,7 +31961,10 @@
         "This card has only one Permanent Weapon icon (two such icons is a misprint)."
       ],
       "set": "112",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Lando"
+      ]
     },
     {
       "front": {
@@ -31653,7 +32004,10 @@
       ],
       "rarity": "R",
       "set": "7",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Lando's Blaster Rifle"
+      ]
     },
     {
       "abbr": [
@@ -31755,7 +32109,10 @@
       ],
       "rarity": "R",
       "set": "6",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Laudica"
+      ]
     },
     {
       "canceledBy": [
@@ -32014,6 +32371,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Leia (V)"
+      ],
+      "personas": [
+        "Leia"
       ]
     },
     {
@@ -32068,7 +32428,10 @@
       ],
       "rarity": "PM",
       "set": "200",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Leia"
+      ]
     },
     {
       "front": {
@@ -32199,6 +32562,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Leia Organa (V)"
+      ],
+      "personas": [
+        "Leia"
       ]
     },
     {
@@ -32245,7 +32611,10 @@
         "If she adds a destiny to total power or attrition, she can no longer draw one battle destiny if unable to otherwise that battle."
       ],
       "set": "202",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Leia"
+      ]
     },
     {
       "abbr": [
@@ -32305,7 +32674,11 @@
       ],
       "rarity": "PM",
       "set": "108",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Leia",
+        "Leia's Blaster Rifle"
+      ]
     },
     {
       "abbr": [
@@ -32372,7 +32745,10 @@
         "Second sentence - Due to her errata, opponent only needs a non-alien at the location (not necessarily present at the location) to avoid having total ability = 0."
       ],
       "set": "13",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Leia"
+      ]
     },
     {
       "front": {
@@ -32461,7 +32837,10 @@
       ],
       "rarity": "R",
       "set": "7",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Leia's Blaster Rifle"
+      ]
     },
     {
       "front": {
@@ -32865,7 +33244,10 @@
       ],
       "rarity": "U",
       "set": "211",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Libertine"
+      ]
     },
     {
       "front": {
@@ -32983,7 +33365,10 @@
       ],
       "rarity": "R",
       "set": "9",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Blount"
+      ]
     },
     {
       "front": {
@@ -33097,7 +33482,10 @@
       ],
       "rarity": "C1",
       "set": "209",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Connix"
+      ]
     },
     {
       "front": {
@@ -33783,6 +34171,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Lobot (V)"
+      ],
+      "personas": [
+        "Lobot"
       ]
     },
     {
@@ -33827,7 +34218,10 @@
         "Uniqueness rules prevent LS Lobot and DS Lobot (same card title) from being on table at the same time."
       ],
       "set": "200",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Lobot"
+      ]
     },
     {
       "front": {
@@ -34296,7 +34690,10 @@
       ],
       "rarity": "PM",
       "set": "101",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Luke"
+      ]
     },
     {
       "abbr": [
@@ -34357,6 +34754,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Luke Skywalker (V)"
+      ],
+      "personas": [
+        "Luke"
       ]
     },
     {
@@ -34419,7 +34819,10 @@
       ],
       "rarity": "R1",
       "set": "200",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Luke"
+      ]
     },
     {
       "abbr": [
@@ -34483,7 +34886,10 @@
         "This card even subtracts 3 from opponent's Epic Duel total involving Luke."
       ],
       "set": "9",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Luke"
+      ]
     },
     {
       "abbr": [
@@ -34553,6 +34959,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Luke Skywalker, Rebel Scout (V)"
+      ],
+      "personas": [
+        "Luke"
       ]
     },
     {
@@ -34616,7 +35025,10 @@
       ],
       "rarity": "PM",
       "set": "200",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Luke"
+      ]
     },
     {
       "abbr": [
@@ -34664,7 +35076,10 @@
         "May deploy (or persona replace) at a <u>system or sector</u> opponent occupies."
       ],
       "set": "210",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Luke"
+      ]
     },
     {
       "front": {
@@ -34719,7 +35134,10 @@
       ],
       "rarity": "U",
       "set": "208",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Luke"
+      ]
     },
     {
       "abbr": [
@@ -34781,7 +35199,11 @@
       ],
       "rarity": "PM",
       "set": "108",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Luke",
+        "Luke's Lightsaber"
+      ]
     },
     {
       "front": {
@@ -35186,7 +35608,10 @@
       ],
       "rarity": "R",
       "set": "9",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Luke's Lightsaber"
+      ]
     },
     {
       "front": {
@@ -35437,6 +35862,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Mace Windu (V)"
+      ],
+      "personas": [
+        "Mace"
       ]
     },
     {
@@ -35475,6 +35903,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Mace Windu (V) (AI)"
+      ],
+      "personas": [
+        "Mace"
       ]
     },
     {
@@ -35531,7 +35962,10 @@
         "When using Sorry About The Mess to swing during the control phase, Mace only swings once. If Mace then battles later that turn, he may still swing twice in that battle."
       ],
       "set": "201",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Mace"
+      ]
     },
     {
       "front": {
@@ -35574,7 +36008,10 @@
         "When using Sorry About The Mess to swing during the control phase, Mace only swings once. If Mace then battles later that turn, he may still swing twice in that battle."
       ],
       "set": "201",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Mace"
+      ]
     },
     {
       "abbr": [
@@ -35620,7 +36057,10 @@
         "When using Sorry About The Mess to swing during the control phase, Mace only swings once. If Mace then battles later that turn, he may still swing twice in that battle."
       ],
       "set": "201",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Mace"
+      ]
     },
     {
       "abbr": [
@@ -35664,7 +36104,10 @@
         "When using Sorry About The Mess to swing during the control phase, Mace only swings once. If Mace then battles later that turn, he may still swing twice in that battle."
       ],
       "set": "201",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Mace"
+      ]
     },
     {
       "cancels": [
@@ -35721,6 +36164,9 @@
           "title": "Mace Windu (V) (C-Slip AI)",
           "cardId": 7227
         }
+      ],
+      "personas": [
+        "Mace"
       ]
     },
     {
@@ -35762,6 +36208,9 @@
           "title": "Mace Windu (V) (C-Slip AI 2)",
           "cardId": 7230
         }
+      ],
+      "personas": [
+        "Mace"
       ]
     },
     {
@@ -36692,6 +37141,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Master Luke (V)"
+      ],
+      "personas": [
+        "Luke"
       ]
     },
     {
@@ -36738,6 +37190,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Master Qui-Gon (V)"
+      ],
+      "personas": [
+        "Qui-Gon"
       ]
     },
     {
@@ -36776,6 +37231,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Master Qui-Gon (V) (AI)"
+      ],
+      "personas": [
+        "Qui-Gon"
       ]
     },
     {
@@ -36834,7 +37292,10 @@
         "Example: Tatooine Occupation causes 3 Force loss. Master Qui-Gon (V) may respond once, not 3 times."
       ],
       "set": "200",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Qui-Gon"
+      ]
     },
     {
       "conceptBy": "(Original concept by James Booker - Worlds 2005)",
@@ -36875,7 +37336,10 @@
         "Example: Tatooine Occupation causes 3 Force loss. Master Qui-Gon (V) may respond once, not 3 times."
       ],
       "set": "200",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Qui-Gon"
+      ]
     },
     {
       "combo": [
@@ -36959,7 +37423,10 @@
         "If there are only 1 or 2 cards in Reserve Deck, Maz can still reveal them, but she cannot take an alien into hand."
       ],
       "set": "211",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Maz"
+      ]
     },
     {
       "front": {
@@ -37569,6 +38036,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Millennium Falcon (V)"
+      ],
+      "personas": [
+        "Falcon"
       ]
     },
     {
@@ -38172,6 +38642,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Senator Mon Mothma"
+      ],
+      "personas": [
+        "Mon Mothma"
       ]
     },
     {
@@ -39132,7 +39605,10 @@
       ],
       "rarity": "U2",
       "set": "2",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Nalan Cheel"
+      ]
     },
     {
       "conceptBy": "(Original concept by Jarad Konsker, New Jersey Mini Open 2011)",
@@ -39709,6 +40185,9 @@
           "cardId": 7256,
           "title": "Nien Nunb, Sullustan Smuggler"
         }
+      ],
+      "personas": [
+        "Nien Nunb"
       ]
     },
     {
@@ -40000,7 +40479,11 @@
         "The total battle destiny reset protection text works against Zuckuss In Mist Hunter."
       ],
       "set": "200",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Radiant VII",
+        "Madakor"
+      ]
     },
     {
       "combo": [
@@ -40055,6 +40538,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Obi-Wan Kenobi (V)"
+      ],
+      "personas": [
+        "Obi-Wan"
       ]
     },
     {
@@ -40117,7 +40603,10 @@
         "For example, if with Vader, Emperor, and Luke, then Obi-Wan Kenobi (V) is power +3."
       ],
       "set": "201",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Obi-Wan"
+      ]
     },
     {
       "abbr": [
@@ -40173,7 +40662,10 @@
         "'Immune to Sniper' prevents the control phase sniping function and prevents the place in Lost Pile function of the combo card. It does not prevent the 3 being added to weapon destiny function of the combo card."
       ],
       "set": "13",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Obi-Wan"
+      ]
     },
     {
       "combo": [
@@ -40226,6 +40718,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Obi-Wan Kenobi, Padawan Learner (V)"
+      ],
+      "personas": [
+        "Obi-Wan"
       ]
     },
     {
@@ -40264,6 +40759,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Obi-Wan Kenobi, Padawan Learner (V) (AI)"
+      ],
+      "personas": [
+        "Obi-Wan"
       ]
     },
     {
@@ -40310,7 +40808,10 @@
       ],
       "rarity": "R",
       "set": "200",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Obi-Wan"
+      ]
     },
     {
       "front": {
@@ -40346,7 +40847,10 @@
       ],
       "rarity": "R",
       "set": "200",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Obi-Wan"
+      ]
     },
     {
       "abbr": [
@@ -40400,7 +40904,11 @@
       ],
       "rarity": "PM",
       "set": "108",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Obi-Wan",
+        "Obi-Wan's Lightsaber"
+      ]
     },
     {
       "counterpart": "Image Of The Dark Lord",
@@ -40550,7 +41058,10 @@
       ],
       "rarity": "R1",
       "set": "1",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Obi-Wan's Lightsaber"
+      ]
     },
     {
       "front": {
@@ -40589,7 +41100,10 @@
       ],
       "rarity": "PM",
       "set": "13",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Obi-Wan's Lightsaber"
+      ]
     },
     {
       "counterpart": "Lana Dobreed",
@@ -40803,7 +41317,10 @@
         "Perosei's deploy phase relocation is an unlimited move. Perosei may make a regular move during the same turn."
       ],
       "set": "14",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Perosei"
+      ]
     },
     {
       "abbr": [
@@ -41951,6 +42468,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Padme Naberrie (V)"
+      ],
+      "personas": [
+        "Amidala"
       ]
     },
     {
@@ -41989,6 +42509,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Padme Naberrie (V) (AI)"
+      ],
+      "personas": [
+        "Amidala"
       ]
     },
     {
@@ -42042,7 +42565,10 @@
         "Cancels the +9 power from the game text of Death Star Assault Squadron. None of DSAS's other game text is affected."
       ],
       "set": "203",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Amidala"
+      ]
     },
     {
       "front": {
@@ -42078,7 +42604,10 @@
       ],
       "rarity": "R",
       "set": "203",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Amidala"
+      ]
     },
     {
       "front": {
@@ -42263,7 +42792,10 @@
       ],
       "rarity": "R",
       "set": "14",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Panaka"
+      ]
     },
     {
       "front": {
@@ -42298,7 +42830,10 @@
       ],
       "rarity": "R",
       "set": "14",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Panaka"
+      ]
     },
     {
       "combo": [
@@ -42423,6 +42958,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Paploo (V)"
+      ],
+      "personas": [
+        "Paploo"
       ]
     },
     {
@@ -42456,7 +42994,10 @@
       ],
       "rarity": "U",
       "set": "210",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Paploo"
+      ]
     },
     {
       "front": {
@@ -43027,6 +43568,9 @@
           "title": "Plo Koon (V) (AI)",
           "cardId": 7380
         }
+      ],
+      "personas": [
+        "Plo Koon"
       ]
     },
     {
@@ -43069,7 +43613,10 @@
       ],
       "rarity": "R",
       "set": "210",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Plo Koon"
+      ]
     },
     {
       "counterpart": "Start Your Engines!",
@@ -43154,7 +43701,10 @@
       ],
       "rarity": "U",
       "set": "204",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Poe Dameron"
+      ]
     },
     {
       "front": {
@@ -43553,6 +44103,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Princess Leia (V)"
+      ],
+      "personas": [
+        "Leia"
       ]
     },
     {
@@ -43616,7 +44169,10 @@
         "'Former member of the Imperial Senate' in lore makes her a senator."
       ],
       "set": "201",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Leia"
+      ]
     },
     {
       "combo": [
@@ -43671,7 +44227,10 @@
       ],
       "rarity": "R",
       "set": "6",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Leia"
+      ]
     },
     {
       "combo": [
@@ -43760,7 +44319,10 @@
       ],
       "rarity": "R",
       "set": "7",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Leia"
+      ]
     },
     {
       "front": {
@@ -43812,6 +44374,9 @@
       "underlyingCardFor": [
         "Prisoner 2187 (V)",
         "There Is Another"
+      ],
+      "personas": [
+        "Leia"
       ]
     },
     {
@@ -43855,7 +44420,10 @@
       ],
       "rarity": "U",
       "set": "207",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Profundity"
+      ]
     },
     {
       "front": {
@@ -43898,7 +44466,10 @@
       ],
       "rarity": "U",
       "set": "207",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Profundity"
+      ]
     },
     {
       "abbr": [
@@ -44210,6 +44781,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Booster In Pulsar Skate"
+      ],
+      "personas": [
+        "Pulsar Skate"
       ]
     },
     {
@@ -44405,7 +44979,10 @@
         "'Immune to Sniper' prevents the control phase sniping function and prevents the place in Lost Pile function of the combo card. It does not prevent the 3 being added to weapon destiny function of the combo card."
       ],
       "set": "14",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Amidala"
+      ]
     },
     {
       "front": {
@@ -44440,7 +45017,10 @@
       ],
       "rarity": "R",
       "set": "14",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Amidala"
+      ]
     },
     {
       "combo": [
@@ -44488,7 +45068,10 @@
       ],
       "rarity": "R",
       "set": "12",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Amidala"
+      ]
     },
     {
       "front": {
@@ -44521,7 +45104,10 @@
       ],
       "rarity": "R",
       "set": "12",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Amidala"
+      ]
     },
     {
       "front": {
@@ -44569,6 +45155,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Ric In Queen's Royal Starship"
+      ],
+      "personas": [
+        "Queen's Royal Starship"
       ]
     },
     {
@@ -44618,7 +45207,10 @@
       ],
       "rarity": "R",
       "set": "11",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Qui-Gon"
+      ]
     },
     {
       "front": {
@@ -44653,7 +45245,10 @@
       ],
       "rarity": "R",
       "set": "11",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Qui-Gon"
+      ]
     },
     {
       "abbr": [
@@ -44703,7 +45298,11 @@
       ],
       "rarity": "R",
       "set": "14",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Qui-Gon",
+        "Qui-Gon Jinn's Lightsaber"
+      ]
     },
     {
       "front": {
@@ -44752,7 +45351,10 @@
       ],
       "rarity": "PM",
       "set": "13",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Qui-Gon"
+      ]
     },
     {
       "front": {
@@ -44800,6 +45402,9 @@
           "title": "Qui-Gon Jinn's Lightsaber (V)",
           "cardId": 7217
         }
+      ],
+      "personas": [
+        "Qui-Gon Jinn's Lightsaber"
       ]
     },
     {
@@ -44833,6 +45438,9 @@
           "title": "Qui-Gon Jinn's Lightsaber (V) (AI)",
           "cardId": 7218
         }
+      ],
+      "personas": [
+        "Qui-Gon Jinn's Lightsaber"
       ]
     },
     {
@@ -44877,7 +45485,10 @@
       ],
       "rarity": "PM",
       "set": "13",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Qui-Gon Jinn's Lightsaber"
+      ]
     },
     {
       "front": {
@@ -45145,7 +45756,11 @@
         "Provided that their conditions are met, R2-D2 & C-3PO will relocate to the Dune Sea even if they are being affected by an 'all cards situation' such as Program Trap, Overwhelmed, etc."
       ],
       "set": "203",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "R2-D2",
+        "C-3PO"
+      ]
     },
     {
       "canceledBy": [
@@ -45206,6 +45821,9 @@
       "underlyingCardFor": [
         "R2-D2 (Artoo-Detoo) (V)",
         "R2-D2 (Artoo-Detoo) (V) (AI)"
+      ],
+      "personas": [
+        "R2-D2"
       ]
     },
     {
@@ -45269,7 +45887,10 @@
         "For R2-D2 (V) to use his 'subtract 1' action, the following conditions must be met: First, the battle must be at an interior site. Second, R2-D2 (V) must be at the same site or at a related site (not necessarily an interior one, but R2-D2 (V) must be at a site - not a system or sector)."
       ],
       "set": "201",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "R2-D2"
+      ]
     },
     {
       "front": {
@@ -45696,6 +46317,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Madakor In Radiant VII"
+      ],
+      "personas": [
+        "Radiant VII"
       ]
     },
     {
@@ -45993,7 +46617,10 @@
       ],
       "rarity": "R",
       "set": "6",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Rayc"
+      ]
     },
     {
       "front": {
@@ -46943,6 +47570,9 @@
       "underlyingCardFor": [
         "Red 1 (V)",
         "Red 12"
+      ],
+      "personas": [
+        "Red 1"
       ]
     },
     {
@@ -47003,7 +47633,10 @@
         "This <u>is not</u> the same starship persona as Red Squadron 1, so both could be on table at same time."
       ],
       "set": "200",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Red 1"
+      ]
     },
     {
       "combo": [
@@ -47110,7 +47743,10 @@
         "This <u>is</u> the same starship persona as Red Squadron 1, so both cannot be on table at same time."
       ],
       "set": "2",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Red 2"
+      ]
     },
     {
       "combo": [
@@ -47223,6 +47859,9 @@
       "underlyingCardFor": [
         "Corran Horn In Rogue 9",
         "Red 5 (V)"
+      ],
+      "personas": [
+        "Red 5"
       ]
     },
     {
@@ -47263,7 +47902,10 @@
       ],
       "rarity": "R1",
       "set": "209",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Red 5"
+      ]
     },
     {
       "combo": [
@@ -47553,7 +48195,10 @@
       ],
       "rarity": "R1",
       "set": "1",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Red Leader"
+      ]
     },
     {
       "abbr": [
@@ -47594,7 +48239,11 @@
         "The permanent pilot <u>is</u> the same persona as the character card Red Leader, so both cannot be on table at same time."
       ],
       "set": "103",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Red 1",
+        "Red Leader"
+      ]
     },
     {
       "abbr": [
@@ -47655,6 +48304,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Wedge In Red Squadron 1"
+      ],
+      "personas": [
+        "Red 2"
       ]
     },
     {
@@ -48749,7 +49401,10 @@
         "If Rey is at the Jakku system location, she is not 'on' Jakku."
       ],
       "set": "204",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Rey"
+      ]
     },
     {
       "front": {
@@ -48806,7 +49461,10 @@
         "If Rey is at the Jakku system location, she is not 'on' Jakku."
       ],
       "set": "204",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Rey"
+      ]
     },
     {
       "abbr": [
@@ -48858,7 +49516,11 @@
         "If something prevents the target from being hit (e.g. Theed Palace Generator Core) it also prevents retrieving 1 Force."
       ],
       "set": "209",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Rey",
+        "Anakin's Lightsaber"
+      ]
     },
     {
       "abbr": [
@@ -48910,7 +49572,11 @@
         "If something prevents the target from being hit (e.g. Theed Palace Generator Core) it also prevents retrieving 1 Force."
       ],
       "set": "209",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Rey",
+        "Anakin's Lightsaber"
+      ]
     },
     {
       "front": {
@@ -48950,7 +49616,11 @@
       ],
       "rarity": "R",
       "set": "205",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Queen's Royal Starship",
+        "Ric"
+      ]
     },
     {
       "combo": [
@@ -48996,7 +49666,10 @@
       ],
       "rarity": "R",
       "set": "12",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Ric"
+      ]
     },
     {
       "combo": [
@@ -49042,7 +49715,10 @@
       ],
       "rarity": "R",
       "set": "14",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Ric"
+      ]
     },
     {
       "front": {
@@ -49280,6 +49956,9 @@
           "title": "Zev In Rogue 2",
           "cardId": 7360
         }
+      ],
+      "personas": [
+        "Rogue 2"
       ]
     },
     {
@@ -49728,7 +50407,10 @@
         "Automatic 'about to be hit' actions (such as Theed Palace Generator Core) happen before optional ones (such as Rose Tico)."
       ],
       "set": "209",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Rose"
+      ]
     },
     {
       "front": {
@@ -50009,7 +50691,10 @@
       ],
       "rarity": "R",
       "set": "12",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Sabe"
+      ]
     },
     {
       "front": {
@@ -50056,7 +50741,10 @@
         "If firing a repeating weapon (e.g. BlasTech E-11B Blaster Rifle), only the first shot can be made free. The text can be used to add 2 to weapon destiny on a repeat firing instead, but it won't be free."
       ],
       "set": "207",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Sabine"
+      ]
     },
     {
       "canceledBy": [
@@ -50180,6 +50868,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Dorme"
+      ],
+      "personas": [
+        "Sache"
       ]
     },
     {
@@ -51116,6 +51807,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Kanan Jarrus"
+      ],
+      "personas": [
+        "C-3PO"
       ]
     },
     {
@@ -51353,7 +52047,10 @@
         "Her card title makes her a senator (as would 'former member of the Imperial Senate' in lore)."
       ],
       "set": "204",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Mon Mothma"
+      ]
     },
     {
       "combo": [
@@ -51394,7 +52091,10 @@
       ],
       "rarity": "R",
       "set": "12",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Sidious"
+      ]
     },
     {
       "front": {
@@ -51426,7 +52126,10 @@
       ],
       "rarity": "R",
       "set": "12",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Sidious"
+      ]
     },
     {
       "canceledBy": [
@@ -51706,7 +52409,10 @@
       ],
       "rarity": "R",
       "set": "6",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Doallyn"
+      ]
     },
     {
       "front": {
@@ -51823,7 +52529,10 @@
       ],
       "rarity": "U",
       "set": "8",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Junkin"
+      ]
     },
     {
       "combo": [
@@ -51906,7 +52615,10 @@
       ],
       "rarity": "U1",
       "set": "3",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Shawn"
+      ]
     },
     {
       "front": {
@@ -52616,7 +53328,10 @@
       ],
       "rarity": "R",
       "set": "204",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Han"
+      ]
     },
     {
       "canceledBy": [
@@ -52825,6 +53540,9 @@
           "title": "Son Of Skywalker (V)",
           "cardId": 7357
         }
+      ],
+      "personas": [
+        "Luke"
       ]
     },
     {
@@ -54710,7 +55428,10 @@
         "When counting spies out of play, two spies of the same title or same persona still count as two spies."
       ],
       "set": "209",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Sefla"
+      ]
     },
     {
       "combo": [
@@ -54993,7 +55714,10 @@
       ],
       "rarity": "U",
       "set": "211",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Tallie"
+      ]
     },
     {
       "front": {
@@ -55169,7 +55893,10 @@
       ],
       "rarity": "R",
       "set": "6",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Lando"
+      ]
     },
     {
       "front": {
@@ -55216,6 +55943,9 @@
       "underlyingCardFor": [
         "Tantive IV (V)",
         "Tantive IV (V) (AI)"
+      ],
+      "personas": [
+        "Tantive IV"
       ]
     },
     {
@@ -55258,7 +55988,10 @@
       ],
       "rarity": "R1",
       "set": "201",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Tantive IV"
+      ]
     },
     {
       "combo": [
@@ -56729,7 +57462,10 @@
       ],
       "rarity": "PM",
       "set": "102",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Tedn Dahai"
+      ]
     },
     {
       "front": {
@@ -56799,7 +57535,10 @@
       ],
       "rarity": "C2",
       "set": "208",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Snap Wexley"
+      ]
     },
     {
       "front": {
@@ -57125,7 +57864,10 @@
         "Versions of Han and Chewie without an Episode VII icon will not trigger the 'maneuver = 6' or 'immune to to attrition < 5' text, but they are still matching pilots (e.g. for Squadron Assignments)."
       ],
       "set": "206",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Falcon"
+      ]
     },
     {
       "abbr": [
@@ -57203,7 +57945,10 @@
         "Flipping from starship to vehicle causes attached Mynocks to detach."
       ],
       "set": "204",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Falcon"
+      ]
     },
     {
       "canceledBy": [
@@ -57860,7 +58605,10 @@
         "May serve as a Jawa Rep for Agents In The Court."
       ],
       "set": "7",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Thedit"
+      ]
     },
     {
       "front": {
@@ -58498,7 +59246,10 @@
       ],
       "rarity": "R",
       "set": "8",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "C-3PO"
+      ]
     },
     {
       "abbr": [
@@ -58550,7 +59301,10 @@
       ],
       "rarity": "R",
       "set": "11",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "C-3PO"
+      ]
     },
     {
       "abbr": [
@@ -58595,7 +59349,10 @@
       ],
       "rarity": "R",
       "set": "11",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "C-3PO"
+      ]
     },
     {
       "abbr": [
@@ -58903,7 +59660,10 @@
       ],
       "rarity": "U1",
       "set": "3",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Tigran"
+      ]
     },
     {
       "counterpart": "Timer Mine",
@@ -59030,6 +59790,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "TK-422 (V)"
+      ],
+      "personas": [
+        "Han"
       ]
     },
     {
@@ -59527,6 +60290,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Tycho Celchu (V)"
+      ],
+      "personas": [
+        "Tycho"
       ]
     },
     {
@@ -59569,7 +60335,10 @@
       ],
       "rarity": "R",
       "set": "205",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Tycho"
+      ]
     },
     {
       "front": {
@@ -59608,7 +60377,11 @@
       ],
       "rarity": "R",
       "set": "205",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Green Squadron 3",
+        "Tycho"
+      ]
     },
     {
       "combo": [
@@ -60380,7 +61153,10 @@
       ],
       "rarity": "R",
       "set": "6",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Vul"
+      ]
     },
     {
       "front": {
@@ -61042,6 +61818,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Wedge Antilles (V)"
+      ],
+      "personas": [
+        "Wedge"
       ]
     },
     {
@@ -61088,7 +61867,10 @@
       ],
       "rarity": "R1",
       "set": "202",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Wedge"
+      ]
     },
     {
       "abbr": [
@@ -61179,7 +61961,10 @@
         "Admiral Raddus/Boshek/Boshek(V) are not Red/Rogue Squadron pilots by default (despite what's printed on their card). They still become one while piloting a Red/Rogue card, just like any other pilot."
       ],
       "set": "9",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Wedge"
+      ]
     },
     {
       "front": {
@@ -61222,7 +62007,11 @@
       ],
       "rarity": "R",
       "set": "200",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Red 2",
+        "Wedge"
+      ]
     },
     {
       "cancels": [
@@ -61521,7 +62310,10 @@
       ],
       "rarity": "R2",
       "set": "3",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Wes Janson"
+      ]
     },
     {
       "combo": [
@@ -63618,6 +64410,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Yoda (V)"
+      ],
+      "personas": [
+        "Yoda"
       ]
     },
     {
@@ -63653,7 +64448,10 @@
       ],
       "rarity": "R",
       "set": "207",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Yoda"
+      ]
     },
     {
       "front": {
@@ -63759,7 +64557,10 @@
         "Preventing destiny draws from being modified can be circumvented with a substituted destiny that has been modified <u>before</u> the substitution (e.g. Darklighter Spin on a modified maneuver value, or a senator on Sando Aqua Monster that is already receiving a global modifier from the Senate Objective)."
       ],
       "set": "202",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Yoda"
+      ]
     },
     {
       "abbr": [
@@ -63812,7 +64613,10 @@
         "Preventing destiny draws from being modified can be circumvented with a substituted destiny that has been modified <u>before</u> the substitution (e.g. Darklighter Spin on a modified maneuver value, or a senator on Sando Aqua Monster that is already receiving a global modifier from the Senate Objective)."
       ],
       "set": "202",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Yoda"
+      ]
     },
     {
       "abbr": [
@@ -63863,7 +64667,10 @@
         "Preventing destiny draws from being modified can be circumvented with a substituted destiny that has been modified <u>before</u> the substitution (e.g. Darklighter Spin on a modified maneuver value, or a senator on Sando Aqua Monster that is already receiving a global modifier from the Senate Objective)."
       ],
       "set": "202",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Yoda"
+      ]
     },
     {
       "abbr": [
@@ -63930,6 +64737,9 @@
       "side": "Light",
       "underlyingCardFor": [
         "Yoda, Master Of The Force (V)"
+      ],
+      "personas": [
+        "Yoda"
       ]
     },
     {
@@ -63986,6 +64796,9 @@
           "title": "Yoda, Keeper Of The Peace (C-Slip AI)",
           "cardId": 7224
         }
+      ],
+      "personas": [
+        "Yoda"
       ]
     },
     {
@@ -64026,6 +64839,9 @@
           "title": "Yoda, Keeper Of The Peace (C-Slip AI 2)",
           "cardId": 7231
         }
+      ],
+      "personas": [
+        "Yoda"
       ]
     },
     {
@@ -65163,7 +65979,10 @@
       ],
       "rarity": "R2",
       "set": "3",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Zev Senesca"
+      ]
     },
     {
       "combo": [
@@ -65307,7 +66126,10 @@
       ],
       "rarity": "C",
       "set": "213",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Lando"
+      ]
     },
     {
       "front": {
@@ -65351,7 +66173,10 @@
         "When stacking L3-37 on a freighter, she does not go to the Lost pile and therefore she is not 'just lost'."
       ],
       "set": "213",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "L3-37"
+      ]
     },
     {
       "front": {
@@ -65407,7 +66232,10 @@
       ],
       "rarity": "R2",
       "set": "213",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Chewie"
+      ]
     },
     {
       "abbr": [
@@ -65454,7 +66282,10 @@
       ],
       "rarity": "R1",
       "set": "213",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Qi'ra"
+      ]
     },
     {
       "front": {
@@ -65492,7 +66323,10 @@
       ],
       "rarity": "C",
       "set": "213",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Rio"
+      ]
     },
     {
       "front": {
@@ -65535,7 +66369,10 @@
       ],
       "rarity": "C",
       "set": "213",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Han"
+      ]
     },
     {
       "front": {
@@ -65579,7 +66416,10 @@
         "Counts weapon destiny draws completed by both players."
       ],
       "set": "213",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Qui-Gon"
+      ]
     },
     {
       "front": {
@@ -65625,7 +66465,10 @@
         "The destiny +3 text is not applicable while stacked on Kessel Run (V) or a podracer, etc."
       ],
       "set": "213",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Beckett"
+      ]
     },
     {
       "front": {
@@ -65665,7 +66508,10 @@
       ],
       "rarity": "C",
       "set": "213",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Val"
+      ]
     },
     {
       "front": {
@@ -65718,7 +66564,10 @@
         "Relocating does not allow Yoda to embark or disembark."
       ],
       "set": "213",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Yoda"
+      ]
     },
     {
       "canceledBy": [
@@ -66243,7 +67092,10 @@
       ],
       "rarity": "C2",
       "set": "301",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Puck"
+      ]
     },
     {
       "front": {
@@ -66278,7 +67130,10 @@
       ],
       "rarity": "U",
       "set": "214",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Beaumont"
+      ]
     },
     {
       "front": {
@@ -66353,7 +67208,10 @@
       ],
       "rarity": "U",
       "set": "214",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Din"
+      ]
     },
     {
       "abbr": [
@@ -66401,7 +67259,10 @@
         "When playing against Bring Him Before Me, Rey may not select Luke as either of the two cards."
       ],
       "set": "214",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Rey"
+      ]
     },
     {
       "abbr": [
@@ -66680,7 +67541,10 @@
         "This is a matching weapon for Ahsoka, but not for other Jedi or Padawans in general."
       ],
       "set": "214",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Ahsoka's Shoto Lightsaber"
+      ]
     },
     {
       "front": {
@@ -66759,7 +67623,10 @@
         "The Force loss is a mandatory action initiated by Light. If not initiated, it occurs automatically at end of control phase. "
       ],
       "set": "215",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "C-3PO"
+      ]
     },
     {
       "front": {
@@ -66804,7 +67671,10 @@
         "Cards mentioning 'Cal' refer to Cal Alder. To refer to this character, cards will say 'Cal Kestis' instead."
       ],
       "set": "215",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Cal Kestis"
+      ]
     },
     {
       "front": {
@@ -67105,7 +67975,10 @@
         "Destiny to total power is drawn before battle destiny."
       ],
       "set": "215",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Han"
+      ]
     },
     {
       "front": {
@@ -67148,7 +68021,10 @@
       ],
       "rarity": "U",
       "set": "215",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Jannah"
+      ]
     },
     {
       "front": {
@@ -67511,7 +68387,10 @@
         "Game text referring to troopers/stormtroopers counts characters on both sides."
       ],
       "set": "215",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Han"
+      ]
     },
     {
       "front": {
@@ -67646,7 +68525,10 @@
         "Losing 2 Force is a cost to add a battle destiny; this cost cannot be reduced such as by It Could Be Worse. Likewise if We're Doomed has been played, it is simply ignored and Light still loses 2, not 1."
       ],
       "set": "216",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Anakin"
+      ]
     },
     {
       "front": {
@@ -67733,7 +68615,10 @@
       ],
       "rarity": "R",
       "set": "216",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Chewie"
+      ]
     },
     {
       "front": {
@@ -67890,7 +68775,14 @@
         "This card contains all 5 of the unique personas listed in the lore box."
       ],
       "set": "216",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Figrin D'an",
+        "Doikk Na'ts",
+        "Ickabel G'ont",
+        "Nalan Cheel",
+        "Tedn Dahai"
+      ]
     },
     {
       "cancels": [
@@ -67982,7 +68874,10 @@
         "May only save a Mandalorian just lost from an active or inactive state on table."
       ],
       "set": "216",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Grogu"
+      ]
     },
     {
       "front": {
@@ -68176,7 +69071,10 @@
         "Last sentence only works on a starship freighter, not a vehicle freighter (e.g. does not work on the vehicle side of The Falcon, Junkyard Garbage)."
       ],
       "set": "216",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Ketwol"
+      ]
     },
     {
       "front": {
@@ -68228,7 +69126,10 @@
         "If there are only 1 or 2 cards in Reserve Deck, Lando can still reveal them, but he cannot take a starship into hand."
       ],
       "set": "216",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Lando"
+      ]
     },
     {
       "front": {
@@ -68273,7 +69174,10 @@
         "Technically may use 1 Force to add power multiple times in a single battle, but this is fairly useless as only the first usage will be applied."
       ],
       "set": "216",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Obi-Wan"
+      ]
     },
     {
       "front": {
@@ -68321,7 +69225,10 @@
         "You may not persona replace a character if the new version would violate this card's deployment restrictions."
       ],
       "set": "216",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Qui-Gon"
+      ]
     },
     {
       "front": {
@@ -68366,7 +69273,10 @@
         "For example, Qui-Gon Jinn (fully immune to attrition) would not be affected by Tyranus at all. Then the limit of < 4 would be applied to Qui-Gon."
       ],
       "set": "216",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Yoda"
+      ]
     },
     {
       "front": {
@@ -68483,7 +69393,10 @@
         "To place her out of play using her game text, she must be lost from an active or inactive state on table - not from hand or Life Force."
       ],
       "set": "216",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Paige"
+      ]
     },
     {
       "front": {
@@ -69023,7 +69936,10 @@
         "This card is a Fett (e.g. Boba deploys -1 at Kamino: Clone Training Center, and Mace Windu (V) prevents Boba from adding a battle destiny)."
       ],
       "set": "217",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Boba Fett"
+      ]
     },
     {
       "abbr": [
@@ -69073,7 +69989,10 @@
         "If firing a repeating blaster (e.g. BlasTech E-11B Blaster Rifle), only the first shot is free."
       ],
       "set": "217",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Bo-Katan"
+      ]
     },
     {
       "abbr": [
@@ -69412,7 +70331,10 @@
         "Do not reorder or reshuffle the cards in the Used Pile."
       ],
       "set": "217",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Kanan"
+      ]
     },
     {
       "abbr": [
@@ -69511,7 +70433,10 @@
         "Moving For Free: When using Nabrun Leids or docking bay transit, the cost is free <u>only</u> if Mara is moving alone or if the cards moving with her also move for free (Light still draws destiny for Nabrun Leids)."
       ],
       "set": "217",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Mara Jade"
+      ]
     },
     {
       "abbr": [
@@ -69640,7 +70565,10 @@
         "If Profundity is lost from table, this site remains on table."
       ],
       "set": "217",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Profundity"
+      ]
     },
     {
       "front": {
@@ -70041,7 +70969,11 @@
       ],
       "rarity": "C",
       "set": "218",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Qui-Gon",
+        "Qui-Gon Jinn's Lightsaber"
+      ]
     },
     {
       "abbr": [
@@ -70100,7 +71032,10 @@
         "When using Sorry About The Mess to swing during the control phase, Mace only swings once. If Mace then battles later that turn, he may still swing twice in that battle."
       ],
       "set": "218",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Mace"
+      ]
     },
     {
       "abbr": [
@@ -70500,7 +71435,10 @@
         "This card is the same persona as Admiral Ackbar (e.g. for <i>Home One</i> and for Rebel Leadership combo); Admiral Ackbar and Fleet Admiral Gial Ackbar cannot be on table at the same time."
       ],
       "set": "218",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Ackbar"
+      ]
     },
     {
       "abbr": [
@@ -70761,7 +71699,10 @@
         "Can only deploy a lightsaber from Lost Pile that is normally allowed to deploy on him (e.g. not Obi-Wan's Lightsaber)."
       ],
       "set": "218",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Luke"
+      ]
     },
     {
       "abbr": [
@@ -71100,7 +72041,10 @@
         "Artoo placing an Interrupt out of play is global (e.g. he can do this during a battle at another location)."
       ],
       "set": "219",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "R2-D2"
+      ]
     },
     {
       "abbr": [
@@ -71190,7 +72134,11 @@
         "Blaster Proficiency works, but note that it only adds 3 to a single shot, not both shots."
       ],
       "set": "219",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Cara Dune",
+        "Cara's Heavy Blaster Rifle"
+      ]
     },
     {
       "abbr": [
@@ -71314,7 +72262,10 @@
         "As this Ezra is not a spy, he would require presence or Force icons in order to deploy to Dathomir: Maul's Chambers."
       ],
       "set": "219",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Ezra"
+      ]
     },
     {
       "abbr": [
@@ -71345,7 +72296,10 @@
       ],
       "rarity": "C2",
       "set": "219",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Ezra's Blaster Lightsaber"
+      ]
     },
     {
       "abbr": [
@@ -71966,7 +72920,10 @@
         "May deploy Han or Chewie aboard from Reserve Deck even if Falcon is landed and/or unpiloted."
       ],
       "set": "220",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Falcon"
+      ]
     },
     {
       "abbr": [
@@ -72065,7 +73022,10 @@
         "The 'even if imprisoned' text does not work while she is an escorted captive."
       ],
       "set": "220",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Leia"
+      ]
     },
     {
       "abbr": [
@@ -72148,7 +73108,11 @@
       ],
       "rarity": "U",
       "set": "211",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Black 1",
+        "BB-8"
+      ]
     },
     {
       "abbr": [
@@ -72204,7 +73168,11 @@
       ],
       "rarity": "PM",
       "set": "204",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Chewie",
+        "Chewbacca's Bowcaster"
+      ]
     },
     {
       "front": {
@@ -72281,7 +73249,10 @@
       ],
       "rarity": "U",
       "set": "204",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Poe Dameron"
+      ]
     },
     {
       "front": {
@@ -72364,7 +73335,10 @@
       ],
       "rarity": "R",
       "set": "204",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Han"
+      ]
     },
     {
       "front": {
@@ -72408,7 +73382,10 @@
       ],
       "rarity": "R1",
       "set": "201",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Tantive IV"
+      ]
     },
     {
       "abbr": [
@@ -72486,7 +73463,10 @@
         "Flipping from starship to vehicle causes attached Mynocks to detach."
       ],
       "set": "204",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Falcon"
+      ]
     },
     {
       "abbr": [
@@ -72816,7 +73796,10 @@
       ],
       "rarity": "C1",
       "set": "221",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Yularen"
+      ]
     },
     {
       "abbr": [
@@ -72860,7 +73843,10 @@
       ],
       "rarity": "R",
       "set": "221",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Anakin"
+      ]
     },
     {
       "abbr": [
@@ -73687,7 +74673,10 @@
       ],
       "rarity": "R",
       "set": "221",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Qui-Gon Jinn's Lightsaber"
+      ]
     },
     {
       "abbr": [
@@ -73718,7 +74707,10 @@
       ],
       "rarity": "R",
       "set": "221",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Qui-Gon Jinn's Lightsaber"
+      ]
     },
     {
       "front": {
@@ -74060,7 +75052,10 @@
       ],
       "rarity": "C",
       "set": "222",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Poe Dameron"
+      ]
     },
     {
       "abbr": [
@@ -74203,7 +75198,10 @@
       ],
       "rarity": "R",
       "set": "222",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Nien Nunb"
+      ]
     },
     {
       "front": {
@@ -74358,7 +75356,10 @@
       ],
       "rarity": "U",
       "set": "222",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Luke"
+      ]
     },
     {
       "front": {
@@ -74444,7 +75445,10 @@
         "BB-8 may be placed in Used Pile even if there are no Undercover spies there."
       ],
       "set": "204",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "BB-8"
+      ]
     },
     {
       "front": {
@@ -74479,7 +75483,10 @@
       ],
       "rarity": "U",
       "set": "214",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Din"
+      ]
     },
     {
       "front": {
@@ -74531,7 +75538,10 @@
         "May even deploy as a 'react' to same location as Light's permanent pilot such as on a vehicle or starship (even a landed starship)."
       ],
       "set": "204",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Finn"
+      ]
     },
     {
       "front": {
@@ -74582,7 +75592,10 @@
       ],
       "rarity": "R",
       "set": "207",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Leia"
+      ]
     },
     {
       "front": {
@@ -74701,7 +75714,10 @@
         "Text to 'draw one battle destiny if unable to otherwise' does not work while Jyn is Undercover."
       ],
       "set": "206",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Jyn Erso"
+      ]
     },
     {
       "abbr": [
@@ -74805,7 +75821,10 @@
       ],
       "rarity": "U",
       "set": "208",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Luke"
+      ]
     },
     {
       "front": {
@@ -74906,7 +75925,10 @@
         "For R2-D2 (V) to use his 'subtract 1' action, the following conditions must be met: First, the battle must be at an interior site. Second, R2-D2 (V) must be at the same site or at a related site (not necessarily an interior one, but R2-D2 (V) must be at a site - not a system or sector)."
       ],
       "set": "201",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "R2-D2"
+      ]
     },
     {
       "abbr": [
@@ -74954,7 +75976,10 @@
         "When playing against Bring Him Before Me, Rey may not select Luke as either of the two cards."
       ],
       "set": "214",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Rey"
+      ]
     },
     {
       "abbr": [
@@ -75002,7 +76027,10 @@
       ],
       "rarity": "R1",
       "set": "213",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Qi'ra"
+      ]
     },
     {
       "abbr": [
@@ -75055,7 +76083,10 @@
         "However, if Ahsoka does happen to be at the location and is excluded during a battle, then she is inactive, and cannot subtract."
       ],
       "set": "223",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Ahsoka"
+      ]
     },
     {
       "abbr": [
@@ -75106,7 +76137,10 @@
         "Does not protect against Physical Choke."
       ],
       "set": "223",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Jyn Erso"
+      ]
     },
     {
       "abbr": [
@@ -75306,7 +76340,10 @@
       ],
       "rarity": "PM",
       "set": "223",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Leia"
+      ]
     },
     {
       "front": {
@@ -75419,7 +76456,10 @@
       ],
       "rarity": "PM",
       "set": "223",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Corran Horn"
+      ]
     },
     {
       "abbr": [
@@ -75802,7 +76842,10 @@
       ],
       "rarity": "C",
       "set": "223",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Sabine"
+      ]
     },
     {
       "abbr": [
@@ -76079,7 +77122,10 @@
         "Only a lightsaber that can deploy on Ben may deploy on him from Lost Pile."
       ],
       "set": "224",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Ben Solo"
+      ]
     },
     {
       "abbr": [
@@ -76312,7 +77358,10 @@
       ],
       "rarity": "R1",
       "set": "224",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Han"
+      ]
     },
     {
       "abbr": [
@@ -76365,7 +77414,10 @@
         "A stolen blaster deploying on Jaxxon must still obey uniqueness rules."
       ],
       "set": "224",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Jaxxon"
+      ]
     },
     {
       "abbr": [
@@ -76502,7 +77554,10 @@
         "The phrase 'exclude all other characters' means exclude all characters except for the targeted Dark Jedi and Son Of Skywalker himself."
       ],
       "set": "224",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Luke"
+      ]
     },
     {
       "abbr": [
@@ -76635,7 +77690,11 @@
         "Zev is a matching pilot, so this vehicle is immune to attrition < 6 with Echo Base Garrison."
       ],
       "set": "224",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Rogue 2",
+        "Zev Senesca"
+      ]
     },
     {
       "abbr": [
@@ -76730,7 +77789,10 @@
         "Losing 2 Force is a cost to add a battle destiny; this cost cannot be reduced such as by It Could Be Worse. Likewise if We're Doomed has been played, it is simply ignored and Light still loses 2, not 1."
       ],
       "set": "216",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Anakin"
+      ]
     },
     {
       "front": {
@@ -76790,7 +77852,10 @@
       ],
       "rarity": "R1",
       "set": "210",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Anakin's Lightsaber"
+      ]
     },
     {
       "front": {
@@ -77089,7 +78154,10 @@
       ],
       "rarity": "R",
       "set": "210",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Plo Koon"
+      ]
     },
     {
       "abbr": [
@@ -77517,7 +78585,10 @@
         "His 'just captured' text works regardless of being seized, imprisoned, or escaped."
       ],
       "set": "225",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Han"
+      ]
     },
     {
       "abbr": [
@@ -77566,7 +78637,10 @@
         "Adds a battle destiny with either player's droid."
       ],
       "set": "225",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Chewie"
+      ]
     },
     {
       "abbr": [
@@ -77797,7 +78871,10 @@
         "This text permits Jedi Lightsaber (V) to deploy on (and be used by) Finn."
       ],
       "set": "225",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Finn"
+      ]
     },
     {
       "abbr": [
@@ -77956,7 +79033,11 @@
         "Lando's retrieval action occurs as soon as Light has calculated their total battle destiny, including any modifiers. If Light initiated the battle, this will be after Light has completed their battle destiny draws and before Dark has started their battle destiny draws."
       ],
       "set": "225",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Lando",
+        "Lando's Blaster Rifle"
+      ]
     },
     {
       "abbr": [
@@ -77995,7 +79076,10 @@
         "If a character does not have immunity to attrition, they still receive defense value +1."
       ],
       "set": "225",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Leia's Lightsaber"
+      ]
     },
     {
       "abbr": [
@@ -78591,7 +79675,10 @@
         "Beq's text does not cause lightsabers to become matching weapons for him."
       ],
       "set": "226",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Beq"
+      ]
     },
     {
       "cancels": [
@@ -78878,7 +79965,10 @@
       ],
       "rarity": "C2",
       "set": "226",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Obi-Wan"
+      ]
     },
     {
       "abbr": [
@@ -79417,7 +80507,10 @@
       ],
       "rarity": "R1",
       "set": "200",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Luke"
+      ]
     },
     {
       "abbr": [
@@ -79465,7 +80558,10 @@
         "May deploy (or persona replace) at a <u>system or sector</u> opponent occupies."
       ],
       "set": "210",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Luke"
+      ]
     },
     {
       "abbr": [
@@ -79524,7 +80620,10 @@
         "When using Sorry About The Mess to swing during the control phase, Mace only swings once. If Mace then battles later that turn, he may still swing twice in that battle."
       ],
       "set": "218",
-      "side": "Light"
+      "side": "Light",
+      "personas": [
+        "Mace"
+      ]
     },
     {
       "counterpart": "Tatooine: Lars' Moisture Farm",


### PR DESCRIPTION
## Personas Added

This PR adds top-level `personas` arrays to `714` card/persona associations across `235` unique personas in `Dark.json` and `Light.json`.

`636` cards have at least one persona. Expand each persona below to see the cards that received that human-readable value.

<details>
<summary><strong>4-LOM</strong> (5 cards)</summary>

- `4_91` (Dark, set 4) •4-LOM
- `109_6` (Dark, set 109) •4-LOM With Concussion Rifle
- `200_71` (Dark, set 200) •4-LOM With Concussion Rifle (V)
- `200_71` (Dark, set 200) •4-LOM With Concussion Rifle (V) (AI)
- `221_42` (Dark, set 221) •Zuckuss And 4-LOM In Mist Hunter

</details>

<details>
<summary><strong>4-LOM's Concussion Rifle</strong> (4 cards)</summary>

- `4_174` (Dark, set 4) •4-LOM's Concussion Rifle
- `109_6` (Dark, set 109) •4-LOM With Concussion Rifle
- `200_71` (Dark, set 200) •4-LOM With Concussion Rifle (V)
- `200_71` (Dark, set 200) •4-LOM With Concussion Rifle (V) (AI)

</details>

<details>
<summary><strong>Ackbar</strong> (3 cards)</summary>

- `9_6` (Light, set 9) •Admiral Ackbar
- `203_1` (Light, set 203) •Admiral Ackbar (V)
- `218_20` (Light, set 218) •Fleet Admiral Gial Ackbar

</details>

<details>
<summary><strong>Ahsoka</strong> (4 cards)</summary>

- `211_59` (Light, set 211) •Ahsoka Tano
- `223_4` (Light, set 223) •Ahsoka, Friend Of The Family
- `301_1` (Light, set 301) •Ahsoka Tano With Lightsabers
- `301_1` (Light, set 301) •Ahsoka Tano With Lightsabers (AI)

</details>

<details>
<summary><strong>Ahsoka's Lightsabers</strong> (2 cards)</summary>

- `301_1` (Light, set 301) •Ahsoka Tano With Lightsabers
- `301_1` (Light, set 301) •Ahsoka Tano With Lightsabers (AI)

</details>

<details>
<summary><strong>Ahsoka's Shoto Lightsaber</strong> (1 card)</summary>

- `214_15` (Light, set 214) •Ahsoka's Shoto Lightsaber

</details>

<details>
<summary><strong>Amidala</strong> (8 cards)</summary>

- `11_8` (Light, set 11) •Padme Naberrie
- `11_9` (Light, set 11) •Padme Naberrie (AI)
- `12_22` (Light, set 12) •Queen Amidala, Ruler Of Naboo
- `12_23` (Light, set 12) •Queen Amidala, Ruler Of Naboo (AI)
- `14_25` (Light, set 14) •Queen Amidala
- `14_26` (Light, set 14) •Queen Amidala (AI)
- `203_10` (Light, set 203) •Padme Naberrie (V)
- `203_36` (Light, set 203) •Padme Naberrie (V) (AI)

</details>

<details>
<summary><strong>Anakin</strong> (5 cards)</summary>

- `200_2` (Light, set 200) •Anakin Skywalker, Padawan Learner
- `200_2` (Light, set 200) •Anakin Skywalker, Padawan Learner (AI)
- `216_21` (Light, set 216) •Anakin Skywalker, Jedi Knight
- `216_21` (Light, set 216) •Anakin Skywalker, Jedi Knight (Holo AI)
- `221_46` (Light, set 221) •Anakin Skywalker, Junkyard Slave

</details>

<details>
<summary><strong>Anakin's Lightsaber</strong> (5 cards)</summary>

- `3_71` (Light, set 3) •Anakin's Lightsaber
- `209_10` (Light, set 209) •Rey With Lightsaber
- `209_10` (Light, set 209) •Rey With Lightsaber (AI)
- `210_3` (Light, set 210) •Anakin's Lightsaber (V)
- `210_3` (Light, set 210) •Anakin's Lightsaber (V) (AI)

</details>

<details>
<summary><strong>Aphra</strong> (2 cards)</summary>

- `209_35` (Dark, set 209) •Dr. Chelli Lona Aphra
- `209_35` (Dark, set 209) •Dr. Chelli Lona Aphra (AI)

</details>

<details>
<summary><strong>Arm Cannon</strong> (1 card)</summary>

- `225_14` (Dark, set 225) •Cardo

</details>

<details>
<summary><strong>Asajj's Lightsabers</strong> (3 cards)</summary>

- `221_9` (Dark, set 221) •Asajj Ventress' Lightsabers
- `301_3` (Dark, set 301) •Asajj Ventress With Lightsabers
- `301_3` (Dark, set 301) •Asajj Ventress With Lightsabers (AI)

</details>

<details>
<summary><strong>Aurra</strong> (5 cards)</summary>

- `11_51` (Dark, set 11) •Aurra Sing
- `11_52` (Dark, set 11) •Aurra Sing (AI)
- `212_3` (Dark, set 212) •Aurra Sing With Blaster Rifle
- `212_3` (Dark, set 212) •Aurra Sing With Blaster Rifle (AI)
- `212_3` (Dark, set 212) •Aurra Sing With Blaster Rifle (C-Slip AI)

</details>

<details>
<summary><strong>Aurra Sing's Blaster Rifle</strong> (4 cards)</summary>

- `13_53` (Dark, set 13) •Aurra Sing's Blaster Rifle
- `212_3` (Dark, set 212) •Aurra Sing With Blaster Rifle
- `212_3` (Dark, set 212) •Aurra Sing With Blaster Rifle (AI)
- `212_3` (Dark, set 212) •Aurra Sing With Blaster Rifle (C-Slip AI)

</details>

<details>
<summary><strong>Baylan</strong> (1 card)</summary>

- `225_12` (Dark, set 225) •Baylan Skoll

</details>

<details>
<summary><strong>Baze</strong> (1 card)</summary>

- `207_1` (Light, set 207) •Baze Malbus With Cannon

</details>

<details>
<summary><strong>Baze's Cannon</strong> (1 card)</summary>

- `207_1` (Light, set 207) •Baze Malbus With Cannon

</details>

<details>
<summary><strong>BB-8</strong> (4 cards)</summary>

- `204_1` (Light, set 204) •BB-8 (Beebee-Ate)
- `204_1` (Light, set 204) •BB-8 (Beebee-Ate) (AI)
- `211_28` (Light, set 211) •BB-8 In Black Squadron 1
- `211_28` (Light, set 211) •BB-8 In Black Squadron 1 (AI)

</details>

<details>
<summary><strong>Beaumont</strong> (1 card)</summary>

- `214_16` (Light, set 214) •Beaumont Kin

</details>

<details>
<summary><strong>Beckett</strong> (1 card)</summary>

- `213_42` (Light, set 213) •Tobias Beckett

</details>

<details>
<summary><strong>Beedo</strong> (1 card)</summary>

- `6_97` (Dark, set 6) •Beedo

</details>

<details>
<summary><strong>Ben Solo</strong> (1 card)</summary>

- `224_11` (Light, set 224) •Ben Solo

</details>

<details>
<summary><strong>Beq</strong> (1 card)</summary>

- `226_18` (Light, set 226) •Kelleran Beq

</details>

<details>
<summary><strong>Bestoon Legacy</strong> (1 card)</summary>

- `214_2` (Dark, set 214) •Bestoon Legacy

</details>

<details>
<summary><strong>Bib Fortuna</strong> (4 cards)</summary>

- `6_98` (Dark, set 6) •Bib Fortuna
- `13_55` (Dark, set 13) •Bib Fortuna
- `220_1` (Dark, set 220) •Bib Fortuna, Heir To The Palace
- `225_1` (Dark, set 225) •Bib Fortuna (V)

</details>

<details>
<summary><strong>Black 1</strong> (2 cards)</summary>

- `211_28` (Light, set 211) •BB-8 In Black Squadron 1
- `211_28` (Light, set 211) •BB-8 In Black Squadron 1 (AI)

</details>

<details>
<summary><strong>Black 2</strong> (3 cards)</summary>

- `1_299` (Dark, set 1) •Black 2
- `7_303` (Dark, set 7) •Death Star Assault Squadron
- `200_127` (Dark, set 200) •Black 2 (V)

</details>

<details>
<summary><strong>Black 3</strong> (3 cards)</summary>

- `1_300` (Dark, set 1) •Black 3
- `7_303` (Dark, set 7) •Death Star Assault Squadron
- `210_28` (Dark, set 210) •Black 3 (V)

</details>

<details>
<summary><strong>Blizzard 1</strong> (2 cards)</summary>

- `3_154` (Dark, set 3) •Blizzard 1
- `217_4` (Dark, set 217) •Blizzard 1 (V)

</details>

<details>
<summary><strong>Blockade Flagship</strong> (5 cards)</summary>

- `12_164` (Dark, set 12) •Blockade Flagship: Bridge
- `13_57` (Dark, set 13) •Blockade Flagship: Hallway
- `14_111` (Dark, set 14) •Blockade Flagship: Docking Bay
- `14_114` (Dark, set 14) •Blockade Flagship
- `14_48` (Light, set 14) •Blockade Flagship: Docking Bay

</details>

<details>
<summary><strong>Blount</strong> (1 card)</summary>

- `9_21` (Light, set 9) •Lieutenant Blount

</details>

<details>
<summary><strong>Blue 11</strong> (1 card)</summary>

- `209_32` (Light, set 209) •Blue 11

</details>

<details>
<summary><strong>Blue Squadron 1</strong> (1 card)</summary>

- `210_5` (Light, set 210) •Blue Squadron 1

</details>

<details>
<summary><strong>Bo-Katan</strong> (1 card)</summary>

- `217_30` (Light, set 217) •Bo-Katan

</details>

<details>
<summary><strong>Boba Fett</strong> (9 cards)</summary>

- `5_91` (Dark, set 5) •Boba Fett
- `7_167` (Dark, set 7) •Boba Fett
- `13_59` (Dark, set 13) •Boba Fett, Bounty Hunter
- `108_5` (Dark, set 108) •Boba Fett With Blaster Rifle
- `109_8` (Dark, set 109) •Boba Fett In Slave I
- `200_130` (Dark, set 200) •Boba Fett In Slave I (V)
- `206_9` (Dark, set 206) •Boba Fett (V)
- `222_5` (Dark, set 222) •Boba Fett With Blaster Rifle (V)
- `217_31` (Light, set 217) •Boba

</details>

<details>
<summary><strong>Boba Fett's Blaster Rifle</strong> (4 cards)</summary>

- `5_179` (Dark, set 5) •Boba Fett's Blaster Rifle
- `108_5` (Dark, set 108) •Boba Fett With Blaster Rifle
- `205_22` (Dark, set 205) •Boba Fett's Blaster Rifle (V)
- `222_5` (Dark, set 222) •Boba Fett With Blaster Rifle (V)

</details>

<details>
<summary><strong>Booster</strong> (1 card)</summary>

- `200_60` (Light, set 200) •Booster In Pulsar Skate

</details>

<details>
<summary><strong>BoShek</strong> (2 cards)</summary>

- `1_4` (Light, set 1) •BoShek
- `210_6` (Light, set 210) •BoShek, Gritty Smuggler

</details>

<details>
<summary><strong>Bossk</strong> (5 cards)</summary>

- `4_92` (Dark, set 4) •Bossk
- `7_301` (Dark, set 7) •Bossk In Hound's Tooth
- `110_5` (Dark, set 110) •Bossk With Mortar Gun
- `200_75` (Dark, set 200) •Bossk (V)
- `200_131` (Dark, set 200) •Bossk In Hound's Tooth (V)

</details>

<details>
<summary><strong>Bossk's Mortar Gun</strong> (2 cards)</summary>

- `4_175` (Dark, set 4) •Bossk's Mortar Gun
- `110_5` (Dark, set 110) •Bossk With Mortar Gun

</details>

<details>
<summary><strong>C-3PO</strong> (8 cards)</summary>

- `1_5` (Light, set 1) •C-3PO (See-Threepio)
- `8_31` (Light, set 8) •Threepio
- `10_2` (Light, set 10) •Artoo & •Threepio
- `11_13` (Light, set 11) •Threepio With His Parts Showing
- `11_14` (Light, set 11) •Threepio With His Parts Showing (AI)
- `110_3` (Light, set 110) •See-Threepio
- `203_11` (Light, set 203) •R2-D2 & •C-3PO
- `215_3` (Light, set 215) •C-3PO (See-Threepio) (V)

</details>

<details>
<summary><strong>Cad</strong> (1 card)</summary>

- `203_24` (Dark, set 203) •Cad Bane

</details>

<details>
<summary><strong>Cal</strong> (2 cards)</summary>

- `3_2` (Light, set 3) •Cal Alder
- `206_2` (Light, set 206) •Cal Alder (V)

</details>

<details>
<summary><strong>Cal Kestis</strong> (1 card)</summary>

- `215_4` (Light, set 215) •Cal Kestis

</details>

<details>
<summary><strong>Cara Dune</strong> (1 card)</summary>

- `219_30` (Light, set 219) •Cara Dune With Heavy Blaster Rifle

</details>

<details>
<summary><strong>Cara's Heavy Blaster Rifle</strong> (1 card)</summary>

- `219_30` (Light, set 219) •Cara Dune With Heavy Blaster Rifle

</details>

<details>
<summary><strong>Cassian</strong> (1 card)</summary>

- `206_3` (Light, set 206) •Captain Cassian Andor

</details>

<details>
<summary><strong>Chewbacca's Bowcaster</strong> (3 cards)</summary>

- `8_86` (Light, set 8) •Chewbacca's Bowcaster
- `204_4` (Light, set 204) •Chewie With Bowcaster
- `204_4` (Light, set 204) •Chewie With Bowcaster (AI)

</details>

<details>
<summary><strong>Chewie</strong> (14 cards)</summary>

- `2_3` (Light, set 2) •Chewbacca
- `8_2` (Light, set 8) •Chewbacca Of Kashyyyk
- `10_3` (Light, set 10) •Chewbacca, Protector
- `13_9` (Light, set 13) •Chewie, Enraged
- `13_21` (Light, set 13) •Han, Chewie, And The Falcon
- `104_1` (Light, set 104) •Chewie
- `109_1` (Light, set 109) •Chewie With Blaster Rifle
- `200_5` (Light, set 200) •Chewie (V)
- `204_4` (Light, set 204) •Chewie With Bowcaster
- `204_4` (Light, set 204) •Chewie With Bowcaster (AI)
- `205_7` (Light, set 205) •Han, Chewie, And The Falcon (V)
- `213_36` (Light, set 213) •Chewbacca (V)
- `216_23` (Light, set 216) •Chewbacca, Defender Of Kashyyyk
- `225_39` (Light, set 225) •Chewie With Blaster Rifle (V)

</details>

<details>
<summary><strong>Chimaera</strong> (3 cards)</summary>

- `9_154` (Dark, set 9) •Chimaera
- `219_2` (Dark, set 219) •Chimaera (V)
- `219_2` (Dark, set 219) •Chimaera (V) (AI)

</details>

<details>
<summary><strong>Chopper</strong> (1 card)</summary>

- `208_2` (Light, set 208) •C1-10P (Chopper)

</details>

<details>
<summary><strong>Connix</strong> (1 card)</summary>

- `209_9` (Light, set 209) •Lieutenant Kaydel Connix

</details>

<details>
<summary><strong>Corran Horn</strong> (3 cards)</summary>

- `10_5` (Light, set 10) •Corran Horn
- `202_8` (Light, set 202) •Corran Horn In Rogue 9
- `223_35` (Light, set 223) •Corran Horn, Jedi

</details>

<details>
<summary><strong>Cracken</strong> (2 cards)</summary>

- `9_8` (Light, set 9) •Colonel Cracken
- `200_12` (Light, set 200) •General Airen Cracken

</details>

<details>
<summary><strong>Dack Ralter</strong> (1 card)</summary>

- `3_4` (Light, set 3) •Dack Ralter

</details>

<details>
<summary><strong>Dannik Jerriko</strong> (2 cards)</summary>

- `2_84` (Dark, set 2) •Dannik Jerriko
- `215_24` (Dark, set 215) •Dannik Jerriko (V)

</details>

<details>
<summary><strong>Dash</strong> (3 cards)</summary>

- `10_6` (Light, set 10) •Dash Rendar
- `201_20` (Light, set 201) •Dash In Rogue 12
- `210_12` (Light, set 210) •Dash Rendar (V)

</details>

<details>
<summary><strong>Dengar</strong> (5 cards)</summary>

- `4_100` (Dark, set 4) •Dengar
- `109_10` (Dark, set 109) •Dengar In Punishing One
- `110_7` (Dark, set 110) •Dengar With Blaster Carbine
- `200_79` (Dark, set 200) •Dengar With Blaster Carbine (V)
- `205_23` (Dark, set 205) •Dengar (V)

</details>

<details>
<summary><strong>Dengar's Blaster Carbine</strong> (3 cards)</summary>

- `4_176` (Dark, set 4) •Dengar's Blaster Carbine
- `110_7` (Dark, set 110) •Dengar With Blaster Carbine
- `200_79` (Dark, set 200) •Dengar With Blaster Carbine (V)

</details>

<details>
<summary><strong>Din</strong> (2 cards)</summary>

- `214_18` (Light, set 214) •Din Djarin
- `214_18` (Light, set 214) •Din Djarin (AI)

</details>

<details>
<summary><strong>Doallyn</strong> (1 card)</summary>

- `6_38` (Light, set 6) •Sergeant Doallyn

</details>

<details>
<summary><strong>Dofine</strong> (3 cards)</summary>

- `12_103` (Dark, set 12) •Daultay Dofine
- `14_76` (Dark, set 14) •Captain Daultay Dofine
- `219_3` (Dark, set 219) •Daultay Dofine (V)

</details>

<details>
<summary><strong>Doikk Na'ts</strong> (2 cards)</summary>

- `2_7` (Light, set 2) •Doikk Na'ts
- `216_27` (Light, set 216) •Figrin D'an & •The Modal Nodes

</details>

<details>
<summary><strong>Dooku</strong> (4 cards)</summary>

- `200_76` (Dark, set 200) •Count Dooku
- `200_76` (Dark, set 200) •Count Dooku (AI)
- `213_3` (Dark, set 213) •Darth Tyranus
- `213_3` (Dark, set 213) •Darth Tyranus (Holo AI)

</details>

<details>
<summary><strong>Dooku's Lightsaber</strong> (2 cards)</summary>

- `200_142` (Dark, set 200) •Dooku's Lightsaber
- `200_142` (Dark, set 200) •Dooku's Lightsaber (AI)

</details>

<details>
<summary><strong>DS-61-2</strong> (2 cards)</summary>

- `1_173` (Dark, set 1) •DS-61-2
- `7_303` (Dark, set 7) •Death Star Assault Squadron

</details>

<details>
<summary><strong>DS-61-3</strong> (3 cards)</summary>

- `1_174` (Dark, set 1) •DS-61-3
- `7_303` (Dark, set 7) •Death Star Assault Squadron
- `225_18` (Dark, set 225) •DS-61-3 (V)

</details>

<details>
<summary><strong>Dutch</strong> (4 cards)</summary>

- `1_8` (Light, set 1) •Dutch
- `103_1` (Light, set 103) •Gold Leader In Gold 1
- `200_62` (Light, set 200) •Gold Leader In Gold 1 (V)
- `210_13` (Light, set 210) •Dutch (V)

</details>

<details>
<summary><strong>Elis</strong> (1 card)</summary>

- `200_134` (Dark, set 200) •Elis In Hinthra

</details>

<details>
<summary><strong>Executor</strong> (9 cards)</summary>

- `4_159` (Dark, set 4) •Executor: Comm Station
- `4_160` (Dark, set 4) •Executor: Control Station
- `4_161` (Dark, set 4) •Executor: Holotheatre
- `4_162` (Dark, set 4) •Executor: Main Corridor
- `4_163` (Dark, set 4) •Executor: Meditation Chamber
- `4_167` (Dark, set 4) •Executor
- `7_282` (Dark, set 7) •Executor: Docking Bay
- `9_157` (Dark, set 9) •Flagship Executor
- `213_24` (Dark, set 213) •Executor: Control Station (V)

</details>

<details>
<summary><strong>Ezra</strong> (2 cards)</summary>

- `210_14` (Light, set 210) •Ezra Bridger
- `219_33` (Light, set 219) •Ezra, Hero Of Phoenix Squadron

</details>

<details>
<summary><strong>Ezra's Blaster Lightsaber</strong> (1 card)</summary>

- `219_34` (Light, set 219) •Ezra's Blaster Lightsaber

</details>

<details>
<summary><strong>Falcon</strong> (9 cards)</summary>

- `1_143` (Light, set 1) •Millennium Falcon
- `9_68` (Light, set 9) •Gold Squadron 1
- `13_21` (Light, set 13) •Han, Chewie, And The Falcon
- `109_2` (Light, set 109) •Lando In Millennium Falcon
- `204_35` (Light, set 204) •The Falcon, Junkyard Garbage / •The Falcon, Junkyard Garbage
- `204_35` (Light, set 204) •The Falcon, Junkyard Garbage / •The Falcon, Junkyard Garbage (AI)
- `205_7` (Light, set 205) •Han, Chewie, And The Falcon (V)
- `206_8` (Light, set 206) •The Falcon
- `220_7` (Light, set 220) •Millennium Falcon (V)

</details>

<details>
<summary><strong>Fennec Shand</strong> (1 card)</summary>

- `219_6` (Dark, set 219) •Fennec Shand

</details>

<details>
<summary><strong>Fenson</strong> (1 card)</summary>

- `8_108` (Dark, set 8) •Navy Trooper Fenson

</details>

<details>
<summary><strong>Figrin D'an</strong> (2 cards)</summary>

- `1_9` (Light, set 1) •Figrin D'an
- `216_27` (Light, set 216) •Figrin D'an & •The Modal Nodes

</details>

<details>
<summary><strong>Finn</strong> (3 cards)</summary>

- `204_6` (Light, set 204) •Finn
- `204_6` (Light, set 204) •Finn (AI)
- `225_45` (Light, set 225) •Finn, Resistance Hero

</details>

<details>
<summary><strong>First Light</strong> (4 cards)</summary>

- `213_25` (Dark, set 213) •First Light: Bar
- `213_26` (Dark, set 213) •First Light: Dryden's Study
- `213_27` (Dark, set 213) •First Light: Reception Area
- `221_19` (Dark, set 221) •First Light

</details>

<details>
<summary><strong>Garindan</strong> (2 cards)</summary>

- `1_177` (Dark, set 1) •Garindan
- `226_4` (Dark, set 226) •Garindan, Imperial Spy

</details>

<details>
<summary><strong>Gideon</strong> (2 cards)</summary>

- `212_2` (Dark, set 212) •Moff Gideon
- `223_18` (Dark, set 223) •Moff Gideon, Suited For Battle

</details>

<details>
<summary><strong>Gold 1</strong> (3 cards)</summary>

- `1_141` (Light, set 1) •Gold 1
- `103_1` (Light, set 103) •Gold Leader In Gold 1
- `200_62` (Light, set 200) •Gold Leader In Gold 1 (V)

</details>

<details>
<summary><strong>Green Leader</strong> (3 cards)</summary>

- `9_16` (Light, set 9) •Green Leader
- `201_18` (Light, set 201) •Green Leader In Green Squadron 1
- `201_18` (Light, set 201) •Green Leader In Green Squadron 1 (AI)

</details>

<details>
<summary><strong>Green Squadron 1</strong> (3 cards)</summary>

- `9_71` (Light, set 9) •Green Squadron 1
- `201_18` (Light, set 201) •Green Leader In Green Squadron 1
- `201_18` (Light, set 201) •Green Leader In Green Squadron 1 (AI)

</details>

<details>
<summary><strong>Green Squadron 3</strong> (2 cards)</summary>

- `9_72` (Light, set 9) •Green Squadron 3
- `205_10` (Light, set 205) •Tycho In Green Squadron 3

</details>

<details>
<summary><strong>Grenwick</strong> (1 card)</summary>

- `7_171` (Dark, set 7) •Corporal Grenwick

</details>

<details>
<summary><strong>Grievous</strong> (3 cards)</summary>

- `203_27` (Dark, set 203) •General Grievous
- `203_27` (Dark, set 203) •General Grievous (AI)
- `203_27` (Dark, set 203) •General Grievous (Holo AI)

</details>

<details>
<summary><strong>Grogu</strong> (1 card)</summary>

- `216_29` (Light, set 216) •Grogu

</details>

<details>
<summary><strong>Grondorn</strong> (1 card)</summary>

- `7_19` (Light, set 7) •Grondorn Muse

</details>

<details>
<summary><strong>Gunray</strong> (4 cards)</summary>

- `12_112` (Dark, set 12) •Nute Gunray
- `14_81` (Dark, set 14) •Nute Gunray, Neimoidian Viceroy
- `14_82` (Dark, set 14) •Nute Gunray, Neimoidian Viceroy (AI)
- `210_40` (Dark, set 210) •Nute Gunray (V)

</details>

<details>
<summary><strong>Haako</strong> (3 cards)</summary>

- `12_117` (Dark, set 12) •Rune Haako
- `14_86` (Dark, set 14) •Rune Haako, Legal Counsel
- `14_87` (Dark, set 14) •Rune Haako, Legal Counsel (AI)

</details>

<details>
<summary><strong>Han</strong> (18 cards)</summary>

- `10_42` (Dark, set 10) •Jabba's Prize / Jabba's Prize
- `1_11` (Light, set 1) •Han Solo
- `5_1` (Light, set 5) •Captain Han Solo
- `7_48` (Light, set 7) •TK-422
- `8_15` (Light, set 8) •General Solo
- `13_21` (Light, set 13) •Han, Chewie, And The Falcon
- `102_2` (Light, set 102) •Han
- `108_1` (Light, set 108) •Han With Heavy Blaster Pistol
- `200_13` (Light, set 200) •General Solo (V)
- `200_14` (Light, set 200) •Han (V)
- `204_11` (Light, set 204) •Solo
- `204_11` (Light, set 204) •Solo (AI)
- `205_7` (Light, set 205) •Han, Chewie, And The Falcon (V)
- `213_37` (Light, set 213) •Han... Solo
- `215_11` (Light, set 215) •Han Solo, Optimistic General
- `215_20` (Light, set 215) •TK-422 (V)
- `224_16` (Light, set 224) •Han Solo (V)
- `225_38` (Light, set 225) •Captain Han Solo (V)

</details>

<details>
<summary><strong>Han's Heavy Blaster Pistol</strong> (3 cards)</summary>

- `1_154` (Light, set 1) •Han's Heavy Blaster Pistol
- `108_1` (Light, set 108) •Han With Heavy Blaster Pistol
- `200_70` (Light, set 200) •Han's Heavy Blaster Pistol (V)

</details>

<details>
<summary><strong>Het</strong> (1 card)</summary>

- `2_9` (Light, set 2) •Het Nkik

</details>

<details>
<summary><strong>Home One</strong> (3 cards)</summary>

- `9_57` (Light, set 9) •Home One: Docking Bay
- `9_58` (Light, set 9) •Home One: War Room
- `9_74` (Light, set 9) •Home One

</details>

<details>
<summary><strong>Hound's Tooth</strong> (4 cards)</summary>

- `4_168` (Dark, set 4) •Hound's Tooth
- `7_301` (Dark, set 7) •Bossk In Hound's Tooth
- `200_131` (Dark, set 200) •Bossk In Hound's Tooth (V)
- `200_135` (Dark, set 200) •Hound's Tooth (V)

</details>

<details>
<summary><strong>Ickabel G'ont</strong> (2 cards)</summary>

- `2_11` (Light, set 2) •Ickabel G'ont
- `216_27` (Light, set 216) •Figrin D'an & •The Modal Nodes

</details>

<details>
<summary><strong>IG-2000</strong> (2 cards)</summary>

- `4_169` (Dark, set 4) •IG-2000
- `110_8` (Dark, set 110) •IG-88 In IG-2000

</details>

<details>
<summary><strong>IG-88</strong> (4 cards)</summary>

- `4_101` (Dark, set 4) •IG-88
- `109_11` (Dark, set 109) •IG-88 With Riot Gun
- `110_8` (Dark, set 110) •IG-88 In IG-2000
- `200_83` (Dark, set 200) •IG-88 (V)

</details>

<details>
<summary><strong>Invisible Hand</strong> (6 cards)</summary>

- `211_20` (Dark, set 211) •Invisible Hand: Bridge
- `211_21` (Dark, set 211) •Invisible Hand: Docking Bay
- `211_22` (Dark, set 211) •Invisible Hand: Hallway 328
- `211_23` (Dark, set 211) •Invisible Hand
- `211_23` (Dark, set 211) •Invisible Hand (ALT)
- `211_27` (Dark, set 211) •Invisible Hand: Observatory Entrance

</details>

<details>
<summary><strong>Jabba</strong> (5 cards)</summary>

- `6_109` (Dark, set 6) •Jabba The Hutt
- `7_182` (Dark, set 7) •Jabba
- `13_71` (Dark, set 13) •Jabba Desilijic Tiure
- `112_14` (Dark, set 112) •Mighty Jabba
- `200_84` (Dark, set 200) •Jabba The Hutt (V)

</details>

<details>
<summary><strong>Jabba's Sail Barge</strong> (3 cards)</summary>

- `6_167` (Dark, set 6) •Jabba's Sail Barge: Passenger Deck
- `6_172` (Dark, set 6) •Jabba's Sail Barge
- `204_56` (Dark, set 204) •Jabba's Sail Barge (V)

</details>

<details>
<summary><strong>Jango</strong> (2 cards)</summary>

- `201_25` (Dark, set 201) •Jango Fett
- `201_25` (Dark, set 201) •Jango Fett (AI)

</details>

<details>
<summary><strong>Jannah</strong> (1 card)</summary>

- `215_12` (Light, set 215) •Jannah

</details>

<details>
<summary><strong>Janse</strong> (1 card)</summary>

- `8_6` (Light, set 8) •Corporal Janse

</details>

<details>
<summary><strong>Jar Jar</strong> (3 cards)</summary>

- `11_4` (Light, set 11) •Jar Jar Binks
- `14_10` (Light, set 14) •General Jar Jar
- `14_11` (Light, set 14) •General Jar Jar (AI)

</details>

<details>
<summary><strong>Jaxxon</strong> (1 card)</summary>

- `224_17` (Light, set 224) •Jaxxon T. Tumperakki

</details>

<details>
<summary><strong>Jendon</strong> (3 cards)</summary>

- `9_105` (Dark, set 9) •Colonel Jendon
- `200_132` (Dark, set 200) •Colonel Jendon In Onyx 1
- `221_1` (Dark, set 221) •Colonel Jendon In Vader's Personal Shuttle

</details>

<details>
<summary><strong>Jerus</strong> (1 card)</summary>

- `14_14` (Light, set 14) •Jerus Jannick

</details>

<details>
<summary><strong>Jonus</strong> (1 card)</summary>

- `205_21` (Dark, set 205) •Captain Jonus In Scimitar 2

</details>

<details>
<summary><strong>Junkin</strong> (1 card)</summary>

- `8_29` (Light, set 8) •Sergeant Junkin

</details>

<details>
<summary><strong>Jyn Erso</strong> (3 cards)</summary>

- `206_4` (Light, set 206) •Jyn Erso
- `206_4` (Light, set 206) •Jyn Erso (AI)
- `223_5` (Light, set 223) •Jyn Erso, Heroic Rebel

</details>

<details>
<summary><strong>Kallus</strong> (2 cards)</summary>

- `203_22` (Dark, set 203) •Agent Kallus
- `203_22` (Dark, set 203) •Agent Kallus (AI)

</details>

<details>
<summary><strong>Kanan</strong> (3 cards)</summary>

- `203_6` (Light, set 203) •Kanan Jarrus
- `203_6` (Light, set 203) •Kanan Jarrus (AI)
- `217_38` (Light, set 217) •Kanan Jarrus, Jedi Knight

</details>

<details>
<summary><strong>Kensaric</strong> (1 card)</summary>

- `8_7` (Light, set 8) •Corporal Kensaric

</details>

<details>
<summary><strong>Ketwol</strong> (1 card)</summary>

- `216_34` (Light, set 216) •Ketwol (V)

</details>

<details>
<summary><strong>Khurgee</strong> (2 cards)</summary>

- `2_83` (Dark, set 2) •Captain Khurgee
- `301_6` (Dark, set 301) •Captain Khurgee (V)

</details>

<details>
<summary><strong>Krennic</strong> (3 cards)</summary>

- `207_20` (Dark, set 207) •Director Orson Krennic
- `207_20` (Dark, set 207) •Director Orson Krennic (AI)
- `209_36` (Dark, set 209) •Krennic, Death Star Commandant

</details>

<details>
<summary><strong>Kuruk</strong> (1 card)</summary>

- `222_11` (Dark, set 222) •Night Buzzard

</details>

<details>
<summary><strong>Kylo</strong> (4 cards)</summary>

- `204_43` (Dark, set 204) •Kylo Ren
- `209_37` (Dark, set 209) •Kylo Ren With Lightsaber
- `209_37` (Dark, set 209) •Kylo Ren With Lightsaber (AI)
- `222_10` (Dark, set 222) •Kylo, Master Of The Knights Of Ren

</details>

<details>
<summary><strong>Kylo's Lightsaber</strong> (3 cards)</summary>

- `204_58` (Dark, set 204) •Kylo Ren's Lightsaber
- `209_37` (Dark, set 209) •Kylo Ren With Lightsaber
- `209_37` (Dark, set 209) •Kylo Ren With Lightsaber (AI)

</details>

<details>
<summary><strong>L3-37</strong> (1 card)</summary>

- `213_38` (Light, set 213) •L3-37 (Elthree-Threeseven)

</details>

<details>
<summary><strong>Lando</strong> (13 cards)</summary>

- `5_99` (Dark, set 5) •Lando Calrissian
- `217_13` (Dark, set 217) •Lando Calrissian, Vader's Broker
- `5_5` (Light, set 5) •Lando Calrissian
- `6_42` (Light, set 6) •Tamtel Skreej
- `9_13` (Light, set 9) •General Calrissian
- `13_27` (Light, set 13) •Lando Calrissian, Scoundrel
- `109_2` (Light, set 109) •Lando In Millennium Falcon
- `109_3` (Light, set 109) •Lando With Blaster Pistol
- `112_3` (Light, set 112) •Lando With Vibro-Ax
- `201_1` (Light, set 201) •Lando Calrissian (V)
- `213_35` (Light, set 213) •Captain Lando Calrissian
- `216_35` (Light, set 216) •Lando, Hero Of The Rebellion
- `225_49` (Light, set 225) •Lando With Blaster Rifle

</details>

<details>
<summary><strong>Lando's Blaster Rifle</strong> (2 cards)</summary>

- `7_160` (Light, set 7) •Lando's Blaster Rifle
- `225_49` (Light, set 225) •Lando With Blaster Rifle

</details>

<details>
<summary><strong>Laudica</strong> (1 card)</summary>

- `6_25` (Light, set 6) •Laudica

</details>

<details>
<summary><strong>Leia</strong> (18 cards)</summary>

- `1_17` (Light, set 1) •Leia Organa
- `5_7` (Light, set 5) •Princess Leia
- `6_32` (Light, set 6) •Princess Leia Organa
- `7_35` (Light, set 7) •Princess Organa
- `8_8` (Light, set 8) •Daughter Of Skywalker
- `13_29` (Light, set 13) •Leia, Rebel Princess
- `102_3` (Light, set 102) •Leia
- `108_2` (Light, set 108) •Leia With Blaster Rifle
- `110_1` (Light, set 110) •Boushh
- `111_5` (Light, set 111) •Prisoner 2187
- `200_9` (Light, set 200) •Daughter Of Skywalker (V)
- `200_18` (Light, set 200) •Leia (V)
- `201_5` (Light, set 201) •Princess Leia (V)
- `202_1` (Light, set 202) •Leia Organa (V)
- `207_5` (Light, set 207) •General Leia Organa
- `207_5` (Light, set 207) •General Leia Organa (AI)
- `220_9` (Light, set 220) •Prisoner 2187 (V)
- `223_32` (Light, set 223) •Boushh (V)

</details>

<details>
<summary><strong>Leia's Blaster Rifle</strong> (2 cards)</summary>

- `7_161` (Light, set 7) •Leia's Blaster Rifle
- `108_2` (Light, set 108) •Leia With Blaster Rifle

</details>

<details>
<summary><strong>Leia's Lightsaber</strong> (1 card)</summary>

- `225_50` (Light, set 225) •Leia's Lightsaber

</details>

<details>
<summary><strong>Libertine</strong> (1 card)</summary>

- `211_34` (Light, set 211) •Libertine

</details>

<details>
<summary><strong>Lobot</strong> (4 cards)</summary>

- `7_187` (Dark, set 7) •Lobot
- `223_16` (Dark, set 223) •Lobot, Lando's Broker
- `5_6` (Light, set 5) •Lobot
- `200_19` (Light, set 200) •Lobot (V)

</details>

<details>
<summary><strong>Lott</strong> (1 card)</summary>

- `12_110` (Dark, set 12) •Lott Dod

</details>

<details>
<summary><strong>Luke</strong> (20 cards)</summary>

- `205_14` (Dark, set 205) •Luke Skywalker, The Emperor's Prize / Luke Skywalker, The Emperor's Prize
- `1_19` (Light, set 1) •Luke Skywalker
- `3_3` (Light, set 3) •Commander Luke Skywalker
- `4_1` (Light, set 4) •Son Of Skywalker
- `9_24` (Light, set 9) •Luke Skywalker, Jedi Knight
- `10_10` (Light, set 10) •Luke Skywalker, Rebel Scout
- `101_2` (Light, set 101) •Luke
- `108_3` (Light, set 108) •Luke With Lightsaber
- `110_2` (Light, set 110) •Master Luke
- `200_7` (Light, set 200) •Commander Luke Skywalker (V)
- `200_20` (Light, set 200) •Luke Skywalker (V)
- `200_20` (Light, set 200) •Luke Skywalker (V) (ALT)
- `200_21` (Light, set 200) •Luke Skywalker, Rebel Scout (V)
- `208_8` (Light, set 208) •Luke Skywalker, The Rebellion's Hope
- `208_8` (Light, set 208) •Luke Skywalker, The Rebellion's Hope (AI)
- `210_20` (Light, set 210) •Luke Skywalker, The Last Jedi
- `210_20` (Light, set 210) •Luke Skywalker, The Last Jedi (ALT)
- `218_25` (Light, set 218) •Master Luke (V)
- `222_29` (Light, set 222) •Young Skywalker
- `224_20` (Light, set 224) •Son Of Skywalker (V)

</details>

<details>
<summary><strong>Luke's Lightsaber</strong> (2 cards)</summary>

- `9_90` (Light, set 9) •Luke's Lightsaber
- `108_3` (Light, set 108) •Luke With Lightsaber

</details>

<details>
<summary><strong>Maarek Stele</strong> (2 cards)</summary>

- `200_85` (Dark, set 200) •Maarek Stele, The Emperor's Reach
- `200_85` (Dark, set 200) •Maarek Stele, The Emperor's Reach (ALT)

</details>

<details>
<summary><strong>Mace</strong> (10 cards)</summary>

- `12_13` (Light, set 12) •Mace Windu
- `12_14` (Light, set 12) •Mace Windu (AI)
- `14_18` (Light, set 14) •Mace Windu, Jedi Master
- `14_19` (Light, set 14) •Mace Windu, Jedi Master (AI)
- `201_2` (Light, set 201) •Mace Windu (V)
- `201_42` (Light, set 201) •Mace Windu (V) (AI)
- `201_42` (Light, set 201) •Mace Windu (V) (C-Slip AI 2)
- `201_42` (Light, set 201) •Mace Windu (V) (C-Slip AI)
- `218_4` (Light, set 218) •Master Windu
- `218_4` (Light, set 218) •Master Windu (ALT)

</details>

<details>
<summary><strong>Madakor</strong> (2 cards)</summary>

- `12_1` (Light, set 12) •Captain Madakor
- `200_63` (Light, set 200) •Madakor In Radiant VII

</details>

<details>
<summary><strong>Mara Jade</strong> (7 cards)</summary>

- `10_31` (Dark, set 10) •Arica
- `110_10` (Dark, set 110) •Mara Jade, The Emperor's Hand
- `200_74` (Dark, set 200) •Arica (V)
- `200_86` (Dark, set 200) •Mara Jade With Lightsaber
- `208_58` (Dark, set 208) •Mara Jade In VT-49 Decimator
- `226_8` (Dark, set 226) •Mara Jade, The Emperor's Hand (V)
- `217_40` (Light, set 217) •Mara Jade

</details>

<details>
<summary><strong>Mara Jade's Lightsaber</strong> (2 cards)</summary>

- `110_11` (Dark, set 110) •Mara Jade's Lightsaber
- `200_86` (Dark, set 200) •Mara Jade With Lightsaber

</details>

<details>
<summary><strong>Margo</strong> (1 card)</summary>

- `213_9` (Dark, set 213) •Margo

</details>

<details>
<summary><strong>Marquand</strong> (2 cards)</summary>

- `8_106` (Dark, set 8) •Major Marquand
- `210_38` (Dark, set 210) •Marquand In Blizzard 6

</details>

<details>
<summary><strong>Maul</strong> (14 cards)</summary>

- `11_54` (Dark, set 11) •Darth Maul
- `11_55` (Dark, set 11) •Darth Maul (AI)
- `12_101` (Dark, set 12) •Darth Maul, Young Apprentice
- `12_102` (Dark, set 12) •Darth Maul, Young Apprentice (AI)
- `13_74` (Dark, set 13) •Lord Maul
- `14_77` (Dark, set 14) •Darth Maul With Lightsaber
- `203_26` (Dark, set 203) •Darth Maul, Lone Hunter
- `203_26` (Dark, set 203) •Darth Maul, Lone Hunter (AI)
- `203_26` (Dark, set 203) •Darth Maul, Lone Hunter (C-Slip AI 2)
- `203_26` (Dark, set 203) •Darth Maul, Lone Hunter (C-Slip AI)
- `208_34` (Dark, set 208) •Lord Maul With Lightsaber
- `213_10` (Dark, set 213) •Maul
- `213_10` (Dark, set 213) •Maul (Holo AI)
- `223_17` (Dark, set 223) •Maul In Scimitar

</details>

<details>
<summary><strong>Maul's Double-Bladed Lightsaber</strong> (4 cards)</summary>

- `11_99` (Dark, set 11) •Maul's Lightsaber
- `13_75` (Dark, set 13) •Maul's Double-Bladed Lightsaber
- `14_77` (Dark, set 14) •Darth Maul With Lightsaber
- `208_34` (Dark, set 208) •Lord Maul With Lightsaber

</details>

<details>
<summary><strong>Maul's Sith Infiltrator</strong> (3 cards)</summary>

- `12_182` (Dark, set 12) •Maul's Sith Infiltrator
- `12_183` (Dark, set 12) •Maul's Sith Infiltrator (AI)
- `223_17` (Dark, set 223) •Maul In Scimitar

</details>

<details>
<summary><strong>Maz</strong> (1 card)</summary>

- `211_57` (Light, set 211) •Maz Kanata

</details>

<details>
<summary><strong>McQuarrie</strong> (1 card)</summary>

- `7_18` (Light, set 7) •General McQuarrie

</details>

<details>
<summary><strong>Melshi</strong> (1 card)</summary>

- `209_2` (Light, set 209) •Commander Ruescott Melshi

</details>

<details>
<summary><strong>Mist Hunter</strong> (3 cards)</summary>

- `4_170` (Dark, set 4) •Mist Hunter
- `110_12` (Dark, set 110) •Zuckuss In Mist Hunter
- `221_42` (Dark, set 221) •Zuckuss And 4-LOM In Mist Hunter

</details>

<details>
<summary><strong>Mon Mothma</strong> (2 cards)</summary>

- `8_22` (Light, set 8) •Mon Mothma
- `204_10` (Light, set 204) •Senator Mon Mothma

</details>

<details>
<summary><strong>Motti</strong> (3 cards)</summary>

- `1_164` (Dark, set 1) •Admiral Motti
- `102_10` (Dark, set 102) •Motti
- `200_73` (Dark, set 200) •Admiral Motti (V)

</details>

<details>
<summary><strong>Nalan Cheel</strong> (2 cards)</summary>

- `2_13` (Light, set 2) •Nalan Cheel
- `216_27` (Light, set 216) •Figrin D'an & •The Modal Nodes

</details>

<details>
<summary><strong>Narthax</strong> (2 cards)</summary>

- `7_205` (Dark, set 7) •Sergeant Narthax
- `211_7` (Dark, set 211) •Sergeant Narthax With E-web Blaster

</details>

<details>
<summary><strong>Nien Nunb</strong> (2 cards)</summary>

- `9_28` (Light, set 9) •Nien Nunb
- `222_25` (Light, set 222) •Nien Nunb, Sullustan Smuggler

</details>

<details>
<summary><strong>Obi-Wan</strong> (13 cards)</summary>

- `1_21` (Light, set 1) •Obi-Wan Kenobi
- `7_4` (Light, set 7) •Ben Kenobi
- `11_6` (Light, set 11) •Obi-Wan Kenobi, Padawan Learner
- `11_7` (Light, set 11) •Obi-Wan Kenobi, Padawan Learner (AI)
- `13_33` (Light, set 13) •Obi-Wan Kenobi, Jedi Knight
- `108_4` (Light, set 108) •Obi-Wan With Lightsaber
- `200_23` (Light, set 200) •Obi-Wan Kenobi, Padawan Learner (V)
- `200_145` (Light, set 200) •Obi-Wan Kenobi, Padawan Learner (V) (AI)
- `201_4` (Light, set 201) •Obi-Wan Kenobi (V)
- `209_6` (Light, set 209) •General Kenobi
- `209_6` (Light, set 209) •General Kenobi (AI)
- `216_36` (Light, set 216) •Master Kenobi
- `226_24` (Light, set 226) •Obi-Wan Kenobi, Jedi In Exile

</details>

<details>
<summary><strong>Obi-Wan's Lightsaber</strong> (3 cards)</summary>

- `1_157` (Light, set 1) •Obi-Wan's Lightsaber
- `13_34` (Light, set 13) •Obi-Wan's Lightsaber
- `108_4` (Light, set 108) •Obi-Wan With Lightsaber

</details>

<details>
<summary><strong>Ochi</strong> (1 card)</summary>

- `214_7` (Dark, set 214) •Ochi

</details>

<details>
<summary><strong>Odd ball</strong> (1 card)</summary>

- `208_3` (Light, set 208) •CC-2237 (Odd Ball)

</details>

<details>
<summary><strong>Onyx 1</strong> (2 cards)</summary>

- `9_160` (Dark, set 9) •Onyx 1
- `200_132` (Dark, set 200) •Colonel Jendon In Onyx 1

</details>

<details>
<summary><strong>Ortugg's Ax</strong> (1 card)</summary>

- `203_28` (Dark, set 203) •Ortugg (V)

</details>

<details>
<summary><strong>OS-72-1</strong> (1 card)</summary>

- `7_305` (Dark, set 7) •OS-72-1 In Obsidian 1

</details>

<details>
<summary><strong>OS-72-2</strong> (1 card)</summary>

- `7_306` (Dark, set 7) •OS-72-2 In Obsidian 2

</details>

<details>
<summary><strong>Ozzel</strong> (2 cards)</summary>

- `3_82` (Dark, set 3) •Admiral Ozzel
- `213_1` (Dark, set 213) •Admiral Ozzel (V)

</details>

<details>
<summary><strong>Paige</strong> (1 card)</summary>

- `216_41` (Light, set 216) •Paige Tico

</details>

<details>
<summary><strong>Panaka</strong> (3 cards)</summary>

- `12_2` (Light, set 12) •Captain Panaka
- `14_23` (Light, set 14) •Panaka, Protector Of The Queen
- `14_24` (Light, set 14) •Panaka, Protector Of The Queen (AI)

</details>

<details>
<summary><strong>Paploo</strong> (2 cards)</summary>

- `8_24` (Light, set 8) •Paploo
- `210_22` (Light, set 210) •Paploo (V)

</details>

<details>
<summary><strong>Perosei</strong> (1 card)</summary>

- `14_22` (Light, set 14) •Officer Perosei

</details>

<details>
<summary><strong>Piett</strong> (3 cards)</summary>

- `3_85` (Dark, set 3) •Captain Piett
- `9_98` (Dark, set 9) •Admiral Piett
- `215_22` (Dark, set 215) •Admiral Piett (V)

</details>

<details>
<summary><strong>Plo Koon</strong> (3 cards)</summary>

- `12_21` (Light, set 12) •Plo Koon
- `210_23` (Light, set 210) •Plo Koon (V)
- `210_23` (Light, set 210) •Plo Koon (V) (AI)

</details>

<details>
<summary><strong>Poe Dameron</strong> (3 cards)</summary>

- `204_8` (Light, set 204) •Poe Dameron
- `204_8` (Light, set 204) •Poe Dameron (AI)
- `222_21` (Light, set 222) •General Poe Dameron

</details>

<details>
<summary><strong>Praji</strong> (2 cards)</summary>

- `1_167` (Dark, set 1) •Commander Praji
- `221_12` (Dark, set 221) •Commander Praji (V)

</details>

<details>
<summary><strong>Profundity</strong> (3 cards)</summary>

- `207_18` (Light, set 207) •Profundity
- `207_18` (Light, set 207) •Profundity (AI)
- `217_44` (Light, set 217) •Profundity: Docking Bay

</details>

<details>
<summary><strong>Proxima</strong> (1 card)</summary>

- `211_3` (Dark, set 211) •Lady Proxima

</details>

<details>
<summary><strong>Pryce</strong> (1 card)</summary>

- `219_7` (Dark, set 219) •Governor Pryce

</details>

<details>
<summary><strong>Pryde</strong> (1 card)</summary>

- `212_6` (Dark, set 212) •Allegiant General Pryde

</details>

<details>
<summary><strong>Puck</strong> (1 card)</summary>

- `301_7` (Light, set 301) •Puck

</details>

<details>
<summary><strong>Pulsar Skate</strong> (2 cards)</summary>

- `10_20` (Light, set 10) •Pulsar Skate
- `200_60` (Light, set 200) •Booster In Pulsar Skate

</details>

<details>
<summary><strong>Punishing One</strong> (3 cards)</summary>

- `4_171` (Dark, set 4) •Punishing One
- `109_10` (Dark, set 109) •Dengar In Punishing One
- `207_29` (Dark, set 207) •Punishing One (V)

</details>

<details>
<summary><strong>Qi'ra</strong> (3 cards)</summary>

- `217_19` (Dark, set 217) •Qi'ra, Top Lieutenant
- `213_39` (Light, set 213) •Qi'ra
- `213_39` (Light, set 213) •Qi'ra (Holo AI)

</details>

<details>
<summary><strong>Queen's Royal Starship</strong> (2 cards)</summary>

- `12_91` (Light, set 12) •Queen's Royal Starship
- `205_9` (Light, set 205) •Ric In Queen's Royal Starship

</details>

<details>
<summary><strong>Qui-Gon</strong> (11 cards)</summary>

- `11_10` (Light, set 11) •Qui-Gon Jinn
- `11_11` (Light, set 11) •Qui-Gon Jinn (AI)
- `12_16` (Light, set 12) •Master Qui-Gon
- `12_17` (Light, set 12) •Master Qui-Gon (AI)
- `13_39` (Light, set 13) •Qui-Gon Jinn, Jedi Master
- `14_27` (Light, set 14) •Qui-Gon Jinn With Lightsaber
- `200_22` (Light, set 200) •Master Qui-Gon (V)
- `200_146` (Light, set 200) •Master Qui-Gon (V) (AI)
- `213_40` (Light, set 213) •Qui-Gon Jinn, Serene Jedi
- `216_37` (Light, set 216) •Master Qui-Gon Jinn, An Old Friend
- `218_3` (Light, set 218) •Master Qui-Gon With Lightsaber

</details>

<details>
<summary><strong>Qui-Gon Jinn's Lightsaber</strong> (7 cards)</summary>

- `11_49` (Light, set 11) •Qui-Gon Jinn's Lightsaber
- `11_50` (Light, set 11) •Qui-Gon Jinn's Lightsaber (AI)
- `13_40` (Light, set 13) •Qui-Gon's Lightsaber
- `14_27` (Light, set 14) •Qui-Gon Jinn With Lightsaber
- `218_3` (Light, set 218) •Master Qui-Gon With Lightsaber
- `221_69` (Light, set 221) •Qui-Gon Jinn's Lightsaber (V)
- `221_70` (Light, set 221) •Qui-Gon Jinn's Lightsaber (V) (AI)

</details>

<details>
<summary><strong>R2-D2</strong> (10 cards)</summary>

- `2_14` (Light, set 2) •R2-D2 (Artoo-Detoo)
- `6_3` (Light, set 6) •Artoo
- `10_2` (Light, set 10) •Artoo & •Threepio
- `14_3` (Light, set 14) •Artoo, Brave Little Droid
- `14_4` (Light, set 14) •Artoo, Brave Little Droid (AI)
- `111_2` (Light, set 111) •Artoo-Detoo In Red 5
- `201_6` (Light, set 201) •R2-D2 (Artoo-Detoo) (V)
- `201_6` (Light, set 201) •R2-D2 (Artoo-Detoo) (V) (AI)
- `203_11` (Light, set 203) •R2-D2 & •C-3PO
- `219_28` (Light, set 219) •Artoo (V)

</details>

<details>
<summary><strong>Radiant VII</strong> (2 cards)</summary>

- `12_92` (Light, set 12) •Radiant VII
- `200_63` (Light, set 200) •Madakor In Radiant VII

</details>

<details>
<summary><strong>Rayc</strong> (1 card)</summary>

- `6_34` (Light, set 6) •Rayc Ryjerd

</details>

<details>
<summary><strong>Red 1</strong> (3 cards)</summary>

- `1_144` (Light, set 1) •Red 1
- `103_2` (Light, set 103) •Red Leader In Red 1
- `200_65` (Light, set 200) •Red 1 (V)

</details>

<details>
<summary><strong>Red 2</strong> (3 cards)</summary>

- `2_70` (Light, set 2) •Red 2
- `9_81` (Light, set 9) •Red Squadron 1
- `200_67` (Light, set 200) •Wedge In Red Squadron 1

</details>

<details>
<summary><strong>Red 5</strong> (3 cards)</summary>

- `2_71` (Light, set 2) •Red 5
- `111_2` (Light, set 111) •Artoo-Detoo In Red 5
- `209_31` (Light, set 209) •Red 5 (V)

</details>

<details>
<summary><strong>Red Leader</strong> (2 cards)</summary>

- `1_29` (Light, set 1) •Red Leader
- `103_2` (Light, set 103) •Red Leader In Red 1

</details>

<details>
<summary><strong>Rey</strong> (6 cards)</summary>

- `204_9` (Light, set 204) •Rey
- `204_9` (Light, set 204) •Rey (AI)
- `209_10` (Light, set 209) •Rey With Lightsaber
- `209_10` (Light, set 209) •Rey With Lightsaber (AI)
- `214_22` (Light, set 214) •Rey, All Of The Jedi
- `214_22` (Light, set 214) •Rey, All Of The Jedi (AI)

</details>

<details>
<summary><strong>Ric</strong> (3 cards)</summary>

- `12_24` (Light, set 12) •Ric Olie
- `14_29` (Light, set 14) •Ric Olie, Bravo Leader
- `205_9` (Light, set 205) •Ric In Queen's Royal Starship

</details>

<details>
<summary><strong>Rio</strong> (1 card)</summary>

- `213_41` (Light, set 213) •Rio Durant

</details>

<details>
<summary><strong>Rogue 2</strong> (2 cards)</summary>

- `3_67` (Light, set 3) •Rogue 2
- `224_23` (Light, set 224) •Zev In Rogue 2

</details>

<details>
<summary><strong>Rose</strong> (1 card)</summary>

- `209_11` (Light, set 209) •Rose Tico

</details>

<details>
<summary><strong>Rukh</strong> (1 card)</summary>

- `215_26` (Dark, set 215) •Rukh

</details>

<details>
<summary><strong>Sabe</strong> (1 card)</summary>

- `12_25` (Light, set 12) •Sabe

</details>

<details>
<summary><strong>Sabine</strong> (2 cards)</summary>

- `207_9` (Light, set 207) •Sabine Wren
- `223_46` (Light, set 223) •Sabine, Padawan Learner

</details>

<details>
<summary><strong>Sache</strong> (1 card)</summary>

- `12_26` (Light, set 12) •Sache

</details>

<details>
<summary><strong>Scimitar 2</strong> (2 cards)</summary>

- `9_167` (Dark, set 9) •Scimitar 2
- `205_21` (Dark, set 205) •Captain Jonus In Scimitar 2

</details>

<details>
<summary><strong>Sefla</strong> (1 card)</summary>

- `209_13` (Light, set 209) •Taidu Sefla

</details>

<details>
<summary><strong>Seventh Sister</strong> (1 card)</summary>

- `213_12` (Dark, set 213) •Seventh Sister

</details>

<details>
<summary><strong>Shawn</strong> (1 card)</summary>

- `3_19` (Light, set 3) •Shawn Valdez

</details>

<details>
<summary><strong>Sidious</strong> (14 cards)</summary>

- `9_109` (Dark, set 9) •Emperor Palpatine
- `10_51` (Dark, set 10) •The Emperor
- `14_78` (Dark, set 14) •Darth Sidious
- `14_79` (Dark, set 14) •Darth Sidious (AI)
- `205_12` (Dark, set 205) •Emperor Palpatine, Foreseer
- `208_35` (Dark, set 208) •Lord Sidious
- `208_35` (Dark, set 208) •Lord Sidious (ALT)
- `214_8` (Dark, set 214) •Palpatine, Emperor Returned
- `214_8` (Dark, set 214) •Palpatine, Emperor Returned (AI)
- `219_19` (Dark, set 219) •The Emperor, Relentless
- `222_12` (Dark, set 222) •Palpatine, Galactic Emperor
- `225_22` (Dark, set 225) •Master Sidious
- `12_28` (Light, set 12) •Senator Palpatine
- `12_29` (Light, set 12) •Senator Palpatine (AI)

</details>

<details>
<summary><strong>Sidious' Lightsaber</strong> (1 card)</summary>

- `217_22` (Dark, set 217) •Sidious' Lightsaber

</details>

<details>
<summary><strong>Slave I</strong> (5 cards)</summary>

- `5_177` (Dark, set 5) •Slave I
- `109_8` (Dark, set 109) •Boba Fett In Slave I
- `200_130` (Dark, set 200) •Boba Fett In Slave I (V)
- `201_40` (Dark, set 201) •Slave I, Symbol Of Fear
- `201_40` (Dark, set 201) •Slave I, Symbol Of Fear (AI)

</details>

<details>
<summary><strong>Snap Wexley</strong> (1 card)</summary>

- `208_11` (Light, set 208) •Temmin 'Snap' Wexley

</details>

<details>
<summary><strong>Snoke</strong> (2 cards)</summary>

- `209_39` (Dark, set 209) •Supreme Leader Snoke
- `209_39` (Dark, set 209) •Supreme Leader Snoke (Holo AI)

</details>

<details>
<summary><strong>Steadfast</strong> (2 cards)</summary>

- `214_9` (Dark, set 214) •Steadfast
- `214_9` (Dark, set 214) •Steadfast (AI)

</details>

<details>
<summary><strong>Supremacy</strong> (3 cards)</summary>

- `225_27` (Dark, set 225) •Supremacy
- `225_28` (Dark, set 225) •Supremacy: Bridge
- `225_29` (Dark, set 225) •Supremacy: Throne Room

</details>

<details>
<summary><strong>Tallie</strong> (1 card)</summary>

- `211_35` (Light, set 211) •Tallie Lintra In Blue 1

</details>

<details>
<summary><strong>Tantive IV</strong> (3 cards)</summary>

- `2_73` (Light, set 2) •Tantive IV
- `201_19` (Light, set 201) •Tantive IV (V)
- `201_19` (Light, set 201) •Tantive IV (V) (AI)

</details>

<details>
<summary><strong>Tarkin</strong> (4 cards)</summary>

- `1_179` (Dark, set 1) •Grand Moff Tarkin
- `102_11` (Dark, set 102) •Tarkin
- `200_82` (Dark, set 200) •Grand Moff Tarkin (V)
- `204_45` (Dark, set 204) •Tarkin (V)

</details>

<details>
<summary><strong>Tedn Dahai</strong> (2 cards)</summary>

- `102_5` (Light, set 102) •Tedn Dahai
- `216_27` (Light, set 216) •Figrin D'an & •The Modal Nodes

</details>

<details>
<summary><strong>The Grand Inquisitor</strong> (2 cards)</summary>

- `210_46` (Dark, set 210) •The Grand Inquisitor
- `210_46` (Dark, set 210) •The Grand Inquisitor (AI)

</details>

<details>
<summary><strong>Thedit</strong> (1 card)</summary>

- `7_45` (Light, set 7) •Thedit

</details>

<details>
<summary><strong>Thrawn</strong> (4 cards)</summary>

- `10_40` (Dark, set 10) •Grand Admiral Thrawn
- `207_21` (Dark, set 207) •Grand Admiral Thrawn (V)
- `207_30` (Dark, set 207) •Grand Admiral Thrawn (V) (AI)
- `211_1` (Dark, set 211) •Mitth'raw'nuruodo

</details>

<details>
<summary><strong>Tigran</strong> (1 card)</summary>

- `3_22` (Light, set 3) •Tigran Jamiro

</details>

<details>
<summary><strong>Tycho</strong> (3 cards)</summary>

- `9_30` (Light, set 9) •Tycho Celchu
- `205_3` (Light, set 205) •Tycho Celchu (V)
- `205_10` (Light, set 205) •Tycho In Green Squadron 3

</details>

<details>
<summary><strong>Vader</strong> (12 cards)</summary>

- `1_168` (Dark, set 1) •Darth Vader
- `7_175` (Dark, set 7) •Darth Vader, Dark Lord Of The Sith
- `7_303` (Dark, set 7) •Death Star Assault Squadron
- `9_113` (Dark, set 9) •Lord Vader
- `101_5` (Dark, set 101) •Vader
- `108_6` (Dark, set 108) •Darth Vader With Lightsaber
- `200_78` (Dark, set 200) •Darth Vader (V)
- `208_30` (Dark, set 208) •Darth Vader, Emperor's Enforcer
- `208_30` (Dark, set 208) •Darth Vader, Emperor's Enforcer (AI)
- `216_6` (Dark, set 216) •Darth Vader, Betrayer Of The Jedi
- `216_6` (Dark, set 216) •Darth Vader, Betrayer Of The Jedi (AI)
- `219_26` (Dark, set 219) •Vader (V)

</details>

<details>
<summary><strong>Vader's Custom TIE</strong> (3 cards)</summary>

- `1_306` (Dark, set 1) •Vader's Custom TIE
- `7_303` (Dark, set 7) •Death Star Assault Squadron
- `206_14` (Dark, set 206) •Vader's Custom TIE (V)

</details>

<details>
<summary><strong>Vader's Lightsaber</strong> (6 cards)</summary>

- `1_324` (Dark, set 1) •Vader's Lightsaber
- `9_178` (Dark, set 9) •Darth Vader's Lightsaber
- `108_6` (Dark, set 108) •Darth Vader With Lightsaber
- `208_59` (Dark, set 208) •Darth Vader's Lightsaber (V)
- `219_27` (Dark, set 219) •Vader's Lightsaber (V)
- `219_27` (Dark, set 219) •Vader's Lightsaber (V) (ALT)

</details>

<details>
<summary><strong>Vader's Personal Shuttle</strong> (3 cards)</summary>

- `7_309` (Dark, set 7) •Vader's Personal Shuttle
- `200_138` (Dark, set 200) •Vader's Personal Shuttle (V)
- `221_1` (Dark, set 221) •Colonel Jendon In Vader's Personal Shuttle

</details>

<details>
<summary><strong>Val</strong> (1 card)</summary>

- `213_43` (Light, set 213) •Val

</details>

<details>
<summary><strong>Vanee</strong> (2 cards)</summary>

- `209_40` (Dark, set 209) •Vanee
- `209_40` (Dark, set 209) •Vanee (AI)

</details>

<details>
<summary><strong>Vanto</strong> (2 cards)</summary>

- `219_5` (Dark, set 219) •Ensign Eli Vanto
- `223_12` (Dark, set 223) •Eli Vanto In Dreadnaught

</details>

<details>
<summary><strong>Veers</strong> (4 cards)</summary>

- `3_87` (Dark, set 3) •General Veers
- `104_6` (Dark, set 104) •Veers
- `200_81` (Dark, set 200) •General Veers (V)
- `206_11` (Dark, set 206) •Veers (V)

</details>

<details>
<summary><strong>Ventress</strong> (3 cards)</summary>

- `221_8` (Dark, set 221) •Asajj Ventress
- `301_3` (Dark, set 301) •Asajj Ventress With Lightsabers
- `301_3` (Dark, set 301) •Asajj Ventress With Lightsabers (AI)

</details>

<details>
<summary><strong>Vos</strong> (1 card)</summary>

- `213_4` (Dark, set 213) •Dryden Vos

</details>

<details>
<summary><strong>Vul</strong> (1 card)</summary>

- `6_45` (Light, set 6) •Vul Tazaene

</details>

<details>
<summary><strong>Wedge</strong> (6 cards)</summary>

- `2_23` (Light, set 2) •Wedge Antilles
- `7_12` (Light, set 7) •Commander Wedge Antilles
- `9_31` (Light, set 9) •Wedge Antilles, Red Squadron Leader
- `200_67` (Light, set 200) •Wedge In Red Squadron 1
- `202_3` (Light, set 202) •Wedge Antilles (V)
- `205_1` (Light, set 205) •Commander Wedge Antilles (V)

</details>

<details>
<summary><strong>Wes Janson</strong> (1 card)</summary>

- `3_25` (Light, set 3) •Wes Janson

</details>

<details>
<summary><strong>Wuher</strong> (2 cards)</summary>

- `1_198` (Dark, set 1) •Wuher
- `223_2` (Dark, set 223) •Wuher (V)

</details>

<details>
<summary><strong>Yoda</strong> (10 cards)</summary>

- `4_2` (Light, set 4) •Yoda
- `12_35` (Light, set 12) •Yoda, Senior Council Member
- `12_36` (Light, set 12) •Yoda, Senior Council Member (AI)
- `13_48` (Light, set 13) •Yoda, Master Of The Force
- `202_4` (Light, set 202) •Yoda, Keeper Of The Peace
- `202_4` (Light, set 202) •Yoda, Keeper Of The Peace (C-Slip AI 2)
- `202_4` (Light, set 202) •Yoda, Keeper Of The Peace (C-Slip AI)
- `207_10` (Light, set 207) •Yoda (V)
- `213_44` (Light, set 213) •Yoda, Master Of The Force (V)
- `216_38` (Light, set 216) •Master Yoda

</details>

<details>
<summary><strong>Yularen</strong> (3 cards)</summary>

- `1_166` (Dark, set 1) •Colonel Wullf Yularen
- `201_22` (Dark, set 201) •Colonel Wullf Yularen (V)
- `221_45` (Light, set 221) •Admiral Yularen

</details>

<details>
<summary><strong>Yutani</strong> (2 cards)</summary>

- `8_1` (Light, set 8) •Captain Yutani
- `200_4` (Light, set 200) •Captain Yutani With Blaster Cannon

</details>

<details>
<summary><strong>Zev Senesca</strong> (2 cards)</summary>

- `3_27` (Light, set 3) •Zev Senesca
- `224_23` (Light, set 224) •Zev In Rogue 2

</details>

<details>
<summary><strong>Zuckuss</strong> (5 cards)</summary>

- `4_107` (Dark, set 4) •Zuckuss
- `110_12` (Dark, set 110) •Zuckuss In Mist Hunter
- `220_5` (Dark, set 220) •Zuckuss (V)
- `221_42` (Dark, set 221) •Zuckuss And 4-LOM In Mist Hunter
- `223_3` (Dark, set 223) •Zuckuss With Snare Rifle

</details>

<details>
<summary><strong>Zuckuss' Snare Rifle</strong> (2 cards)</summary>

- `4_180` (Dark, set 4) •Zuckuss' Snare Rifle
- `223_3` (Dark, set 223) •Zuckuss With Snare Rifle

</details>
