### PR TITLE
Update card schema for current fields

### DIFF
--- a/.github/workflows/card-schema.json
+++ b/.github/workflows/card-schema.json
@@ -20,10 +20,7 @@
           }
         },
         "back": {
-          "type": "object",
-          "items": {
-            "$ref": "#/$defs/cardFace"
-          }
+          "$ref": "#/$defs/cardFace"
         },
         "canceledBy": {
           "type": "array",
@@ -50,10 +47,7 @@
           "type": "string"
         },
         "front": {
-          "type": "object",
-          "items": {
-            "$ref": "#/$defs/cardFace"
-          }
+          "$ref": "#/$defs/cardFace"
         },
         "gempId": {
           "type": "string"
@@ -111,13 +105,45 @@
         },
         "sourceType": {
           "type": "string"
+        },
+        "personas": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "previousId": {
+          "type": "integer"
+        },
+        "underlyingCardFor": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "cardId": {
+                    "type": "integer"
+                  },
+                  "title": {
+                    "type": "string"
+                  }
+                }
+              }
+            ]
+          }
         }
       }
     },
     "printing": {
       "type": "object",
       "properties": {
-        "set": "string"
+        "set": {
+          "type": "string"
+        }
       }
     },
     "cardFace": {
@@ -208,6 +234,27 @@
           "type": "string"
         },
         "uniqueness": {
+          "type": "string"
+        },
+        "darksideIcons": {
+          "type": "integer"
+        },
+        "errataDate": {
+          "type": "string"
+        },
+        "errataNotes": {
+          "type": "string"
+        },
+        "errataSymbol": {
+          "type": "string"
+        },
+        "lightsideIcons": {
+          "type": "integer"
+        },
+        "printableSlipType": {
+          "type": "string"
+        },
+        "printableSlipUrl": {
           "type": "string"
         }
       }


### PR DESCRIPTION
## Summary

Updates the card JSON schema to match fields currently used by the card data files.

## Changes

- Adds schema coverage for card-level fields:
  - `personas`
  - `previousId`
  - `underlyingCardFor`
- Adds schema coverage for face-level fields:
  - `errataDate`
  - `errataNotes`
  - `errataSymbol`
  - `printableSlipType`
  - `printableSlipUrl`
  - legacy casing variants `darksideIcons` and `lightsideIcons`
- Fixes schema definitions for `front` and `back` so they properly reference `cardFace`.
- Fixes `printing.set` to use a valid JSON Schema type declaration.

## Validation

Validated locally against:

- `Dark.json`
- `DarkLegacy.json`
- `Light.json`
- `LightLegacy.json`

All four files pass with the updated schema.
